### PR TITLE
feat: deploy Headlamp Kubernetes dashboard to local k8s

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ make k8s-logs           # Tail bookinfo namespace logs
 
 **Context safety:** All kubectl/helm calls use `--context=k3d-bookinfo-local`. Never mutates the user's active context.
 
-**Access:** Productpage http://localhost:8080, Webhooks POST http://localhost:8080/v1/* (method-based CQRS routing), Grafana http://localhost:3000, Prometheus http://localhost:9090
+**Access:** Productpage http://localhost:8080, Webhooks POST http://localhost:8080/v1/* (method-based CQRS routing), Grafana http://localhost:3000, Prometheus http://localhost:9090, Headlamp http://localhost:4466
 
 ## Deploy Structure
 

--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,7 @@ k8s-observability: ##@Kubernetes Install observability: Prometheus, Grafana, Tem
 	@$(KUBECTL) apply -k deploy/observability/local/dashboards/
 	@printf "  $(GREEN)Grafana dashboards applied.$(NC)\n"
 	@printf "$(BOLD)[7/7] Installing Headlamp dashboard...$(NC)\n"
-	@$(HELM) repo add headlamp https://charts.kubernetes-sigs.io/headlamp --force-update 2>/dev/null || true
+	@$(HELM) repo add headlamp https://kubernetes-sigs.github.io/headlamp/ --force-update 2>/dev/null || true
 	@$(HELM) upgrade --install headlamp headlamp/headlamp \
 		-n $(K8S_NS_OBSERVABILITY) \
 		-f deploy/observability/local/headlamp-values.yaml \

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ define k8s-guard
 endef
 
 .PHONY: k8s-cluster
-k8s-cluster: ##@Kubernetes Create k3d cluster with port mappings for Gateway + observability
+k8s-cluster: ##@Kubernetes Create k3d cluster with port mappings for Gateway, observability + Headlamp
 	@if k3d cluster list $(K8S_CLUSTER) >/dev/null 2>&1; then \
 		printf "$(GREEN)Cluster '$(K8S_CLUSTER)' already exists.$(NC)\n"; \
 	else \
@@ -230,6 +230,7 @@ k8s-cluster: ##@Kubernetes Create k3d cluster with port mappings for Gateway + o
 			-p "8080:80@loadbalancer" \
 			-p "3000:30300@server:0" \
 			-p "9090:30900@server:0" \
+			-p "4466:30444@server:0" \
 			--k3s-arg "--disable=traefik@server:0" \
 			--wait; \
 	fi
@@ -296,45 +297,52 @@ k8s-platform: ##@Kubernetes Install platform: Envoy Gateway, Strimzi, Kafka, Arg
 	@printf "\n$(GREEN)$(BOLD)Platform layer complete.$(NC)\n\n"
 
 .PHONY: k8s-observability
-k8s-observability: ##@Kubernetes Install observability: Prometheus, Grafana, Tempo, Loki, Alloy
+k8s-observability: ##@Kubernetes Install observability: Prometheus, Grafana, Tempo, Loki, Alloy, Headlamp
 	$(k8s-guard)
 	@printf "\n$(BOLD)═══ Observability Layer ═══$(NC)\n\n"
 	@$(KUBECTL) create namespace $(K8S_NS_OBSERVABILITY) --dry-run=client -o yaml | $(KUBECTL) apply -f -
-	@printf "$(BOLD)[1/6] Installing kube-prometheus-stack...$(NC)\n"
+	@printf "$(BOLD)[1/7] Installing kube-prometheus-stack...$(NC)\n"
 	@$(HELM) repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update 2>/dev/null || true
 	@$(HELM) upgrade --install prometheus prometheus-community/kube-prometheus-stack \
 		-n $(K8S_NS_OBSERVABILITY) \
 		-f deploy/observability/local/kube-prometheus-stack-values.yaml \
 		--wait --timeout 300s
 	@printf "  $(GREEN)kube-prometheus-stack ready.$(NC)\n"
