### PR TITLE
fix: reviews required text label and individual reviewer scores

### DIFF
--- a/docs/superpowers/plans/2026-04-09-reviews-bugfixes.md
+++ b/docs/superpowers/plans/2026-04-09-reviews-bugfixes.md
@@ -1,0 +1,776 @@
+# Reviews Bugfixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two bugs: (1) review text field labeled "optional" but required by domain, (2) all reviews show product average instead of individual reviewer scores.
+
+**Architecture:** Bug 1 is a UI-only fix (HTML templates). Bug 2 requires propagating individual ratings from the ratings API through the reviews service to the productpage — updating domain types, port interface, ratings client, service layer, handler DTOs, productpage client/model/handler, and template rendering.
+
+**Tech Stack:** Go, HTML templates, HTMX
+
+---
+
+### Task 1: Fix UI — mark review text as required
+
+**Files:**
+- Modify: `services/productpage/templates/productpage.html:62-63`
+- Modify: `services/productpage/templates/partials/rating-form.html:38-39`
+
+- [ ] **Step 1: Update the main form template**
+
+In `services/productpage/templates/productpage.html`, change the review textarea from optional to required:
+
+```html
+<!-- OLD (lines 62-63): -->
+                <div class="form-group">
+                    <label for="text">Review (optional)</label>
+                    <textarea id="text" name="text" placeholder="Write your review..."></textarea>
+                </div>
+
+<!-- NEW: -->
+                <div class="form-group">
+                    <label for="text">Review</label>
+                    <textarea id="text" name="text" required placeholder="Write your review..."></textarea>
+                </div>
+```
+
+- [ ] **Step 2: Update the error-state partial template**
+
+In `services/productpage/templates/partials/rating-form.html`, apply the same change:
+
+```html
+<!-- OLD (lines 38-39): -->
+        <label for="text">Review (optional)</label>
+        <textarea id="text" name="text" placeholder="Write your review..."></textarea>
+
+<!-- NEW: -->
+        <label for="text">Review</label>
+        <textarea id="text" name="text" required placeholder="Write your review..."></textarea>
+```
+
+- [ ] **Step 3: Run existing tests to confirm no regressions**
+
+Run: `go test -race -count=1 ./services/productpage/...`
+Expected: All tests PASS (template changes don't break existing tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/productpage/templates/productpage.html services/productpage/templates/partials/rating-form.html
+git commit -m "fix(productpage): mark review text field as required in UI"
+```
+
+---
+
+### Task 2: Add RatingData domain type and update port interface
+
+**Files:**
+- Modify: `services/reviews/internal/core/domain/review.go`
+- Modify: `services/reviews/internal/core/port/outbound.go`
+
+- [ ] **Step 1: Add RatingData type to domain**
+
+In `services/reviews/internal/core/domain/review.go`, add the new type after `ReviewRating`:
+
+```go
+// RatingData holds both product-level and per-reviewer rating data.
+type RatingData struct {
+	Average           float64
+	Count             int
+	IndividualRatings map[string]int // reviewer -> stars
+}
+```
+
+- [ ] **Step 2: Update RatingsClient port interface**
+
+In `services/reviews/internal/core/port/outbound.go`, change the return type of `GetProductRatings`:
+
+```go
+// RatingsClient defines the outbound operations for fetching ratings.
+type RatingsClient interface {
+	// GetProductRatings returns both product-level and per-reviewer rating data.
+	GetProductRatings(ctx context.Context, productID string) (*domain.RatingData, error)
+}
+```
+
+- [ ] **Step 3: Verify the code does NOT compile yet**
+
+Run: `go build ./services/reviews/...`
+Expected: FAIL — the ratings client adapter and test stubs still return `*domain.ReviewRating`, not `*domain.RatingData`.
+
+This is expected. The next tasks will fix the compilation errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/reviews/internal/core/domain/review.go services/reviews/internal/core/port/outbound.go
+git commit -m "feat(reviews): add RatingData domain type and update port interface"
+```
+
+---
+
+### Task 3: Update test stubs and write failing tests for individual ratings
+
+**Files:**
+- Modify: `services/reviews/internal/core/service/review_service_test.go`
+- Modify: `services/reviews/internal/adapter/inbound/http/handler_test.go`
+
+- [ ] **Step 1: Update the service test stub and add a failing test**
+
+In `services/reviews/internal/core/service/review_service_test.go`, update the `stubRatingsClient` to match the new interface and add a test for individual ratings:
+
+Replace the existing stub:
+
+```go
+// stubRatingsClient returns fixed rating data for testing.
+type stubRatingsClient struct {
+	rating *domain.ReviewRating
+	err    error
+}
+
+func (s *stubRatingsClient) GetProductRatings(_ context.Context, _ string) (*domain.ReviewRating, error) {
+	return s.rating, s.err
+}
+```
+
+With:
+
+```go
+// stubRatingsClient returns fixed rating data for testing.
+type stubRatingsClient struct {
+	data *domain.RatingData
+	err  error
+}
+
+func (s *stubRatingsClient) GetProductRatings(_ context.Context, _ string) (*domain.RatingData, error) {
+	return s.data, s.err
+}
+```
+
+Update `TestGetProductReviews_Empty` — change the stub setup:
+
+```go
+func TestGetProductReviews_Empty(t *testing.T) {
+	repo := memory.NewReviewRepository()
+	client := &stubRatingsClient{
+		data: &domain.RatingData{Average: 0, Count: 0, IndividualRatings: map[string]int{}},
+	}
+	svc := service.NewReviewService(repo, client)
+
+	reviews, err := svc.GetProductReviews(context.Background(), "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(reviews) != 0 {
+		t.Errorf("expected 0 reviews, got %d", len(reviews))
+	}
+}
+```
+
+Update `TestGetProductReviews_WithRatings` to verify individual stars per reviewer:
+
+```go
+func TestGetProductReviews_WithRatings(t *testing.T) {
+	repo := memory.NewReviewRepository()
+	client := &stubRatingsClient{
+		data: &domain.RatingData{
+			Average: 3.5,
+			Count:   2,
+			IndividualRatings: map[string]int{
+				"alice": 5,
+				"bob":   2,
+			},
+		},
+	}
+	svc := service.NewReviewService(repo, client)
+
+	_, err := svc.SubmitReview(context.Background(), "product-1", "alice", "Excellent!")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = svc.SubmitReview(context.Background(), "product-1", "bob", "Good read")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	reviews, err := svc.GetProductReviews(context.Background(), "product-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(reviews) != 2 {
+		t.Fatalf("expected 2 reviews, got %d", len(reviews))
+	}
+
+	// Each review should have its individual rating
+	for _, review := range reviews {
+		if review.Rating == nil {
+			t.Errorf("expected non-nil Rating on review by %s", review.Reviewer)
+			continue
+		}
+		if review.Rating.Average != 3.5 {
+			t.Errorf("Rating.Average = %f, want 3.5", review.Rating.Average)
+		}
+		if review.Rating.Count != 2 {
+			t.Errorf("Rating.Count = %d, want 2", review.Rating.Count)
+		}
+		switch review.Reviewer {
+		case "alice":
+			if review.Rating.Stars != 5 {
+				t.Errorf("alice Rating.Stars = %d, want 5", review.Rating.Stars)
+			}
+		case "bob":
+			if review.Rating.Stars != 2 {
+				t.Errorf("bob Rating.Stars = %d, want 2", review.Rating.Stars)
+			}
+		default:
+			t.Errorf("unexpected reviewer: %s", review.Reviewer)
+		}
+	}
+}
+```
+
+Update `TestSubmitReview_Success` and `TestSubmitReview_ValidationError` — change the stub setup from `rating` to `data`:
+
+```go
+func TestSubmitReview_Success(t *testing.T) {
+	repo := memory.NewReviewRepository()
+	client := &stubRatingsClient{}
+	svc := service.NewReviewService(repo, client)
+
+	// ... rest unchanged ...
+}
+
+func TestSubmitReview_ValidationError(t *testing.T) {
+	repo := memory.NewReviewRepository()
+	client := &stubRatingsClient{}
+	svc := service.NewReviewService(repo, client)
+
+	// ... rest unchanged ...
+}
+```
+
+These two functions don't change — they already use `&stubRatingsClient{}` with zero-value fields. The field name changed from `rating` to `data`, but these tests use the zero value so no update needed.
+
+- [ ] **Step 2: Update the handler test stub**
+
+In `services/reviews/internal/adapter/inbound/http/handler_test.go`, update the `stubRatingsClient` and `setupHandler`:
+
+Replace the existing stub:
+
+```go
+type stubRatingsClient struct {
+	rating *domain.ReviewRating
+	err    error
+}
+
+func (s *stubRatingsClient) GetProductRatings(_ context.Context, _ string) (*domain.ReviewRating, error) {
+	return s.rating, s.err
+}
+
+func setupHandler(t *testing.T) *http.ServeMux {
+	t.Helper()
+	repo := memory.NewReviewRepository()
+	client := &stubRatingsClient{
+		rating: &domain.ReviewRating{Average: 4.0, Count: 5},
+	}
+	svc := service.NewReviewService(repo, client)
+	mux := http.NewServeMux()
+	h := handler.NewHandler(svc)
+	h.RegisterRoutes(mux)
+	return mux
+}
+```
+
+With:
+
+```go
+type stubRatingsClient struct {
+	data *domain.RatingData
+	err  error
+}
+
+func (s *stubRatingsClient) GetProductRatings(_ context.Context, _ string) (*domain.RatingData, error) {
+	return s.data, s.err
+}
+
+func setupHandler(t *testing.T) *http.ServeMux {
+	t.Helper()
+	repo := memory.NewReviewRepository()
+	client := &stubRatingsClient{
+		data: &domain.RatingData{
+			Average: 4.0,
+			Count:   5,
+			IndividualRatings: map[string]int{
+				"alice": 4,
+			},
+		},
+	}
+	svc := service.NewReviewService(repo, client)
+	mux := http.NewServeMux()
+	h := handler.NewHandler(svc)
+	h.RegisterRoutes(mux)
+	return mux
+}
+```
+
+Update the assertion in `TestGetProductReviews_WithRatings` to also check `Stars`:
+
+Find the assertions block (lines 145-154):
+
+```go
+	review := body.Reviews[0]
+	if review.Rating == nil {
+		t.Fatal("expected non-nil rating")
+	}
+	if review.Rating.Average != 4.0 {
+		t.Errorf("Rating.Average = %f, want 4.0", review.Rating.Average)
+	}
+	if review.Rating.Count != 5 {
+		t.Errorf("Rating.Count = %d, want 5", review.Rating.Count)
+	}
+```
+
+Replace with:
+
+```go
+	review := body.Reviews[0]
+	if review.Rating == nil {
+		t.Fatal("expected non-nil rating")
+	}
+	if review.Rating.Stars != 4 {
+		t.Errorf("Rating.Stars = %d, want 4", review.Rating.Stars)
+	}
+	if review.Rating.Average != 4.0 {
+		t.Errorf("Rating.Average = %f, want 4.0", review.Rating.Average)
+	}
+	if review.Rating.Count != 5 {
+		t.Errorf("Rating.Count = %d, want 5", review.Rating.Count)
+	}
+```
+
+- [ ] **Step 3: Verify tests compile but the new assertions fail**
+
+Run: `go test -race -count=1 ./services/reviews/...`
+Expected: Tests compile. `TestGetProductReviews_WithRatings` FAILS on `Rating.Stars` assertions (service still assigns product average to all reviews, Stars is 0).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/reviews/internal/core/service/review_service_test.go services/reviews/internal/adapter/inbound/http/handler_test.go
+git commit -m "test(reviews): update stubs and add assertions for individual reviewer ratings"
+```
+
+---
+
+### Task 4: Update ratings client adapter to parse individual ratings
+
+**Files:**
+- Modify: `services/reviews/internal/adapter/outbound/http/ratings_client.go`
+
+- [ ] **Step 1: Update the ratings client to parse full response**
+
+Replace the entire content of `services/reviews/internal/adapter/outbound/http/ratings_client.go`:
+
+```go
+// Package http provides an HTTP client for the ratings service used by reviews.
+package http //nolint:revive // package name matches directory convention
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+)
+
+// individualRating mirrors a single rating entry from the ratings service.
+type individualRating struct {
+	ID        string `json:"id"`
+	ProductID string `json:"product_id"`
+	Reviewer  string `json:"reviewer"`
+	Stars     int    `json:"stars"`
+}
+
+// ratingsResponse mirrors the ratings service ProductRatingsResponse.
+type ratingsResponse struct {
+	ProductID string             `json:"product_id"`
+	Average   float64            `json:"average"`
+	Count     int                `json:"count"`
+	Ratings   []individualRating `json:"ratings"`
+}
+
+// RatingsClient is an HTTP client that fetches ratings from the ratings service.
+type RatingsClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewRatingsClient creates a new RatingsClient pointing to the given base URL.
+func NewRatingsClient(baseURL string) *RatingsClient {
+	return &RatingsClient{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout:   5 * time.Second,
+			Transport: otelhttp.NewTransport(http.DefaultTransport),
+		},
+	}
+}
+
+// GetProductRatings fetches both product-level and per-reviewer ratings from the ratings service.
+func (c *RatingsClient) GetProductRatings(ctx context.Context, productID string) (*domain.RatingData, error) {
+	url := fmt.Sprintf("%s/v1/ratings/%s", c.baseURL, productID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // URL comes from operator-controlled config, not user input
+	if err != nil {
+		return nil, fmt.Errorf("fetching ratings: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ratings service returned status %d", resp.StatusCode)
+	}
+
+	var body ratingsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decoding ratings response: %w", err)
+	}
+
+	individual := make(map[string]int, len(body.Ratings))
+	for _, r := range body.Ratings {
+		individual[r.Reviewer] = r.Stars
+	}
+
+	return &domain.RatingData{
+		Average:           body.Average,
+		Count:             body.Count,
+		IndividualRatings: individual,
+	}, nil
+}
+```
+
+- [ ] **Step 2: Verify the code compiles**
+
+Run: `go build ./services/reviews/...`
+Expected: FAIL — `review_service.go` still uses the old `*domain.ReviewRating` return type in its logic. This is expected.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/reviews/internal/adapter/outbound/http/ratings_client.go
+git commit -m "feat(reviews): parse individual ratings from ratings API response"
+```
+
+---
+
+### Task 5: Update service layer to assign individual ratings per review
+
+**Files:**
+- Modify: `services/reviews/internal/core/service/review_service.go`
+
+- [ ] **Step 1: Update GetProductReviews to use individual ratings**
+
+Replace the `GetProductReviews` method in `services/reviews/internal/core/service/review_service.go`:
+
+```go
+// GetProductReviews returns all reviews for a product, enriched with ratings data.
+func (s *ReviewService) GetProductReviews(ctx context.Context, productID string) ([]domain.Review, error) {
+	reviews, err := s.repo.FindByProductID(ctx, productID)
+	if err != nil {
+		return nil, fmt.Errorf("finding reviews for product %s: %w", productID, err)
+	}
+
+	// Fetch ratings from the ratings service
+	ratingData, err := s.ratingsClient.GetProductRatings(ctx, productID)
+	if err != nil {
+		logger := logging.FromContext(ctx)
+		logger.Warn("failed to fetch ratings, returning reviews without ratings",
+			slog.String("product_id", productID),
+			slog.String("error", err.Error()),
+		)
+		return reviews, nil
+	}
+
+	// Enrich each review with product-level stats and individual reviewer score
+	for i := range reviews {
+		reviews[i].Rating = &domain.ReviewRating{
+			Stars:   ratingData.IndividualRatings[reviews[i].Reviewer],
+			Average: ratingData.Average,
+			Count:   ratingData.Count,
+		}
+	}
+
+	return reviews, nil
+}
+```
+
+Key change: instead of assigning the same `*domain.ReviewRating` pointer to all reviews, we create a new `ReviewRating` per review with `Stars` looked up from `ratingData.IndividualRatings[reviewer]`. If the reviewer has no rating, the map returns 0.
+
+- [ ] **Step 2: Run service tests**
+
+Run: `go test -race -count=1 ./services/reviews/internal/core/service/...`
+Expected: All tests PASS — including the new individual ratings assertions.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/reviews/internal/core/service/review_service.go
+git commit -m "fix(reviews): assign individual reviewer ratings instead of product average"
+```
+
+---
+
+### Task 6: Update handler DTO to include Stars field
+
+**Files:**
+- Modify: `services/reviews/internal/adapter/inbound/http/dto.go`
+- Modify: `services/reviews/internal/adapter/inbound/http/handler.go`
+
+- [ ] **Step 1: Add Stars to ReviewRatingResponse DTO**
+
+In `services/reviews/internal/adapter/inbound/http/dto.go`, update `ReviewRatingResponse`:
+
+```go
+// ReviewRatingResponse represents rating data embedded in a review response.
+type ReviewRatingResponse struct {
+	Stars   int     `json:"stars"`
+	Average float64 `json:"average"`
+	Count   int     `json:"count"`
+}
+```
+
+- [ ] **Step 2: Map Stars in the handler**
+
+In `services/reviews/internal/adapter/inbound/http/handler.go`, update the rating mapping in `getProductReviews` (line 48-51):
+
+```go
+		if review.Rating != nil {
+			resp.Rating = &ReviewRatingResponse{
+				Stars:   review.Rating.Stars,
+				Average: review.Rating.Average,
+				Count:   review.Rating.Count,
+			}
+		}
+```
+
+- [ ] **Step 3: Run handler tests**
+
+Run: `go test -race -count=1 ./services/reviews/internal/adapter/inbound/http/...`
+Expected: All tests PASS — including the new `Rating.Stars` assertion.
+
+- [ ] **Step 4: Run full reviews service tests**
+
+Run: `go test -race -count=1 ./services/reviews/...`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/reviews/internal/adapter/inbound/http/dto.go services/reviews/internal/adapter/inbound/http/handler.go
+git commit -m "feat(reviews): expose individual stars in review API response"
+```
+
+---
+
+### Task 7: Update productpage to render individual scores
+
+**Files:**
+- Modify: `services/productpage/internal/client/reviews.go`
+- Modify: `services/productpage/internal/model/product.go`
+- Modify: `services/productpage/internal/handler/handler.go:179-188`
+- Modify: `services/productpage/templates/partials/reviews.html`
+- Modify: `services/productpage/internal/handler/handler_test.go`
+
+- [ ] **Step 1: Update the mock server in productpage tests**
+
+In `services/productpage/internal/handler/handler_test.go`, update the reviews mock server (inside `setupMockServers`) to include `stars` in the rating:
+
+Find (lines 69-76):
+
+```go
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"product_id": r.PathValue("id"),
+			"reviews": []map[string]any{
+				{
+					"id":         "review-1",
+					"product_id": r.PathValue("id"),
+					"reviewer":   "alice",
+					"text":       "Great book!",
+					"rating":     map[string]any{"average": 4.5, "count": 10},
+				},
+			},
+		})
+```
+
+Replace with:
+
+```go
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"product_id": r.PathValue("id"),
+			"reviews": []map[string]any{
+				{
+					"id":         "review-1",
+					"product_id": r.PathValue("id"),
+					"reviewer":   "alice",
+					"text":       "Great book!",
+					"rating":     map[string]any{"stars": 5, "average": 4.5, "count": 10},
+				},
+			},
+		})
+```
+
+Update `TestPartialReviews` to assert on the individual star count rendered in the template. Add after the existing assertions (after line 189):
+
+```go
+	// Should render 5 filled stars for alice's individual score
+	filledStars := strings.Count(body, "star-filled")
+	if filledStars != 5 {
+		t.Errorf("expected 5 filled stars, got %d", filledStars)
+	}
+	// Should show "5/5" individual score
+	if !strings.Contains(body, "5/5") {
+		t.Errorf("expected '5/5' score display in response, got:\n%s", body)
+	}
+```
+
+- [ ] **Step 2: Verify test fails**
+
+Run: `go test -race -count=1 -run TestPartialReviews ./services/productpage/...`
+Expected: FAIL — the `Stars` field isn't parsed yet, template still uses `Average`.
+
+- [ ] **Step 3: Add Stars to productpage client DTO**
+
+In `services/productpage/internal/client/reviews.go`, update `ReviewRatingResponse`:
+
+```go
+// ReviewRatingResponse represents rating data from the reviews service.
+type ReviewRatingResponse struct {
+	Stars   int     `json:"stars"`
+	Average float64 `json:"average"`
+	Count   int     `json:"count"`
+}
+```
+
+- [ ] **Step 4: Add Stars to productpage view model**
+
+In `services/productpage/internal/model/product.go`, update `ProductReview`:
+
+```go
+// ProductReview is the view model for a single review.
+type ProductReview struct {
+	ID       string
+	Reviewer string
+	Text     string
+	Stars    int
+	Average  float64
+	Count    int
+}
+```
+
+- [ ] **Step 5: Map Stars in productpage handler**
+
+In `services/productpage/internal/handler/handler.go`, update the `partialReviews` function (lines 179-189):
+
+```go
+	var viewModels []model.ProductReview
+	for _, review := range reviews.Reviews {
+		vm := model.ProductReview{
+			ID:       review.ID,
+			Reviewer: review.Reviewer,
+			Text:     review.Text,
+		}
+		if review.Rating != nil {
+			vm.Stars = review.Rating.Stars
+			vm.Average = review.Rating.Average
+			vm.Count = review.Rating.Count
+		}
+		viewModels = append(viewModels, vm)
+	}
+```
+
+- [ ] **Step 6: Update reviews.html template to render individual Stars**
+
+Replace the entire content of `services/productpage/templates/partials/reviews.html`:
+
+```html
+{{if .}}
+{{range .}}
+<div class="review">
+    <div class="review-header">
+        <div class="reviewer">
+            <div class="reviewer-avatar">{{slice .Reviewer 0 1}}</div>
+            <div>
+                <div class="reviewer-name">{{.Reviewer}}</div>
+            </div>
+        </div>
+        {{if gt .Stars 0}}
+        <div style="display: flex; align-items: center; gap: 0.5rem;">
+            <div class="stars">
+                {{$s := .Stars}}
+                {{if ge $s 1}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
+                {{if ge $s 2}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
+                {{if ge $s 3}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
+                {{if ge $s 4}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
+                {{if ge $s 5}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
+            </div>
+            <span class="rating-count">{{.Stars}}/5</span>
+        </div>
+        {{end}}
+    </div>
+    <div class="review-text">{{.Text}}</div>
+</div>
+{{end}}
+{{else}}
+<p style="color: var(--text-muted); font-size: 0.9rem; padding: 0.5rem 0;">No reviews yet.</p>
+{{end}}
+```
+
+Key changes:
+- `{{if gt .Count 0}}` → `{{if gt .Stars 0}}` — show stars only if reviewer has a rating
+- `{{$a := .Average}}` → `{{$s := .Stars}}` — use individual integer stars
+- `{{if ge $a 1.0}}` → `{{if ge $s 1}}` — integer comparison instead of float
+- `{{printf "%.1f" .Average}}` → `{{.Stars}}/5` — show individual score
+
+- [ ] **Step 7: Run productpage tests**
+
+Run: `go test -race -count=1 ./services/productpage/...`
+Expected: All tests PASS — including the new filled-stars and "5/5" assertions.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add services/productpage/internal/client/reviews.go services/productpage/internal/model/product.go services/productpage/internal/handler/handler.go services/productpage/templates/partials/reviews.html services/productpage/internal/handler/handler_test.go
+git commit -m "fix(productpage): render individual reviewer scores instead of product average"
+```
+
+---
+
+### Task 8: Run full test suite and verify
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `go test -race -count=1 ./...`
+Expected: All tests PASS across all services.
+
+- [ ] **Step 2: Run linter**
+
+Run: `make lint`
+Expected: No lint errors.
+
+- [ ] **Step 3: Build all binaries**
+
+Run: `make build-all`
+Expected: All 5 service binaries build successfully.

--- a/docs/superpowers/specs/2026-04-09-reviews-bugfixes-design.md
+++ b/docs/superpowers/specs/2026-04-09-reviews-bugfixes-design.md
@@ -1,0 +1,134 @@
+# Reviews Bugfixes: Required Text Label + Individual Scores
+
+**Date:** 2026-04-09
+**Status:** Approved
+
+## Problem
+
+Two bugs in the reviews/ratings display flow:
+
+1. **Review text labeled "optional" but required by domain** — The HTML form labels the review textarea as "Review (optional)", but `domain.NewReview()` rejects empty text with `"review text is required"`. In the k8s CQRS flow, the POST goes through the Argo Events webhook (returns 200 OK immediately), then the Sensor triggers the reviews write service which silently rejects the review.
+
+2. **All reviews show the product average instead of individual scores** — The ratings service returns individual `ratings[]` per reviewer, but the reviews service `RatingsClient` only extracts the product-level `average` and `count`, then assigns the same average to every review.
+
+## Approach
+
+### Bug 1: Fix UI to match domain (text is required)
+
+The domain validation is correct — reviews should have text. Fix the UI labels and add HTML validation.
+
+**Files changed:**
+- `services/productpage/templates/productpage.html` — Remove "(optional)" from label, add `required` attribute to textarea
+- `services/productpage/templates/partials/rating-form.html` — Same changes (error-state re-render of the form)
+
+### Bug 2: Show individual reviewer scores (Approach A — match by reviewer)
+
+The ratings API already returns individual ratings in `ratings[]`. The reviews service just needs to parse and use them.
+
+**Data flow (current, broken):**
+1. Reviews service calls `GET /v1/ratings/{product_id}`
+2. Ratings API returns `{average: 3.5, count: 4, ratings: [{reviewer: "A", stars: 5}, ...]}`
+3. Reviews `RatingsClient` extracts only `average` and `count`, ignores `ratings[]`
+4. Same average assigned to every review
+
+**Data flow (fixed):**
+1. Reviews service calls `GET /v1/ratings/{product_id}` (no API change)
+2. Ratings API returns same response (no change)
+3. Reviews `RatingsClient` parses full `ratings[]` array, builds `map[reviewer]stars`
+4. Returns both product-level stats AND per-reviewer ratings
+5. Service layer matches each review's `Reviewer` to their individual rating
+6. Each review gets its own `Stars` value
+7. Handler serializes `stars` field per review
+8. Productpage parses `stars` and renders individual scores
+
+**Files changed (reviews service):**
+
+| File | Change |
+|------|--------|
+| `services/reviews/internal/adapter/outbound/http/ratings_client.go` | Parse `ratings[]` from response. Add `individualRating` struct. Return `ProductRatingData` containing both product stats and `map[string]int` (reviewer -> stars). |
+| `services/reviews/internal/core/port/outbound.go` | Update `RatingsClient` interface: `GetProductRatings` returns a new `RatingData` type with product average + individual ratings map. |
+| `services/reviews/internal/core/domain/review.go` | No structural change. `ReviewRating.Stars` field already exists — it will now be populated. |
+| `services/reviews/internal/core/service/review_service.go` | In `GetProductReviews()`, use individual ratings map to set `Stars` per review. Fall back to 0 if reviewer has no rating. Keep `Average`/`Count` as product-level. |
+| `services/reviews/internal/adapter/inbound/http/dto.go` | Add `Stars int` field to `ReviewRatingResponse`. |
+| `services/reviews/internal/adapter/inbound/http/handler.go` | Map `review.Rating.Stars` into response DTO. |
+
+**Files changed (productpage service):**
+
+| File | Change |
+|------|--------|
+| `services/productpage/internal/client/reviews.go` | Add `Stars int` to `ReviewRatingResponse`. |
+| `services/productpage/internal/model/product.go` | Add `Stars int` to `ProductReview`. |
+| `services/productpage/internal/handler/handler.go` | Map `review.Rating.Stars` into view model in `partialReviews()`. |
+| `services/productpage/templates/partials/reviews.html` | Render stars based on individual `.Stars` integer instead of `.Average` float. |
+
+## Interface Changes
+
+### Reviews service outbound port (new return type)
+
+The current `RatingsClient` interface returns `*domain.ReviewRating`. This needs to change to carry both product-level stats and individual ratings:
+
+```go
+// RatingData holds both product-level and per-reviewer rating data.
+type RatingData struct {
+    Average           float64
+    Count             int
+    IndividualRatings map[string]int // reviewer -> stars
+}
+
+type RatingsClient interface {
+    GetProductRatings(ctx context.Context, productID string) (*RatingData, error)
+}
+```
+
+`RatingData` lives in the domain package since the port depends on domain types.
+
+### Reviews API response (additive change)
+
+```json
+{
+  "product_id": "1",
+  "reviews": [
+    {
+      "id": "abc",
+      "product_id": "1",
+      "reviewer": "Alice",
+      "text": "Great book",
+      "rating": {
+        "stars": 5,
+        "average": 3.5,
+        "count": 4
+      }
+    }
+  ]
+}
+```
+
+The `stars` field is new. `average` and `count` remain for backward compatibility (product-level stats).
+
+## Template Rendering Change
+
+Current `reviews.html` uses `{{$a := .Average}}` and `{{if ge $a 1.0}}` for float comparison. The fix switches to integer comparison using `.Stars`:
+
+```
+{{$s := .Stars}}
+{{if ge $s 1}}...filled...{{else}}...empty...{{end}}
+{{if ge $s 2}}...filled...{{else}}...empty...{{end}}
+...
+```
+
+The numeric display changes from `{{printf "%.1f" .Average}}` to `{{.Stars}}/5`.
+
+## Testing
+
+- **Reviews domain**: existing tests still pass (no domain changes)
+- **Reviews handler**: update `getProductReviews` test to verify `stars` field in response
+- **Reviews service**: update `GetProductReviews` test to verify per-reviewer rating matching
+- **Productpage handler**: update `partialReviews` test to verify `Stars` field mapping
+- **E2E (k8s)**: submit rating + review for a product, verify the review page shows the individual score
+
+## Out of Scope
+
+- Changing the ratings service API
+- Adding a per-reviewer ratings endpoint
+- Storing ratings within the reviews domain
+- Half-star or fractional individual ratings (ratings are always integer 1-5)

--- a/services/productpage/internal/client/reviews.go
+++ b/services/productpage/internal/client/reviews.go
@@ -14,6 +14,7 @@ import (
 
 // ReviewRatingResponse represents rating data from the reviews service.
 type ReviewRatingResponse struct {
+	Stars   int     `json:"stars"`
 	Average float64 `json:"average"`
 	Count   int     `json:"count"`
 }

--- a/services/productpage/internal/handler/handler.go
+++ b/services/productpage/internal/handler/handler.go
@@ -183,6 +183,7 @@ func (h *Handler) partialReviews(w http.ResponseWriter, r *http.Request) {
 			Text:     review.Text,
 		}
 		if review.Rating != nil {
+			vm.Stars = review.Rating.Stars
 			vm.Average = review.Rating.Average
 			vm.Count = review.Rating.Count
 		}

--- a/services/productpage/internal/handler/handler_test.go
+++ b/services/productpage/internal/handler/handler_test.go
@@ -72,7 +72,7 @@ func setupMockServers(t *testing.T) (detailsURL, reviewsURL, ratingsURL string) 
 					"product_id": r.PathValue("id"),
 					"reviewer":   "alice",
 					"text":       "Great book!",
-					"rating":     map[string]any{"average": 4.5, "count": 10},
+					"rating":     map[string]any{"stars": 5, "average": 4.5, "count": 10},
 				},
 			},
 		})
@@ -186,6 +186,15 @@ func TestPartialReviews(t *testing.T) {
 	}
 	if !strings.Contains(body, "Great book!") {
 		t.Errorf("expected 'Great book!' in response, got:\n%s", body)
+	}
+	// Should render 5 filled stars for alice's individual score
+	filledStars := strings.Count(body, "star-filled")
+	if filledStars != 5 {
+		t.Errorf("expected 5 filled stars, got %d", filledStars)
+	}
+	// Should show "5/5" individual score
+	if !strings.Contains(body, "5/5") {
+		t.Errorf("expected '5/5' score display in response, got:\n%s", body)
 	}
 }
 

--- a/services/productpage/internal/model/product.go
+++ b/services/productpage/internal/model/product.go
@@ -20,6 +20,7 @@ type ProductReview struct {
 	ID       string
 	Reviewer string
 	Text     string
+	Stars    int
 	Average  float64
 	Count    int
 }

--- a/services/productpage/templates/partials/rating-form.html
+++ b/services/productpage/templates/partials/rating-form.html
@@ -35,8 +35,8 @@
         </select>
     </div>
     <div class="form-group">
-        <label for="text">Review (optional)</label>
-        <textarea id="text" name="text" placeholder="Write your review..."></textarea>
+        <label for="text">Review</label>
+        <textarea id="text" name="text" required placeholder="Write your review..."></textarea>
     </div>
     <button type="submit" class="btn btn-primary">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2L11 13"/><path d="M22 2l-7 20-4-9-9-4 20-7z"/></svg>

--- a/services/productpage/templates/partials/reviews.html
+++ b/services/productpage/templates/partials/reviews.html
@@ -8,17 +8,17 @@
                 <div class="reviewer-name">{{.Reviewer}}</div>
             </div>
         </div>
-        {{if gt .Count 0}}
+        {{if gt .Stars 0}}
         <div style="display: flex; align-items: center; gap: 0.5rem;">
             <div class="stars">
-                {{$a := .Average}}
-                {{if ge $a 1.0}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
-                {{if ge $a 2.0}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
-                {{if ge $a 3.0}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
-                {{if ge $a 4.0}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
-                {{if ge $a 5.0}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
+                {{$s := .Stars}}
+                {{if ge $s 1}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
+                {{if ge $s 2}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
+                {{if ge $s 3}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
+                {{if ge $s 4}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
+                {{if ge $s 5}}<svg class="star star-filled" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{else}}<svg class="star star-empty" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>{{end}}
             </div>
-            <span class="rating-count">{{printf "%.1f" .Average}}</span>
+            <span class="rating-count">{{.Stars}}/5</span>
         </div>
         {{end}}
     </div>

--- a/services/productpage/templates/productpage.html
+++ b/services/productpage/templates/productpage.html
@@ -59,8 +59,8 @@
                     </select>
                 </div>
                 <div class="form-group">
-                    <label for="text">Review (optional)</label>
-                    <textarea id="text" name="text" placeholder="Write your review..."></textarea>
+                    <label for="text">Review</label>
+                    <textarea id="text" name="text" required placeholder="Write your review..."></textarea>
                 </div>
                 <button type="submit" class="btn btn-primary">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2L11 13"/><path d="M22 2l-7 20-4-9-9-4 20-7z"/></svg>

--- a/services/reviews/internal/adapter/inbound/http/dto.go
+++ b/services/reviews/internal/adapter/inbound/http/dto.go
@@ -10,6 +10,7 @@ type SubmitReviewRequest struct {
 
 // ReviewRatingResponse represents rating data embedded in a review response.
 type ReviewRatingResponse struct {
+	Stars   int     `json:"stars"`
 	Average float64 `json:"average"`
 	Count   int     `json:"count"`
 }

--- a/services/reviews/internal/adapter/inbound/http/handler.go
+++ b/services/reviews/internal/adapter/inbound/http/handler.go
@@ -46,6 +46,7 @@ func (h *Handler) getProductReviews(w http.ResponseWriter, r *http.Request) {
 		}
 		if review.Rating != nil {
 			resp.Rating = &ReviewRatingResponse{
+				Stars:   review.Rating.Stars,
 				Average: review.Rating.Average,
 				Count:   review.Rating.Count,
 			}

--- a/services/reviews/internal/adapter/inbound/http/handler_test.go
+++ b/services/reviews/internal/adapter/inbound/http/handler_test.go
@@ -16,19 +16,25 @@ import (
 )
 
 type stubRatingsClient struct {
-	rating *domain.ReviewRating
-	err    error
+	data *domain.RatingData
+	err  error
 }
 
-func (s *stubRatingsClient) GetProductRatings(_ context.Context, _ string) (*domain.ReviewRating, error) {
-	return s.rating, s.err
+func (s *stubRatingsClient) GetProductRatings(_ context.Context, _ string) (*domain.RatingData, error) {
+	return s.data, s.err
 }
 
 func setupHandler(t *testing.T) *http.ServeMux {
 	t.Helper()
 	repo := memory.NewReviewRepository()
 	client := &stubRatingsClient{
-		rating: &domain.ReviewRating{Average: 4.0, Count: 5},
+		data: &domain.RatingData{
+			Average: 4.0,
+			Count:   5,
+			IndividualRatings: map[string]int{
+				"alice": 4,
+			},
+		},
 	}
 	svc := service.NewReviewService(repo, client)
 	mux := http.NewServeMux()
@@ -145,6 +151,9 @@ func TestGetProductReviews_WithRatings(t *testing.T) {
 	review := body.Reviews[0]
 	if review.Rating == nil {
 		t.Fatal("expected non-nil rating")
+	}
+	if review.Rating.Stars != 4 {
+		t.Errorf("Rating.Stars = %d, want 4", review.Rating.Stars)
 	}
 	if review.Rating.Average != 4.0 {
 		t.Errorf("Rating.Average = %f, want 4.0", review.Rating.Average)

--- a/services/reviews/internal/adapter/outbound/http/ratings_client.go
+++ b/services/reviews/internal/adapter/outbound/http/ratings_client.go
@@ -13,11 +13,20 @@ import (
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
 )
 
+// individualRating mirrors a single rating entry from the ratings service.
+type individualRating struct {
+	ID        string `json:"id"`
+	ProductID string `json:"product_id"`
+	Reviewer  string `json:"reviewer"`
+	Stars     int    `json:"stars"`
+}
+
 // ratingsResponse mirrors the ratings service ProductRatingsResponse.
 type ratingsResponse struct {
-	ProductID string  `json:"product_id"`
-	Average   float64 `json:"average"`
-	Count     int     `json:"count"`
+	ProductID string             `json:"product_id"`
+	Average   float64            `json:"average"`
+	Count     int                `json:"count"`
+	Ratings   []individualRating `json:"ratings"`
 }
 
 // RatingsClient is an HTTP client that fetches ratings from the ratings service.
@@ -37,8 +46,8 @@ func NewRatingsClient(baseURL string) *RatingsClient {
 	}
 }
 
-// GetProductRatings fetches the aggregated ratings for a product from the ratings service.
-func (c *RatingsClient) GetProductRatings(ctx context.Context, productID string) (*domain.ReviewRating, error) {
+// GetProductRatings fetches both product-level and per-reviewer ratings from the ratings service.
+func (c *RatingsClient) GetProductRatings(ctx context.Context, productID string) (*domain.RatingData, error) {
 	url := fmt.Sprintf("%s/v1/ratings/%s", c.baseURL, productID)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -61,8 +70,14 @@ func (c *RatingsClient) GetProductRatings(ctx context.Context, productID string)
 		return nil, fmt.Errorf("decoding ratings response: %w", err)
 	}
 
-	return &domain.ReviewRating{
-		Average: body.Average,
-		Count:   body.Count,
+	individual := make(map[string]int, len(body.Ratings))
+	for _, r := range body.Ratings {
+		individual[r.Reviewer] = r.Stars
+	}
+
+	return &domain.RatingData{
+		Average:           body.Average,
+		Count:             body.Count,
+		IndividualRatings: individual,
 	}, nil
 }

--- a/services/reviews/internal/core/domain/review.go
+++ b/services/reviews/internal/core/domain/review.go
@@ -14,6 +14,13 @@ type ReviewRating struct {
 	Count   int
 }
 
+// RatingData holds both product-level and per-reviewer rating data.
+type RatingData struct {
+	Average           float64
+	Count             int
+	IndividualRatings map[string]int // reviewer -> stars
+}
+
 // Review represents a user review for a product.
 type Review struct {
 	ID        string

--- a/services/reviews/internal/core/port/outbound.go
+++ b/services/reviews/internal/core/port/outbound.go
@@ -18,6 +18,6 @@ type ReviewRepository interface {
 
 // RatingsClient defines the outbound operations for fetching ratings.
 type RatingsClient interface {
-	// GetProductRatings returns the aggregated rating info for a product.
-	GetProductRatings(ctx context.Context, productID string) (*domain.ReviewRating, error)
+	// GetProductRatings returns both product-level and per-reviewer rating data.
+	GetProductRatings(ctx context.Context, productID string) (*domain.RatingData, error)
 }

--- a/services/reviews/internal/core/service/review_service.go
+++ b/services/reviews/internal/core/service/review_service.go
@@ -33,7 +33,7 @@ func (s *ReviewService) GetProductReviews(ctx context.Context, productID string)
 	}
 
 	// Fetch ratings from the ratings service
-	rating, err := s.ratingsClient.GetProductRatings(ctx, productID)
+	ratingData, err := s.ratingsClient.GetProductRatings(ctx, productID)
 	if err != nil {
 		logger := logging.FromContext(ctx)
 		logger.Warn("failed to fetch ratings, returning reviews without ratings",
@@ -43,9 +43,13 @@ func (s *ReviewService) GetProductReviews(ctx context.Context, productID string)
 		return reviews, nil
 	}
 
-	// Enrich each review with the product-level rating
+	// Enrich each review with product-level stats and individual reviewer score
 	for i := range reviews {
-		reviews[i].Rating = rating
+		reviews[i].Rating = &domain.ReviewRating{
+			Stars:   ratingData.IndividualRatings[reviews[i].Reviewer],
+			Average: ratingData.Average,
+			Count:   ratingData.Count,
+		}
 	}
 
 	return reviews, nil

--- a/services/reviews/internal/core/service/review_service_test.go
+++ b/services/reviews/internal/core/service/review_service_test.go
@@ -12,12 +12,12 @@ import (
 
 // stubRatingsClient returns fixed rating data for testing.
 type stubRatingsClient struct {
-	rating *domain.ReviewRating
-	err    error
+	data *domain.RatingData
+	err  error
 }
 
-func (s *stubRatingsClient) GetProductRatings(_ context.Context, _ string) (*domain.ReviewRating, error) {
-	return s.rating, s.err
+func (s *stubRatingsClient) GetProductRatings(_ context.Context, _ string) (*domain.RatingData, error) {
+	return s.data, s.err
 }
 
 func TestSubmitReview_Success(t *testing.T) {
@@ -70,7 +70,7 @@ func TestSubmitReview_ValidationError(t *testing.T) {
 func TestGetProductReviews_Empty(t *testing.T) {
 	repo := memory.NewReviewRepository()
 	client := &stubRatingsClient{
-		rating: &domain.ReviewRating{Stars: 0, Average: 0, Count: 0},
+		data: &domain.RatingData{Average: 0, Count: 0, IndividualRatings: map[string]int{}},
 	}
 	svc := service.NewReviewService(repo, client)
 
@@ -87,7 +87,14 @@ func TestGetProductReviews_Empty(t *testing.T) {
 func TestGetProductReviews_WithRatings(t *testing.T) {
 	repo := memory.NewReviewRepository()
 	client := &stubRatingsClient{
-		rating: &domain.ReviewRating{Stars: 0, Average: 4.5, Count: 10},
+		data: &domain.RatingData{
+			Average: 3.5,
+			Count:   2,
+			IndividualRatings: map[string]int{
+				"alice": 5,
+				"bob":   2,
+			},
+		},
 	}
 	svc := service.NewReviewService(repo, client)
 
@@ -110,17 +117,28 @@ func TestGetProductReviews_WithRatings(t *testing.T) {
 		t.Fatalf("expected 2 reviews, got %d", len(reviews))
 	}
 
-	// Each review should have rating data
 	for _, review := range reviews {
 		if review.Rating == nil {
-			t.Error("expected non-nil Rating on review")
+			t.Errorf("expected non-nil Rating on review by %s", review.Reviewer)
 			continue
 		}
-		if review.Rating.Average != 4.5 {
-			t.Errorf("Rating.Average = %f, want 4.5", review.Rating.Average)
+		if review.Rating.Average != 3.5 {
+			t.Errorf("Rating.Average = %f, want 3.5", review.Rating.Average)
 		}
-		if review.Rating.Count != 10 {
-			t.Errorf("Rating.Count = %d, want 10", review.Rating.Count)
+		if review.Rating.Count != 2 {
+			t.Errorf("Rating.Count = %d, want 2", review.Rating.Count)
+		}
+		switch review.Reviewer {
+		case "alice":
+			if review.Rating.Stars != 5 {
+				t.Errorf("alice Rating.Stars = %d, want 5", review.Rating.Stars)
+			}
+		case "bob":
+			if review.Rating.Stars != 2 {
+				t.Errorf("bob Rating.Stars = %d, want 2", review.Rating.Stars)
+			}
+		default:
+			t.Errorf("unexpected reviewer: %s", review.Reviewer)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Bug 1:** Review text field was labeled "optional" in UI but required by domain validation — removed "(optional)" label and added `required` HTML attribute
- **Bug 2:** All reviews showed the product average rating instead of each reviewer's individual score — propagated individual ratings from the ratings API through the reviews service to the productpage template

## Changes

### Bug 1: Review text required
- Updated `productpage.html` and `rating-form.html` templates

### Bug 2: Individual reviewer scores
- **Reviews service:** Added `RatingData` domain type with `IndividualRatings map[string]int`, updated port interface, rewrote ratings client to parse `ratings[]` array, updated service to assign per-reviewer Stars, added `stars` field to API response DTO
- **Productpage:** Added `Stars` to client DTO, view model, and handler mapping; rewrote `reviews.html` template to render individual integer Stars instead of product Average

## Test plan

- [x] All unit tests pass (`go test -race -count=1 ./...`)
- [x] Linter passes (`make lint` — 0 issues)
- [x] All binaries build (`make build-all`)
- [x] Deployed to local k8s cluster (`make k8s-rebuild`)
- [ ] Manual verification: submit reviews with different star ratings, verify individual scores display correctly
- [ ] Manual verification: try to submit review without text, verify browser prevents submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)