-	@printf "$(BOLD)[2/6] Installing Tempo...$(NC)\n"
+	@printf "$(BOLD)[2/7] Installing Tempo...$(NC)\n"
 	@$(HELM) repo add grafana https://grafana.github.io/helm-charts --force-update 2>/dev/null || true
 	@$(HELM) upgrade --install tempo grafana/tempo \
 		-n $(K8S_NS_OBSERVABILITY) \
 		-f deploy/observability/local/tempo-values.yaml \
 		--wait --timeout 120s
 	@printf "  $(GREEN)Tempo ready.$(NC)\n"
-	@printf "$(BOLD)[3/6] Installing Loki...$(NC)\n"
+	@printf "$(BOLD)[3/7] Installing Loki...$(NC)\n"
 	@$(HELM) upgrade --install loki grafana/loki \
 		-n $(K8S_NS_OBSERVABILITY) \
 		-f deploy/observability/local/loki-values.yaml \
 		--wait --timeout 300s
 	@printf "  $(GREEN)Loki ready.$(NC)\n"
-	@printf "$(BOLD)[4/6] Installing Alloy (logs)...$(NC)\n"
+	@printf "$(BOLD)[4/7] Installing Alloy (logs)...$(NC)\n"
 	@$(HELM) upgrade --install alloy-logs grafana/alloy \
 		-n $(K8S_NS_OBSERVABILITY) \
 		-f deploy/observability/local/alloy-logs-values.yaml \
 		--wait --timeout 120s
 	@printf "  $(GREEN)Alloy (logs) ready.$(NC)\n"
-	@printf "$(BOLD)[5/6] Installing Alloy (metrics+traces)...$(NC)\n"
+	@printf "$(BOLD)[5/7] Installing Alloy (metrics+traces)...$(NC)\n"
 	@$(HELM) upgrade --install alloy-metrics-traces grafana/alloy \
 		-n $(K8S_NS_OBSERVABILITY) \
 		-f deploy/observability/local/alloy-metrics-traces-values.yaml \
 		--wait --timeout 120s
 	@printf "  $(GREEN)Alloy (metrics+traces) ready.$(NC)\n"
-	@printf "$(BOLD)[6/6] Applying Grafana dashboards...$(NC)\n"
+	@printf "$(BOLD)[6/7] Applying Grafana dashboards...$(NC)\n"
 	@$(KUBECTL) apply -k deploy/observability/local/dashboards/
 	@printf "  $(GREEN)Grafana dashboards applied.$(NC)\n"
+	@printf "$(BOLD)[7/7] Installing Headlamp dashboard...$(NC)\n"
+	@$(HELM) repo add headlamp https://charts.kubernetes-sigs.io/headlamp --force-update 2>/dev/null || true
+	@$(HELM) upgrade --install headlamp headlamp/headlamp \
+		-n $(K8S_NS_OBSERVABILITY) \
+		-f deploy/observability/local/headlamp-values.yaml \
+		--wait --timeout 120s
+	@printf "  $(GREEN)Headlamp dashboard ready.$(NC)\n"
 	@printf "\n$(GREEN)$(BOLD)Observability layer complete.$(NC)\n\n"
 
 .PHONY: k8s-deploy
@@ -433,6 +441,7 @@ k8s-status: ##@Kubernetes Show pod status and access URLs
 	@printf "  $(CYAN)Productpage:$(NC)  http://localhost:8080\n"
 	@printf "  $(CYAN)Grafana:$(NC)      http://localhost:3000  (admin/admin)\n"
 	@printf "  $(CYAN)Prometheus:$(NC)   http://localhost:9090\n"
+	@printf "  $(CYAN)Headlamp:$(NC)     http://localhost:4466\n"
 	@printf "\n$(BOLD)Webhooks (via Gateway CQRS routing):$(NC)\n\n"
 	@printf "  $(CYAN)book-added:$(NC)         curl -X POST http://localhost:8080/v1/details -H 'Content-Type: application/json' -d '{...}'\n"
 	@printf "  $(CYAN)review-submitted:$(NC)   curl -X POST http://localhost:8080/v1/reviews -H 'Content-Type: application/json' -d '{...}'\n"

--- a/Makefile
+++ b/Makefile
@@ -442,6 +442,7 @@ k8s-status: ##@Kubernetes Show pod status and access URLs
 	@printf "  $(CYAN)Grafana:$(NC)      http://localhost:3000  (admin/admin)\n"
 	@printf "  $(CYAN)Prometheus:$(NC)   http://localhost:9090\n"
 	@printf "  $(CYAN)Headlamp:$(NC)     http://localhost:4466\n"
+	@printf "\n  $(BOLD)Headlamp token:$(NC) $(KUBECTL) create token headlamp -n $(K8S_NS_OBSERVABILITY)\n"
 	@printf "\n$(BOLD)Webhooks (via Gateway CQRS routing):$(NC)\n\n"
 	@printf "  $(CYAN)book-added:$(NC)         curl -X POST http://localhost:8080/v1/details -H 'Content-Type: application/json' -d '{...}'\n"
 	@printf "  $(CYAN)review-submitted:$(NC)   curl -X POST http://localhost:8080/v1/reviews -H 'Content-Type: application/json' -d '{...}'\n"

--- a/deploy/observability/local/headlamp-values.yaml
+++ b/deploy/observability/local/headlamp-values.yaml
@@ -1,6 +1,6 @@
 # Headlamp Kubernetes Dashboard
 # Helm chart: headlamp/headlamp
-# Repo: https://charts.kubernetes-sigs.io/headlamp
+# Repo: https://kubernetes-sigs.github.io/headlamp/
 
 service:
   type: NodePort

--- a/deploy/observability/local/headlamp-values.yaml
+++ b/deploy/observability/local/headlamp-values.yaml
@@ -1,0 +1,15 @@
+# Headlamp Kubernetes Dashboard
+# Helm chart: headlamp/headlamp
+# Repo: https://charts.kubernetes-sigs.io/headlamp
+
+service:
+  type: NodePort
+  port: 80
+  nodePort: 30444
+
+clusterRoleBinding:
+  create: true
+  clusterRoleName: cluster-admin
+
+ingress:
+  enabled: false

--- a/docs/superpowers/plans/2026-04-09-headlamp-dashboard.md
+++ b/docs/superpowers/plans/2026-04-09-headlamp-dashboard.md
@@ -1,0 +1,208 @@
+# Headlamp Kubernetes Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy Headlamp as the Kubernetes dashboard in the local k8s environment, accessible at `http://localhost:4466`.
+
+**Architecture:** Official Headlamp Helm chart installed into the `observability` namespace with NodePort service (30444) exposed via k3d port mapping (4466:30444). Same pattern as Grafana and Prometheus.
+
+**Tech Stack:** Helm, k3d, Makefile
+
+---
+
+### Task 1: Create Headlamp Helm values file
+
+**Files:**
+- Create: `deploy/observability/local/headlamp-values.yaml`
+
+- [ ] **Step 1: Create the values file**
+
+Create `deploy/observability/local/headlamp-values.yaml`:
+
+```yaml
+# Headlamp Kubernetes Dashboard
+# Helm chart: headlamp/headlamp
+# Repo: https://charts.kubernetes-sigs.io/headlamp
+
+service:
+  type: NodePort
+  port: 80
+  nodePort: 30444
+
+clusterRoleBinding:
+  create: true
+  clusterRoleName: cluster-admin
+
+ingress:
+  enabled: false
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add deploy/observability/local/headlamp-values.yaml
+git commit -m "feat(observability): add Headlamp Helm values for local k8s"
+```
+
+---
+
+### Task 2: Update Makefile — k3d port mapping, observability target, status output
+
+**Files:**
+- Modify: `Makefile:232` (k8s-cluster target — add port mapping)
+- Modify: `Makefile:298-338` (k8s-observability target — add Headlamp step, update step counts)
+- Modify: `Makefile:423-440` (k8s-status target — add Headlamp URL)
+
+- [ ] **Step 1: Add k3d port mapping for Headlamp**
+
+In `Makefile`, inside the `k8s-cluster` target, add a new port mapping line after the Prometheus port mapping (line 232):
+
+Find:
+```makefile
+			-p "9090:30900@server:0" \
+			--k3s-arg "--disable=traefik@server:0" \
+```
+
+Replace with:
+```makefile
+			-p "9090:30900@server:0" \
+			-p "4466:30444@server:0" \
+			--k3s-arg "--disable=traefik@server:0" \
+```
+
+- [ ] **Step 2: Update k8s-observability step counts from [N/6] to [N/7]**
+
+In the `k8s-observability` target, update all step labels from `/6]` to `/7]`:
+
+- `[1/6]` → `[1/7]`
+- `[2/6]` → `[2/7]`
+- `[3/6]` → `[3/7]`
+- `[4/6]` → `[4/7]`
+- `[5/6]` → `[5/7]`
+- `[6/6]` → `[6/7]`
+
+- [ ] **Step 3: Add Headlamp install step after Grafana dashboards**
+
+In the `k8s-observability` target, add the Headlamp step after the Grafana dashboards block (after line 337: `@printf "  $(GREEN)Grafana dashboards applied.$(NC)\n"`):
+
+```makefile
+	@printf "$(BOLD)[7/7] Installing Headlamp dashboard...$(NC)\n"
+	@$(HELM) repo add headlamp https://charts.kubernetes-sigs.io/headlamp --force-update 2>/dev/null || true
+	@$(HELM) upgrade --install headlamp headlamp/headlamp \
+		-n $(K8S_NS_OBSERVABILITY) \
+		-f deploy/observability/local/headlamp-values.yaml \
+		--wait --timeout 120s
+	@printf "  $(GREEN)Headlamp dashboard ready.$(NC)\n"
+```
+
+- [ ] **Step 4: Add Headlamp URL to k8s-status output**
+
+In the `k8s-status` target, add the Headlamp URL after the Prometheus line (after line 435: `@printf "  $(CYAN)Prometheus:$(NC)   http://localhost:9090\n"`):
+
+```makefile
+	@printf "  $(CYAN)Headlamp:$(NC)     http://localhost:4466\n"
+```
+
+- [ ] **Step 5: Update k8s-cluster target description**
+
+In the `k8s-cluster` target help comment (line 223), update the description to mention Headlamp:
+
+Find:
+```makefile
+k8s-cluster: ##@Kubernetes Create k3d cluster with port mappings for Gateway + observability
+```
+
+Replace with:
+```makefile
+k8s-cluster: ##@Kubernetes Create k3d cluster with port mappings for Gateway, observability + Headlamp
+```
+
+- [ ] **Step 6: Update k8s-observability target description**
+
+In the `k8s-observability` target help comment (line 299), update the description to mention Headlamp:
+
+Find:
+```makefile
+k8s-observability: ##@Kubernetes Install observability: Prometheus, Grafana, Tempo, Loki, Alloy
+```
+
+Replace with:
+```makefile
+k8s-observability: ##@Kubernetes Install observability: Prometheus, Grafana, Tempo, Loki, Alloy, Headlamp
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Makefile
+git commit -m "feat(observability): add Headlamp to k8s cluster setup and status"
+```
+
+---
+
+### Task 3: Update CLAUDE.md access documentation
+
+**Files:**
+- Modify: `CLAUDE.md:55`
+
+- [ ] **Step 1: Add Headlamp to the Access line**
+
+In `CLAUDE.md`, update the Access line (line 55):
+
+Find:
+```
+**Access:** Productpage http://localhost:8080, Webhooks POST http://localhost:8080/v1/* (method-based CQRS routing), Grafana http://localhost:3000, Prometheus http://localhost:9090
+```
+
+Replace with:
+```
+**Access:** Productpage http://localhost:8080, Webhooks POST http://localhost:8080/v1/* (method-based CQRS routing), Grafana http://localhost:3000, Prometheus http://localhost:9090, Headlamp http://localhost:4466
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add Headlamp URL to project access documentation"
+```
+
+---
+
+### Task 4: Deploy and verify
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Recreate the k3d cluster with the new port mapping**
+
+The new `-p "4466:30444@server:0"` port mapping requires recreating the cluster:
+
+```bash
+make stop-k8s
+make run-k8s
+```
+
+This will create a fresh cluster with the Headlamp port mapping, install all platform + observability + app layers, and print status with the new Headlamp URL.
+
+- [ ] **Step 2: Verify Headlamp pod is running**
+
+```bash
+kubectl --context=k3d-bookinfo-local get pods -n observability -l app.kubernetes.io/name=headlamp
+```
+
+Expected: One pod in `Running` state.
+
+- [ ] **Step 3: Verify Headlamp is accessible**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:4466
+```
+
+Expected: `200`
+
+- [ ] **Step 4: Verify k8s-status output includes Headlamp**
+
+```bash
+make k8s-status
+```
+
+Expected: Output includes `Headlamp:     http://localhost:4466`

--- a/docs/superpowers/specs/2026-04-09-headlamp-dashboard-design.md
+++ b/docs/superpowers/specs/2026-04-09-headlamp-dashboard-design.md
@@ -1,0 +1,69 @@
+# Headlamp Kubernetes Dashboard — Local Deployment
+
+**Date:** 2026-04-09
+**Status:** Approved
+
+## Goal
+
+Deploy Headlamp as the Kubernetes dashboard in the local k8s environment, following the same Helm + NodePort + k3d port mapping pattern used by Grafana and Prometheus.
+
+## Approach
+
+Install the official `headlamp/headlamp` Helm chart into the `observability` namespace with a NodePort service exposed via k3d port mapping at `http://localhost:4466`.
+
+## Changes
+
+### New file: `deploy/observability/local/headlamp-values.yaml`
+
+Helm values for the Headlamp chart:
+- Service type: `NodePort`, nodePort `30444`
+- `cluster-admin` ClusterRoleBinding for full local dev access
+- No plugins, no custom branding, no auth
+
+### Modified: `Makefile`
+
+**`k8s-cluster` target** — add k3d port mapping:
+```
+-p "4466:30444@server:0"
+```
+
+**`k8s-observability` target** — add Headlamp as step `[7/7]` after Grafana dashboards:
+```
+helm repo add headlamp https://headlamp-k8s.github.io/headlamp/
+helm upgrade --install headlamp headlamp/headlamp \
+    -n observability \
+    -f deploy/observability/local/headlamp-values.yaml \
+    --wait --timeout 120s
+```
+
+**`k8s-status` target** — add Headlamp URL to access URLs output:
+```
+Headlamp:     http://localhost:4466
+```
+
+### Modified: `CLAUDE.md`
+
+Add Headlamp to the Access section: `Headlamp http://localhost:4466`
+
+## Port Mapping Summary
+
+| Tool | localhost | NodePort |
+|------|-----------|----------|
+| Productpage | :8080 | (loadbalancer) |
+| Grafana | :3000 | 30300 |
+| Prometheus | :9090 | 30900 |
+| Headlamp | :4466 | 30444 |
+
+## RBAC
+
+The Headlamp service account gets a `cluster-admin` ClusterRoleBinding. This is acceptable for a local dev cluster (k3d). No token-based auth or OIDC — Headlamp will have full read/write access to all cluster resources.
+
+The Headlamp Helm chart supports `clusterRoleBinding.create: true` with a configurable role, which handles RBAC setup declaratively.
+
+## Out of Scope
+
+- Headlamp plugins
+- Custom branding or theming
+- Authentication (OIDC, token)
+- Production deployment considerations
+- Ingress or Gateway routing for Headlamp


### PR DESCRIPTION
## Summary

- Deploy [Headlamp](https://headlamp.dev/) as the Kubernetes dashboard in the local k8s environment
- Follows the existing Helm + NodePort + k3d port mapping pattern used by Grafana and Prometheus
- Accessible at `http://localhost:4466` with token auth via `kubectl create token`

## Changes

- **New:** `deploy/observability/local/headlamp-values.yaml` — Helm values (NodePort 30444, cluster-admin RBAC)
- **Makefile:** k3d port mapping (`4466:30444`), observability step `[7/7]`, status URL + token command
- **CLAUDE.md:** Added Headlamp to access URLs

## Test plan

- [x] `make run-k8s` completes with Headlamp as step `[7/7]`
- [x] Headlamp pod running in `observability` namespace
- [x] `curl http://localhost:4466` returns 200
- [x] `make k8s-status` shows Headlamp URL and token generation command
- [x] Token generation command works: `kubectl create token headlamp -n observability`

🤖 Generated with [Claude Code](https://claude.com/claude-code)