### PR TITLE
feat: database operation tracing and service graph visibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -461,6 +461,39 @@ k8s-logs: ##@Kubernetes Tail logs from bookinfo namespace
 	$(k8s-guard)
 	$(KUBECTL) logs -n $(K8S_NS_BOOKINFO) -l part-of=event-driven-bookinfo -f --max-log-requests=10
 
+# ─── Traffic ─────────────────────────────────────────────────────────────────
+
+GATEWAY_URL := http://localhost:8080
+
+.PHONY: k8s-traffic
+k8s-traffic: ##@Kubernetes Generate sample GET and POST traffic through the gateway
+	@printf "$(BOLD)Generating sample traffic against $(GATEWAY_URL)...$(NC)\n\n"
+	@printf "$(CYAN)[POST]$(NC) /v1/details — add a book\n"
+	@curl -s -X POST $(GATEWAY_URL)/v1/details \
+		-H 'Content-Type: application/json' \
+		-d '{"title":"The Go Programming Language","author":"Donovan & Kernighan","year":2015,"isbn":"978-0134190440"}' \
+		-w "  HTTP %{http_code}\n"
+	@printf "$(CYAN)[POST]$(NC) /v1/ratings — submit a rating\n"
+	@curl -s -X POST $(GATEWAY_URL)/v1/ratings \
+		-H 'Content-Type: application/json' \
+		-d '{"book_id":"1","rating":5}' \
+		-w "  HTTP %{http_code}\n"
+	@printf "$(CYAN)[POST]$(NC) /v1/reviews — submit a review\n"
+	@curl -s -X POST $(GATEWAY_URL)/v1/reviews \
+		-H 'Content-Type: application/json' \
+		-d '{"book_id":"1","reviewer":"alice","text":"Excellent book on Go","rating":5}' \
+		-w "  HTTP %{http_code}\n"
+	@sleep 2
+	@printf "\n$(CYAN)[GET]$(NC)  /v1/products/1 — read product page\n"
+	@curl -s $(GATEWAY_URL)/v1/products/1 -o /dev/null -w "  HTTP %{http_code}\n"
+	@printf "$(CYAN)[GET]$(NC)  /v1/details — list details\n"
+	@curl -s $(GATEWAY_URL)/v1/details -o /dev/null -w "  HTTP %{http_code}\n"
+	@printf "$(CYAN)[GET]$(NC)  /v1/ratings/1 — get ratings\n"
+	@curl -s $(GATEWAY_URL)/v1/ratings/1 -o /dev/null -w "  HTTP %{http_code}\n"
+	@printf "$(CYAN)[GET]$(NC)  /v1/reviews/1 — get reviews\n"
+	@curl -s $(GATEWAY_URL)/v1/reviews/1 -o /dev/null -w "  HTTP %{http_code}\n"
+	@printf "\n$(GREEN)Done. Check traces at http://localhost:3000 (Grafana > Explore > Tempo)$(NC)\n"
+
 # ─── Help ───────────────────────────────────────────────────────────────────
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -466,32 +466,27 @@ k8s-logs: ##@Kubernetes Tail logs from bookinfo namespace
 GATEWAY_URL := http://localhost:8080
 
 .PHONY: k8s-traffic
-k8s-traffic: ##@Kubernetes Generate sample GET and POST traffic through the gateway
+k8s-traffic: ##@Kubernetes Generate sample traffic through the productpage
 	@printf "$(BOLD)Generating sample traffic against $(GATEWAY_URL)...$(NC)\n\n"
-	@printf "$(CYAN)[POST]$(NC) /v1/details — add a book\n"
-	@curl -s -X POST $(GATEWAY_URL)/v1/details \
-		-H 'Content-Type: application/json' \
-		-d '{"title":"The Go Programming Language","author":"Donovan & Kernighan","year":2015,"isbn":"978-0134190440"}' \
-		-w "  HTTP %{http_code}\n"
-	@printf "$(CYAN)[POST]$(NC) /v1/ratings — submit a rating\n"
-	@curl -s -X POST $(GATEWAY_URL)/v1/ratings \
-		-H 'Content-Type: application/json' \
-		-d '{"book_id":"1","rating":5}' \
-		-w "  HTTP %{http_code}\n"
-	@printf "$(CYAN)[POST]$(NC) /v1/reviews — submit a review\n"
-	@curl -s -X POST $(GATEWAY_URL)/v1/reviews \
-		-H 'Content-Type: application/json' \
-		-d '{"book_id":"1","reviewer":"alice","text":"Excellent book on Go","rating":5}' \
-		-w "  HTTP %{http_code}\n"
-	@sleep 2
-	@printf "\n$(CYAN)[GET]$(NC)  /v1/products/1 — read product page\n"
-	@curl -s $(GATEWAY_URL)/v1/products/1 -o /dev/null -w "  HTTP %{http_code}\n"
-	@printf "$(CYAN)[GET]$(NC)  /v1/details — list details\n"
-	@curl -s $(GATEWAY_URL)/v1/details -o /dev/null -w "  HTTP %{http_code}\n"
-	@printf "$(CYAN)[GET]$(NC)  /v1/ratings/1 — get ratings\n"
-	@curl -s $(GATEWAY_URL)/v1/ratings/1 -o /dev/null -w "  HTTP %{http_code}\n"
-	@printf "$(CYAN)[GET]$(NC)  /v1/reviews/1 — get reviews\n"
-	@curl -s $(GATEWAY_URL)/v1/reviews/1 -o /dev/null -w "  HTTP %{http_code}\n"
+	@printf "$(BOLD)── Read path (GET via productpage → fan-out to backends) ──$(NC)\n"
+	@printf "$(CYAN)[GET]$(NC)  / — home page (productpage → details)\n"
+	@curl -s $(GATEWAY_URL)/ -o /dev/null -w "  HTTP %{http_code}\n"
+	@PRODUCT_ID=$$(curl -s $(GATEWAY_URL)/ | grep -o '/products/[^"]*' | head -1 | sed 's|/products/||'); \
+	if [ -z "$$PRODUCT_ID" ]; then \
+		printf "  $(RED)No products found, skipping product-specific requests$(NC)\n"; \
+	else \
+		printf "$(CYAN)[GET]$(NC)  /products/$$PRODUCT_ID — product page (productpage → details + reviews + ratings)\n"; \
+		curl -s $(GATEWAY_URL)/products/$$PRODUCT_ID -o /dev/null -w "  HTTP %{http_code}\n"; \
+		printf "$(CYAN)[GET]$(NC)  /partials/details/$$PRODUCT_ID — HTMX partial details\n"; \
+		curl -s $(GATEWAY_URL)/partials/details/$$PRODUCT_ID -o /dev/null -w "  HTTP %{http_code}\n"; \
+		printf "$(CYAN)[GET]$(NC)  /partials/reviews/$$PRODUCT_ID — HTMX partial reviews\n"; \
+		curl -s $(GATEWAY_URL)/partials/reviews/$$PRODUCT_ID -o /dev/null -w "  HTTP %{http_code}\n"; \
+		printf "\n$(BOLD)── Write path (POST via productpage → gateway → Argo Events CQRS) ──$(NC)\n"; \
+		printf "$(CYAN)[POST]$(NC) /partials/rating — submit rating+review (productpage → ratings + reviews via gateway)\n"; \
+		curl -s -o /dev/null -X POST $(GATEWAY_URL)/partials/rating \
+			-d "product_id=$$PRODUCT_ID&reviewer=alice&stars=5&text=Excellent+book+on+Go" \
+			-w "  HTTP %{http_code}\n"; \
+	fi
 	@printf "\n$(GREEN)Done. Check traces at http://localhost:3000 (Grafana > Explore > Tempo)$(NC)\n"
 
 # ─── Help ───────────────────────────────────────────────────────────────────

--- a/deploy/observability/local/tempo-values.yaml
+++ b/deploy/observability/local/tempo-values.yaml
@@ -24,6 +24,10 @@ tempo:
       service_graphs:
         enable_virtual_node_label: true
         enable_messaging_system_latency_histogram: true
+        peer_attributes:
+          - peer.service
+          - db.system
+          - server.address
         histogram_buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
         dimensions:
           - http.method

--- a/deploy/observability/local/tempo-values.yaml
+++ b/deploy/observability/local/tempo-values.yaml
@@ -30,9 +30,6 @@ tempo:
           - server.address
         histogram_buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
         dimensions:
-          - http.method
-          - k8s.namespace.name
-          - k8s.cluster.name
           - messaging.system
   overrides:
     defaults:

--- a/deploy/observability/local/tempo-values.yaml
+++ b/deploy/observability/local/tempo-values.yaml
@@ -22,11 +22,14 @@ tempo:
           - server.address
         histogram_buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
       service_graphs:
+        enable_virtual_node_label: true
+        enable_messaging_system_latency_histogram: true
         histogram_buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
         dimensions:
           - http.method
           - k8s.namespace.name
           - k8s.cluster.name
+          - messaging.system
   overrides:
     defaults:
       metrics_generator:

--- a/docs/superpowers/plans/2026-04-10-alloy-span-kind-transform.md
+++ b/docs/superpowers/plans/2026-04-10-alloy-span-kind-transform.md
@@ -1,5 +1,7 @@
 # Alloy Span Kind Transform Implementation Plan
 
+> **SUPERSEDED:** This plan is not being executed. The Argo Events fork will be updated directly with proper span kinds (Plan: `2026-04-10-argo-events-messaging-spans.md`), making this Alloy workaround unnecessary. Kept for reference.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Make Argo Events sensors and EventSources visible in the Grafana Tempo service graph by transforming their span kinds from INTERNAL to CLIENT/SERVER in the Alloy collector pipeline.

--- a/docs/superpowers/plans/2026-04-10-alloy-span-kind-transform.md
+++ b/docs/superpowers/plans/2026-04-10-alloy-span-kind-transform.md
@@ -1,0 +1,297 @@
+# Alloy Span Kind Transform Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Argo Events sensors and EventSources visible in the Grafana Tempo service graph by transforming their span kinds from INTERNAL to CLIENT/SERVER in the Alloy collector pipeline.
+
+**Architecture:** Add an `otelcol.processor.transform` block to the Alloy trace pipeline that rewrites span kinds for Argo Events spans before they reach Tempo. Also enable `enable_virtual_node_label` in Tempo's service graph processor for resilience against unpaired spans.
+
+**Tech Stack:** Grafana Alloy (OTTL transform processor), Grafana Tempo (metrics generator), Helm
+
+**Spec:** `docs/superpowers/specs/2026-04-10-alloy-span-kind-transform-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `deploy/observability/local/alloy-metrics-traces-values.yaml` | Modify | Helm values with inline Alloy config — **this is the deployed config** |
+| `deploy/observability/local/alloy-metrics-traces-config.alloy` | Modify | Reference copy of the Alloy config — must stay in sync with values.yaml |
+| `deploy/observability/local/tempo-values.yaml` | Modify | Tempo Helm values — add `enable_virtual_node_label` to service graph processor |
+
+---
+
+### Task 1: Add Transform Processor to Alloy Config (Reference File)
+
+**Files:**
+- Modify: `deploy/observability/local/alloy-metrics-traces-config.alloy:33-42` (cluster attributes output wiring)
+
+The transform processor slots between the cluster attributes processor and the batch processor. Two changes are needed: (1) rewire the cluster attributes output to feed the transform, and (2) add the transform block that feeds the batch processor.
+
+- [ ] **Step 1: Rewire cluster attributes output to feed transform instead of batch**
+
+In `deploy/observability/local/alloy-metrics-traces-config.alloy`, change the cluster attributes processor output from `otelcol.processor.batch.default.input` to `otelcol.processor.transform.argo_events.input`:
+
+```alloy
+// -- Static Cluster Name Attribute --
+otelcol.processor.attributes "cluster" {
+  action {
+    key    = "k8s.cluster.name"
+    value  = "bookinfo-local"
+    action = "insert"
+  }
+  output {
+    traces = [otelcol.processor.transform.argo_events.input]
+  }
+}
+```
+
+- [ ] **Step 2: Add transform processor block after cluster attributes and before batch**
+
+Insert this new block between the cluster attributes block (line 42) and the batch processor block (line 44) in `deploy/observability/local/alloy-metrics-traces-config.alloy`:
+
+```alloy
+// -- Fix Argo Events span kinds for Tempo service graph --
+// Workaround: Argo Events PR #3961 sets all spans to INTERNAL.
+// Tempo service graph only processes CLIENT/SERVER pairs.
+// This transform rewrites known Argo Events span patterns so they
+// appear as nodes/edges in the service graph.
+// Remove when Argo Events fork ships proper span kinds.
+otelcol.processor.transform "argo_events" {
+  error_mode = "ignore"
+
+  trace_statements {
+    context = "span"
+    conditions = [
+      `IsMatch(resource.attributes["service.name"], ".*-sensor$")`,
+    ]
+    statements = [
+      `set(span.kind.string, "Client") where IsMatch(name, "^sensor\\.trigger")`,
+    ]
+  }
+
+  trace_statements {
+    context = "span"
+    conditions = [
+      `IsMatch(resource.attributes["service.name"], ".*-eventsource$")`,
+    ]
+    statements = [
+      `set(span.kind.string, "Server") where IsMatch(name, "^eventsource\\.publish")`,
+    ]
+  }
+
+  output {
+    traces = [otelcol.processor.batch.default.input]
+  }
+}
+```
+
+- [ ] **Step 3: Verify the final pipeline order in the reference file**
+
+Read the file and confirm the pipeline flows:
+
+```
+receiver.otlp → processor.k8sattributes → processor.attributes.cluster → processor.transform.argo_events → processor.batch → exporter.otlp.tempo
+```
+
+- [ ] **Step 4: Commit reference file changes**
+
+```bash
+git add deploy/observability/local/alloy-metrics-traces-config.alloy
+git commit -m "feat(observability): add Argo Events span kind transform to Alloy config reference"
+```
+
+---
+
+### Task 2: Sync Transform to Alloy Helm Values (Deployed Config)
+
+**Files:**
+- Modify: `deploy/observability/local/alloy-metrics-traces-values.yaml:44-54` (cluster attributes output wiring in inline config)
+
+The inline config in the Helm values must match the reference `.alloy` file exactly. Apply the same two changes: rewire cluster output and add the transform block.
+
+- [ ] **Step 1: Rewire cluster attributes output in values.yaml inline config**
+
+In `deploy/observability/local/alloy-metrics-traces-values.yaml`, find the inline cluster attributes block (around line 45-54) and change its output from `otelcol.processor.batch.default.input` to `otelcol.processor.transform.argo_events.input`:
+
+```alloy
+      // -- Static Cluster Name Attribute --
+      otelcol.processor.attributes "cluster" {
+        action {
+          key    = "k8s.cluster.name"
+          value  = "bookinfo-local"
+          action = "insert"
+        }
+        output {
+          traces = [otelcol.processor.transform.argo_events.input]
+        }
+      }
+```
+
+- [ ] **Step 2: Add transform processor block in values.yaml inline config**
+
+Insert the transform block after the cluster attributes block and before the batch processor block in the inline config. The indentation must be 6 spaces (matching the surrounding inline config blocks):
+
+```alloy
+      // -- Fix Argo Events span kinds for Tempo service graph --
+      // Workaround: Argo Events PR #3961 sets all spans to INTERNAL.
+      // Tempo service graph only processes CLIENT/SERVER pairs.
+      // This transform rewrites known Argo Events span patterns so they
+      // appear as nodes/edges in the service graph.
+      // Remove when Argo Events fork ships proper span kinds.
+      otelcol.processor.transform "argo_events" {
+        error_mode = "ignore"
+
+        trace_statements {
+          context = "span"
+          conditions = [
+            `IsMatch(resource.attributes["service.name"], ".*-sensor$")`,
+          ]
+          statements = [
+            `set(span.kind.string, "Client") where IsMatch(name, "^sensor\\.trigger")`,
+          ]
+        }
+
+        trace_statements {
+          context = "span"
+          conditions = [
+            `IsMatch(resource.attributes["service.name"], ".*-eventsource$")`,
+          ]
+          statements = [
+            `set(span.kind.string, "Server") where IsMatch(name, "^eventsource\\.publish")`,
+          ]
+        }
+
+        output {
+          traces = [otelcol.processor.batch.default.input]
+        }
+      }
+```
+
+- [ ] **Step 3: Verify inline config matches reference file**
+
+Diff the inline config content (between `content: |-` and the next top-level YAML key) against the reference `.alloy` file. They should be identical except for leading indentation.
+
+- [ ] **Step 4: Commit values file changes**
+
+```bash
+git add deploy/observability/local/alloy-metrics-traces-values.yaml
+git commit -m "feat(observability): sync Argo Events span kind transform to Alloy Helm values"
+```
+
+---
+
+### Task 3: Enable Virtual Node Label in Tempo Service Graph
+
+**Files:**
+- Modify: `deploy/observability/local/tempo-values.yaml:24-29` (service_graphs processor config)
+
+- [ ] **Step 1: Add `enable_virtual_node_label` to service graph config**
+
+In `deploy/observability/local/tempo-values.yaml`, add `enable_virtual_node_label: true` to the `service_graphs` block. The full block should become:
+
+```yaml
+      service_graphs:
+        enable_virtual_node_label: true
+        histogram_buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+        dimensions:
+          - http.method
+          - k8s.namespace.name
+          - k8s.cluster.name
+```
+
+- [ ] **Step 2: Commit Tempo config change**
+
+```bash
+git add deploy/observability/local/tempo-values.yaml
+git commit -m "feat(observability): enable virtual node label in Tempo service graph"
+```
+
+---
+
+### Task 4: Deploy and Verify
+
+**Prerequisites:** The k3d cluster must be running (`make k8s-status` to check). If not running, start it with `make run-k8s`.
+
+- [ ] **Step 1: Redeploy Tempo with updated config**
+
+```bash
+helm upgrade --install tempo grafana/tempo \
+  -n observability \
+  --kube-context=k3d-bookinfo-local \
+  -f deploy/observability/local/tempo-values.yaml \
+  --wait --timeout 120s
+```
+
+Expected: Helm reports `Release "tempo" has been upgraded. Happy Helming!`
+
+- [ ] **Step 2: Redeploy Alloy (metrics+traces) with updated config**
+
+```bash
+helm upgrade --install alloy-metrics-traces grafana/alloy \
+  -n observability \
+  --kube-context=k3d-bookinfo-local \
+  -f deploy/observability/local/alloy-metrics-traces-values.yaml \
+  --wait --timeout 120s
+```
+
+Expected: Helm reports `Release "alloy-metrics-traces" has been upgraded. Happy Helming!`
+
+- [ ] **Step 3: Verify Alloy pod is running with new config**
+
+```bash
+kubectl --context=k3d-bookinfo-local -n observability get pods -l app.kubernetes.io/instance=alloy-metrics-traces
+```
+
+Expected: Pod in `Running` state with `1/1` ready.
+
+- [ ] **Step 4: Trigger a POST request to generate a trace with Argo Events spans**
+
+```bash
+curl -s -X POST http://localhost:8080/v1/ratings \
+  -H "Content-Type: application/json" \
+  -d '{"book_id":"1","rating":5}'
+```
+
+Expected: `201 Created` or similar success response.
+
+- [ ] **Step 5: Wait for trace propagation and check Tempo**
+
+Wait ~10 seconds for the trace to propagate through the pipeline. Then open Grafana at `http://localhost:3000`, go to Explore > Tempo, and search for recent traces. Find the trace from the POST request.
+
+Verify:
+1. The trace still shows all spans correctly linked (no broken parent-child relationships)
+2. The `sensor.trigger` span now shows `kind=Client` instead of `kind=Internal`
+3. The `eventsource.publish` span now shows `kind=Server` instead of `kind=Internal`
+
+- [ ] **Step 6: Check the service graph**
+
+In Grafana, go to Explore > Tempo > Service Graph. Verify:
+1. `*-eventsource` nodes now appear in the graph
+2. `*-sensor` nodes now appear in the graph
+3. Edges exist: `gateway → eventsource` and `sensor → write-service`
+
+- [ ] **Step 7: Query Prometheus for service graph metrics**
+
+Open Prometheus at `http://localhost:9090` and run:
+
+```promql
+traces_service_graph_request_total{client=~".*sensor.*"}
+```
+
+Expected: Results showing sensor → write-service edges with request counts.
+
+```promql
+traces_service_graph_request_total{server=~".*eventsource.*"}
+```
+
+Expected: Results showing gateway → eventsource edges with request counts.
+
+- [ ] **Step 8: Check unpaired spans metric**
+
+```promql
+traces_service_graph_unpaired_spans_total{client=~".*sensor.*|.*eventsource.*"}
+```
+
+Expected: Zero or very low counts, indicating spans are being paired correctly.

--- a/docs/superpowers/plans/2026-04-10-argo-events-messaging-spans.md
+++ b/docs/superpowers/plans/2026-04-10-argo-events-messaging-spans.md
@@ -1,0 +1,880 @@
+# Argo Events Messaging Spans Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add proper PRODUCER/CONSUMER spans with OTel messaging semantic conventions to Argo Events so sensors and EventSources appear as connected nodes in Tempo's service graph, including the EventBus messaging edge.
+
+**Architecture:** Extend the existing `pkg/shared/tracing` package with span kind helpers and a messaging attributes builder. Modify `eventsource.publish` to PRODUCER, `sensor.trigger` to CLIENT, add new `sensor.consume` CONSUMER span, and add `eventsource.receive` SERVER span for webhook sources. The EventBus link (`eventsource -> sensor`) uses PRODUCER/CONSUMER edge matching in Tempo via CloudEvent traceparent propagation.
+
+**Tech Stack:** Go, OpenTelemetry Go SDK, Argo Events fork (`ghcr.io/kaio6fellipe/argo-events`, branch based on PRs #3961 + #3983)
+
+**Spec:** `docs/superpowers/specs/2026-04-10-argo-events-messaging-spans-design.md`
+
+**Repos involved:**
+- **Argo Events fork** — all Go code changes (Tasks 1-7)
+- **go-http-server** — Tempo config and image version bump (Task 8)
+
+---
+
+## File Map (Argo Events Fork)
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `pkg/shared/tracing/tracing.go` | Modify | Add span kind helpers: `StartServerSpan`, `StartProducerSpan`, `StartConsumerSpan`, `StartClientSpan` |
+| `pkg/shared/tracing/messaging.go` | Create | `MessagingAttributes()` builder and `SourceTypeSpanKind()` classifier |
+| `pkg/shared/tracing/tracing_test.go` | Create | Tests for span kind helpers |
+| `pkg/shared/tracing/messaging_test.go` | Create | Tests for messaging attributes and source type classification |
+| `pkg/eventsources/eventing.go` | Modify | Change `eventsource.publish` from INTERNAL to PRODUCER with messaging attributes |
+| `pkg/sensors/listener.go` | Modify | Add `sensor.consume` CONSUMER span; change `sensor.trigger` to CLIENT |
+| `eventsources/sources/webhook/start.go` | Modify | Add `eventsource.receive` SERVER span for webhook sources |
+
+## File Map (go-http-server)
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `deploy/observability/local/tempo-values.yaml` | Modify | Enable `enable_messaging_system_latency_histogram`, add `messaging.system` to dimensions |
+
+---
+
+## Phase 1: Core Changes (All Source Types Benefit)
+
+### Task 1: Add Span Kind Helper Functions
+
+**Repo:** Argo Events fork
+**Files:**
+- Modify: `pkg/shared/tracing/tracing.go`
+
+These helpers wrap `tracer.Start()` with the correct `trace.WithSpanKind()` option. Each returns `(context.Context, trace.Span)` matching the standard OTel Go SDK pattern.
+
+- [ ] **Step 1: Write tests for span kind helpers**
+
+Create `pkg/shared/tracing/tracing_test.go`:
+
+```go
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+func setupTestTracer(t *testing.T) (oteltrace.Tracer, *tracetest.InMemoryExporter) {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	return tp.Tracer("test"), exporter
+}
+
+func TestStartServerSpan(t *testing.T) {
+	tracer, exporter := setupTestTracer(t)
+
+	ctx, span := StartServerSpan(context.Background(), tracer, "eventsource.receive")
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if spans[0].SpanKind != oteltrace.SpanKindServer {
+		t.Errorf("expected SpanKindServer, got %v", spans[0].SpanKind)
+	}
+	if spans[0].Name != "eventsource.receive" {
+		t.Errorf("expected name eventsource.receive, got %s", spans[0].Name)
+	}
+	_ = ctx
+}
+
+func TestStartProducerSpan(t *testing.T) {
+	tracer, exporter := setupTestTracer(t)
+
+	ctx, span := StartProducerSpan(context.Background(), tracer, "eventsource.publish")
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if spans[0].SpanKind != oteltrace.SpanKindProducer {
+		t.Errorf("expected SpanKindProducer, got %v", spans[0].SpanKind)
+	}
+	_ = ctx
+}
+
+func TestStartConsumerSpan(t *testing.T) {
+	tracer, exporter := setupTestTracer(t)
+
+	ctx, span := StartConsumerSpan(context.Background(), tracer, "sensor.consume")
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if spans[0].SpanKind != oteltrace.SpanKindConsumer {
+		t.Errorf("expected SpanKindConsumer, got %v", spans[0].SpanKind)
+	}
+	_ = ctx
+}
+
+func TestStartClientSpan(t *testing.T) {
+	tracer, exporter := setupTestTracer(t)
+
+	ctx, span := StartClientSpan(context.Background(), tracer, "sensor.trigger")
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if spans[0].SpanKind != oteltrace.SpanKindClient {
+		t.Errorf("expected SpanKindClient, got %v", spans[0].SpanKind)
+	}
+	_ = ctx
+}
+
+func TestStartSpanWithAttributes(t *testing.T) {
+	tracer, exporter := setupTestTracer(t)
+
+	attrs := MessagingAttributes("kafka", "argo-events", "sensor-group", "kafka:9092")
+	_, span := StartProducerSpan(context.Background(), tracer, "eventsource.publish", attrs...)
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+
+	attrMap := make(map[string]string)
+	for _, a := range spans[0].Attributes {
+		attrMap[string(a.Key)] = a.Value.AsString()
+	}
+	if attrMap["messaging.system"] != "kafka" {
+		t.Errorf("expected messaging.system=kafka, got %s", attrMap["messaging.system"])
+	}
+	if attrMap["messaging.destination.name"] != "argo-events" {
+		t.Errorf("expected messaging.destination.name=argo-events, got %s", attrMap["messaging.destination.name"])
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd pkg/shared/tracing && go test -v -run "TestStart|TestStartSpan"
+```
+
+Expected: Compilation errors — `StartServerSpan`, `StartProducerSpan`, `StartConsumerSpan`, `StartClientSpan`, `MessagingAttributes` are undefined.
+
+- [ ] **Step 3: Implement span kind helpers**
+
+Add to `pkg/shared/tracing/tracing.go`:
+
+```go
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// StartServerSpan starts a new span with SpanKindServer.
+// Used by HTTP webhook EventSource handlers for inbound requests.
+func StartServerSpan(ctx context.Context, tracer trace.Tracer, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	return tracer.Start(ctx, name,
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(attrs...),
+	)
+}
+
+// StartProducerSpan starts a new span with SpanKindProducer.
+// Used by EventSource publish to EventBus.
+func StartProducerSpan(ctx context.Context, tracer trace.Tracer, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	return tracer.Start(ctx, name,
+		trace.WithSpanKind(trace.SpanKindProducer),
+		trace.WithAttributes(attrs...),
+	)
+}
+
+// StartConsumerSpan starts a new span with SpanKindConsumer.
+// Used by Sensor consume from EventBus and subscriber EventSources.
+func StartConsumerSpan(ctx context.Context, tracer trace.Tracer, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	return tracer.Start(ctx, name,
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithAttributes(attrs...),
+	)
+}
+
+// StartClientSpan starts a new span with SpanKindClient.
+// Used by Sensor HTTP trigger and poller EventSources.
+func StartClientSpan(ctx context.Context, tracer trace.Tracer, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	return tracer.Start(ctx, name,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attrs...),
+	)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd pkg/shared/tracing && go test -v -run "TestStart"
+```
+
+Expected: All `TestStartServerSpan`, `TestStartProducerSpan`, `TestStartConsumerSpan`, `TestStartClientSpan` pass. `TestStartSpanWithAttributes` still fails (MessagingAttributes not yet defined).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/shared/tracing/tracing.go pkg/shared/tracing/tracing_test.go
+git commit -m "feat(tracing): add span kind helper functions for SERVER/PRODUCER/CONSUMER/CLIENT"
+```
+
+---
+
+### Task 2: Add Messaging Attributes Builder and Source Type Classifier
+
+**Repo:** Argo Events fork
+**Files:**
+- Create: `pkg/shared/tracing/messaging.go`
+- Create: `pkg/shared/tracing/messaging_test.go`
+
+- [ ] **Step 1: Write tests for MessagingAttributes and SourceTypeSpanKind**
+
+Create `pkg/shared/tracing/messaging_test.go`:
+
+```go
+package tracing
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+func TestMessagingAttributes(t *testing.T) {
+	tests := []struct {
+		name          string
+		busType       string
+		destination   string
+		consumerGroup string
+		serverAddr    string
+		wantSystem    string
+		wantDest      string
+	}{
+		{
+			name:          "kafka eventbus",
+			busType:       "kafka",
+			destination:   "argo-events",
+			consumerGroup: "sensor-group",
+			serverAddr:    "kafka-bootstrap:9092",
+			wantSystem:    "kafka",
+			wantDest:      "argo-events",
+		},
+		{
+			name:          "jetstream eventbus",
+			busType:       "jetstream",
+			destination:   "default",
+			consumerGroup: "sensor-durable",
+			serverAddr:    "nats:4222",
+			wantSystem:    "nats",
+			wantDest:      "default",
+		},
+		{
+			name:          "stan eventbus",
+			busType:       "stan",
+			destination:   "default",
+			consumerGroup: "sensor-queue",
+			serverAddr:    "nats:4222",
+			wantSystem:    "nats",
+			wantDest:      "default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs := MessagingAttributes(tt.busType, tt.destination, tt.consumerGroup, tt.serverAddr)
+
+			attrMap := make(map[attribute.Key]string)
+			for _, a := range attrs {
+				attrMap[a.Key] = a.Value.AsString()
+			}
+
+			if got := attrMap["messaging.system"]; got != tt.wantSystem {
+				t.Errorf("messaging.system = %q, want %q", got, tt.wantSystem)
+			}
+			if got := attrMap["messaging.destination.name"]; got != tt.wantDest {
+				t.Errorf("messaging.destination.name = %q, want %q", got, tt.wantDest)
+			}
+			if _, ok := attrMap["server.address"]; !ok {
+				t.Error("missing server.address attribute")
+			}
+		})
+	}
+}
+
+func TestMessagingAttributes_EmptyConsumerGroup(t *testing.T) {
+	attrs := MessagingAttributes("kafka", "topic", "", "broker:9092")
+
+	for _, a := range attrs {
+		if a.Key == "messaging.consumer.group.name" {
+			t.Error("should not include messaging.consumer.group.name when empty")
+		}
+	}
+}
+
+func TestSourceTypeSpanKind(t *testing.T) {
+	tests := []struct {
+		sourceType string
+		want       oteltrace.SpanKind
+	}{
+		// HTTP webhook receivers -> SERVER
+		{"webhook", oteltrace.SpanKindServer},
+		{"github", oteltrace.SpanKindServer},
+		{"gitlab", oteltrace.SpanKindServer},
+		{"bitbucket", oteltrace.SpanKindServer},
+		{"bitbucketserver", oteltrace.SpanKindServer},
+		{"slack", oteltrace.SpanKindServer},
+		{"stripe", oteltrace.SpanKindServer},
+		{"storagegrid", oteltrace.SpanKindServer},
+		{"sns", oteltrace.SpanKindServer},
+		{"generic", oteltrace.SpanKindServer},
+
+		// Message subscribers -> CONSUMER
+		{"kafka", oteltrace.SpanKindConsumer},
+		{"amqp", oteltrace.SpanKindConsumer},
+		{"nats", oteltrace.SpanKindConsumer},
+		{"nsq", oteltrace.SpanKindConsumer},
+		{"mqtt", oteltrace.SpanKindConsumer},
+		{"gcppubsub", oteltrace.SpanKindConsumer},
+		{"redis", oteltrace.SpanKindConsumer},
+		{"redisStream", oteltrace.SpanKindConsumer},
+		{"sqs", oteltrace.SpanKindConsumer},
+		{"azureEventsHub", oteltrace.SpanKindConsumer},
+		{"azureQueueStorage", oteltrace.SpanKindConsumer},
+		{"azureServiceBus", oteltrace.SpanKindConsumer},
+		{"pulsar", oteltrace.SpanKindConsumer},
+		{"emitter", oteltrace.SpanKindConsumer},
+		{"minio", oteltrace.SpanKindConsumer},
+
+		// Pollers/watchers -> CLIENT
+		{"gerrit", oteltrace.SpanKindClient},
+		{"sftp", oteltrace.SpanKindClient},
+		{"hdfs", oteltrace.SpanKindClient},
+		{"resource", oteltrace.SpanKindClient},
+
+		// Local/scheduled -> INTERNAL
+		{"calendar", oteltrace.SpanKindInternal},
+		{"file", oteltrace.SpanKindInternal},
+
+		// Unknown -> INTERNAL (safe default)
+		{"unknown_source", oteltrace.SpanKindInternal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sourceType, func(t *testing.T) {
+			got := SourceTypeSpanKind(tt.sourceType)
+			if got != tt.want {
+				t.Errorf("SourceTypeSpanKind(%q) = %v, want %v", tt.sourceType, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd pkg/shared/tracing && go test -v -run "TestMessaging|TestSourceType"
+```
+
+Expected: Compilation errors — `MessagingAttributes` and `SourceTypeSpanKind` are undefined.
+
+- [ ] **Step 3: Implement MessagingAttributes and SourceTypeSpanKind**
+
+Create `pkg/shared/tracing/messaging.go`:
+
+```go
+package tracing
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// MessagingAttributes returns OTel semantic convention attributes for messaging spans.
+// busType is the EventBus or external messaging backend type (e.g., "kafka", "jetstream", "stan").
+// destination is the topic/subject/channel name.
+// consumerGroup is the consumer group identifier (omitted if empty).
+// serverAddr is the broker/server address.
+func MessagingAttributes(busType, destination, consumerGroup, serverAddr string) []attribute.KeyValue {
+	system := busType
+	switch busType {
+	case "jetstream", "stan":
+		system = "nats"
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("messaging.system", system),
+		attribute.String("messaging.destination.name", destination),
+		attribute.String("server.address", serverAddr),
+	}
+
+	if consumerGroup != "" {
+		attrs = append(attrs, attribute.String("messaging.consumer.group.name", consumerGroup))
+	}
+
+	return attrs
+}
+
+// SourceTypeSpanKind maps an Argo Events EventSource type to the correct inbound
+// span kind based on how it receives events from its external source.
+func SourceTypeSpanKind(sourceType string) trace.SpanKind {
+	switch sourceType {
+	// HTTP webhook receivers -> SERVER
+	case "webhook", "github", "gitlab", "bitbucket", "bitbucketserver",
+		"slack", "stripe", "storagegrid", "sns", "generic":
+		return trace.SpanKindServer
+
+	// Message/event subscribers -> CONSUMER
+	case "kafka", "amqp", "nats", "nsq", "mqtt", "gcppubsub",
+		"redis", "redisStream", "sqs", "azureEventsHub",
+		"azureQueueStorage", "azureServiceBus", "pulsar",
+		"emitter", "minio":
+		return trace.SpanKindConsumer
+
+	// Pollers/watchers -> CLIENT
+	case "gerrit", "sftp", "hdfs", "resource":
+		return trace.SpanKindClient
+
+	// Local/scheduled and unknown -> INTERNAL
+	default:
+		return trace.SpanKindInternal
+	}
+}
+```
+
+- [ ] **Step 4: Run all tracing package tests**
+
+```bash
+cd pkg/shared/tracing && go test -v ./...
+```
+
+Expected: All tests pass, including `TestStartSpanWithAttributes` from Task 1 (which uses `MessagingAttributes`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/shared/tracing/messaging.go pkg/shared/tracing/messaging_test.go
+git commit -m "feat(tracing): add messaging attributes builder and source type span kind classifier"
+```
+
+---
+
+### Task 3: Change `eventsource.publish` to PRODUCER
+
+**Repo:** Argo Events fork
+**Files:**
+- Modify: `pkg/eventsources/eventing.go`
+
+The `eventsource.publish` span is created in the common publish loop in `eventing.go`. All 32 EventSource types flow through this code path. The change is to replace the bare `tracer.Start(ctx, "eventsource.publish")` call with `StartProducerSpan` and add messaging attributes.
+
+- [ ] **Step 1: Locate the current span creation in `eventing.go`**
+
+Search for `eventsource.publish` in `pkg/eventsources/eventing.go`. The current code looks like:
+
+```go
+ctx, span := tracer.Start(ctx, "eventsource.publish",
+    trace.WithAttributes(
+        attribute.String("eventsource.name", ...),
+        attribute.String("eventsource.type", ...),
+        attribute.String("event.name", ...),
+        attribute.String("event.id", ...),
+    ),
+)
+defer span.End()
+```
+
+Note the surrounding context to understand where `BusConfig` is accessible for extracting the EventBus type, destination, and server address.
+
+- [ ] **Step 2: Replace with `StartProducerSpan` and add messaging attributes**
+
+Change the span creation to use the new helper. The EventBus type is available from the EventSource adaptor's bus config. Build the messaging attributes from it:
+
+```go
+// Determine EventBus type and destination for messaging attributes
+busType, busDestination, busAddr := extractBusInfo(e.busConfig)
+
+msgAttrs := tracing.MessagingAttributes(busType, busDestination, "", busAddr)
+spanAttrs := append(msgAttrs,
+    attribute.String("eventsource.name", eventSourceName),
+    attribute.String("eventsource.type", eventSourceType),
+    attribute.String("event.name", eventName),
+    attribute.String("event.id", eventID),
+    attribute.String("messaging.operation.type", "send"),
+    attribute.String("messaging.operation.name", "send"),
+)
+
+ctx, span := tracing.StartProducerSpan(ctx, tracer, "eventsource.publish", spanAttrs...)
+defer span.End()
+```
+
+The `extractBusInfo` helper extracts the bus type, destination topic/subject, and server address from the `BusConfig` struct:
+
+```go
+func extractBusInfo(bc *eventbuscommon.BusConfig) (busType, destination, serverAddr string) {
+    switch {
+    case bc.Kafka != nil:
+        return "kafka", bc.Kafka.Topic, bc.Kafka.URL
+    case bc.JetStream != nil:
+        return "jetstream", bc.JetStream.StreamConfig.Subjects[0], bc.JetStream.URL
+    case bc.NATS != nil:
+        return "stan", bc.NATS.Subject, bc.NATS.URL
+    default:
+        return "unknown", "", ""
+    }
+}
+```
+
+Adjust field names based on the actual `BusConfig` struct fields in the fork. Examine `pkg/eventbus/common/interface.go` and related files for the exact struct definition.
+
+- [ ] **Step 3: Run the existing eventsource tests**
+
+```bash
+go test -v ./pkg/eventsources/...
+```
+
+Expected: All existing tests pass. The span kind change doesn't affect test assertions since PR #3961's tests don't assert on span kind.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/eventsources/eventing.go
+git commit -m "feat(eventsource): change eventsource.publish span to PRODUCER with messaging attributes"
+```
+
+---
+
+### Task 4: Add `sensor.consume` CONSUMER Span
+
+**Repo:** Argo Events fork
+**Files:**
+- Modify: `pkg/sensors/listener.go`
+
+Add a new CONSUMER span between trace context extraction and trigger execution. This span's parent comes from the CloudEvent traceparent (pointing to `eventsource.publish`), creating the PRODUCER/CONSUMER edge in Tempo's service graph.
+
+- [ ] **Step 1: Locate the trace extraction and trigger call in `listener.go`**
+
+Search for `extractTraceFromEvents` and `triggerOne` in `pkg/sensors/listener.go`. The current flow is:
+
+```go
+ctx = extractTraceFromEvents(ctx, events)
+// ... directly into triggerOne() which creates sensor.trigger span
+```
+
+- [ ] **Step 2: Insert `sensor.consume` CONSUMER span between extraction and trigger**
+
+After `extractTraceFromEvents` returns the context with the remote span context, create a CONSUMER span. This becomes the parent of `sensor.trigger`:
+
+```go
+ctx = extractTraceFromEvents(ctx, events)
+
+// Create CONSUMER span for EventBus message consumption.
+// Parent is the remote eventsource.publish PRODUCER span (via CloudEvent traceparent).
+// This creates the eventsource -> sensor edge in the service graph.
+busType, busDest, busAddr := extractSensorBusInfo(sensorCtx.busConfig)
+consumeAttrs := tracing.MessagingAttributes(busType, busDest, consumerGroup, busAddr)
+consumeAttrs = append(consumeAttrs,
+    attribute.String("sensor.name", sensorName),
+    attribute.String("messaging.operation.type", "process"),
+    attribute.String("messaging.operation.name", "process"),
+)
+ctx, consumeSpan := tracing.StartConsumerSpan(ctx, tracer, "sensor.consume", consumeAttrs...)
+defer consumeSpan.End()
+
+// triggerOne now creates sensor.trigger as a child of sensor.consume
+```
+
+The `extractSensorBusInfo` function mirrors the EventSource-side `extractBusInfo` — it reads the sensor's EventBus config to determine type, destination, consumer group, and server address. Implement it similarly based on the sensor's `BusConfig`.
+
+- [ ] **Step 3: Run existing sensor tests**
+
+```bash
+go test -v ./pkg/sensors/...
+```
+
+Expected: All existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/sensors/listener.go
+git commit -m "feat(sensor): add sensor.consume CONSUMER span for EventBus message consumption"
+```
+
+---
+
+### Task 5: Change `sensor.trigger` to CLIENT
+
+**Repo:** Argo Events fork
+**Files:**
+- Modify: `pkg/sensors/listener.go`
+
+- [ ] **Step 1: Locate the current `sensor.trigger` span creation in `listener.go`**
+
+Search for `sensor.trigger` in `pkg/sensors/listener.go`. The current code in `triggerOne()`:
+
+```go
+ctx, span := tracer.Start(ctx, "sensor.trigger",
+    trace.WithAttributes(
+        attribute.String("sensor.name", ...),
+        attribute.String("trigger.name", ...),
+        attribute.StringSlice("dependencies", ...),
+        attribute.StringSlice("event.ids", ...),
+    ),
+)
+defer span.End()
+```
+
+- [ ] **Step 2: Replace with `StartClientSpan` and add `server.address`**
+
+Change the span creation to use `StartClientSpan`. For HTTP triggers, extract the target URL from the trigger template to set `server.address`:
+
+```go
+spanAttrs := []attribute.KeyValue{
+    attribute.String("sensor.name", sensorName),
+    attribute.String("trigger.name", triggerName),
+    attribute.StringSlice("dependencies", depNames),
+    attribute.StringSlice("event.ids", eventIDs),
+}
+
+// Add server.address for HTTP triggers
+if trigger.Template.HTTP != nil {
+    spanAttrs = append(spanAttrs,
+        attribute.String("server.address", trigger.Template.HTTP.URL),
+        attribute.String("http.request.method", trigger.Template.HTTP.Method),
+    )
+}
+
+ctx, span := tracing.StartClientSpan(ctx, tracer, "sensor.trigger", spanAttrs...)
+defer span.End()
+```
+
+- [ ] **Step 3: Run existing sensor tests**
+
+```bash
+go test -v ./pkg/sensors/...
+```
+
+Expected: All existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/sensors/listener.go
+git commit -m "feat(sensor): change sensor.trigger span to CLIENT with server.address attribute"
+```
+
+---
+
+## Phase 2: Webhook EventSource `eventsource.receive` SERVER Span
+
+### Task 6: Add `eventsource.receive` SERVER Span to Webhook Source
+
+**Repo:** Argo Events fork
+**Files:**
+- Modify: `eventsources/sources/webhook/start.go`
+
+The webhook EventSource handles inbound HTTP requests from external systems (gateway, GitHub, etc.). Adding a SERVER span here creates the `gateway -> eventsource` edge.
+
+- [ ] **Step 1: Locate the webhook event handler in `sources/webhook/start.go`**
+
+Search for the HTTP handler function that processes incoming webhook requests. This is where the incoming HTTP request context is first available, before the event enters the common publish loop.
+
+- [ ] **Step 2: Add `eventsource.receive` SERVER span wrapping the handler**
+
+At the top of the handler, before any event processing, create a SERVER span:
+
+```go
+ctx, receiveSpan := tracing.StartServerSpan(r.Context(), tracer, "eventsource.receive",
+    attribute.String("eventsource.name", eventSourceName),
+    attribute.String("eventsource.type", "webhook"),
+    attribute.String("http.method", r.Method),
+    attribute.String("http.route", r.URL.Path),
+)
+defer receiveSpan.End()
+```
+
+Use this `ctx` for all subsequent operations so that `eventsource.publish` (PRODUCER) becomes a child of `eventsource.receive` (SERVER).
+
+- [ ] **Step 3: Run webhook source tests**
+
+```bash
+go test -v ./eventsources/sources/webhook/...
+```
+
+Expected: All existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add eventsources/sources/webhook/start.go
+git commit -m "feat(eventsource/webhook): add eventsource.receive SERVER span for inbound webhooks"
+```
+
+---
+
+### Task 7: Build and Push Updated Argo Events Image
+
+**Repo:** Argo Events fork
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+go test -race -count=1 ./...
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 2: Build the container image**
+
+Build the updated Argo Events image with a new tag that includes the tracing changes:
+
+```bash
+docker build -t ghcr.io/kaio6fellipe/argo-events:prs-3961-3983-messaging-spans .
+```
+
+Adjust the Dockerfile path and build args based on the fork's build system (check the existing Makefile or Dockerfile).
+
+- [ ] **Step 3: Push the image**
+
+```bash
+docker push ghcr.io/kaio6fellipe/argo-events:prs-3961-3983-messaging-spans
+```
+
+- [ ] **Step 4: Commit any remaining changes**
+
+```bash
+git add -A
+git commit -m "feat(tracing): complete PRODUCER/CONSUMER span instrumentation for service graph"
+```
+
+---
+
+## Phase 3: Tempo Config and Deployment (go-http-server repo)
+
+### Task 8: Update Tempo Config and Deploy
+
+**Repo:** go-http-server
+**Files:**
+- Modify: `deploy/observability/local/tempo-values.yaml`
+
+- [ ] **Step 1: Enable messaging system histogram and add messaging.system dimension**
+
+In `deploy/observability/local/tempo-values.yaml`, update the `service_graphs` block:
+
+```yaml
+      service_graphs:
+        enable_virtual_node_label: true
+        enable_messaging_system_latency_histogram: true
+        histogram_buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+        dimensions:
+          - http.method
+          - k8s.namespace.name
+          - k8s.cluster.name
+          - messaging.system
+```
+
+Note: `enable_virtual_node_label` may already be present from the Alloy transform plan. If so, only add `enable_messaging_system_latency_histogram` and the `messaging.system` dimension.
+
+- [ ] **Step 2: Update Argo Events image tag in deploy manifests**
+
+Update the Argo Events Helm values or Makefile to use the new image tag. Search for the current tag `prs-3961-3983` in the Makefile and Argo Events Helm values:
+
+```bash
+grep -r "prs-3961-3983" deploy/ Makefile
+```
+
+Update all occurrences to the new tag `prs-3961-3983-messaging-spans`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/observability/local/tempo-values.yaml
+git add -A  # Include any Makefile or deploy changes for the image tag
+git commit -m "feat(observability): enable messaging system histogram and update Argo Events image tag"
+```
+
+- [ ] **Step 4: Redeploy Tempo**
+
+```bash
+helm upgrade --install tempo grafana/tempo \
+  -n observability \
+  --kube-context=k3d-bookinfo-local \
+  -f deploy/observability/local/tempo-values.yaml \
+  --wait --timeout 120s
+```
+
+- [ ] **Step 5: Redeploy Argo Events**
+
+Redeploy the Argo Events components to pick up the new image. Use the Makefile target or helm upgrade for the Argo Events deployment:
+
+```bash
+make k8s-platform
+```
+
+Then reapply the bookinfo app manifests to restart EventSources and Sensors:
+
+```bash
+make k8s-apps
+```
+
+- [ ] **Step 6: Remove Alloy transform workaround (if deployed)**
+
+If the Alloy span kind transform from the companion plan was deployed, it can now be removed since Argo Events emits correct span kinds natively. Revert the transform processor block from:
+- `deploy/observability/local/alloy-metrics-traces-config.alloy`
+- `deploy/observability/local/alloy-metrics-traces-values.yaml`
+
+Rewire the cluster attributes output back to the batch processor and remove the `otelcol.processor.transform "argo_events"` block.
+
+Then redeploy Alloy:
+
+```bash
+helm upgrade --install alloy-metrics-traces grafana/alloy \
+  -n observability \
+  --kube-context=k3d-bookinfo-local \
+  -f deploy/observability/local/alloy-metrics-traces-values.yaml \
+  --wait --timeout 120s
+```
+
+- [ ] **Step 7: Verify end-to-end**
+
+Trigger a POST request:
+
+```bash
+curl -s -X POST http://localhost:8080/v1/ratings \
+  -H "Content-Type: application/json" \
+  -d '{"book_id":"1","rating":5}'
+```
+
+Wait ~10 seconds, then verify in Grafana Tempo:
+
+1. **Trace view:** Find the trace and confirm:
+   - `eventsource.receive` span with kind=SERVER
+   - `eventsource.publish` span with kind=PRODUCER and `messaging.system` attribute
+   - `sensor.consume` span with kind=CONSUMER and `messaging.system` attribute
+   - `sensor.trigger` span with kind=CLIENT and `server.address` attribute
+
+2. **Service graph:** Confirm three new edges:
+   - `gateway -> eventsource` (CLIENT/SERVER)
+   - `eventsource -> sensor` (PRODUCER/CONSUMER — the EventBus messaging edge)
+   - `sensor -> write-service` (CLIENT/SERVER)
+
+3. **Prometheus metrics:**
+   ```promql
+   traces_service_graph_request_messaging_system_seconds_count
+   ```
+   Expected: Histogram data with `messaging_system="kafka"` (or `nats` depending on EventBus type).

--- a/docs/superpowers/plans/2026-04-10-argo-events-messaging-spans.md
+++ b/docs/superpowers/plans/2026-04-10-argo-events-messaging-spans.md
@@ -892,25 +892,7 @@ Alternatively, redeploy the full app stack which recreates them:
 make k8s-apps
 ```
 
-- [ ] **Step 6: Remove Alloy transform workaround (if deployed)**
-
-If the Alloy span kind transform from the companion plan was deployed, it can now be removed since Argo Events emits correct span kinds natively. Revert the transform processor block from:
-- `deploy/observability/local/alloy-metrics-traces-config.alloy`
-- `deploy/observability/local/alloy-metrics-traces-values.yaml`
-
-Rewire the cluster attributes output back to the batch processor and remove the `otelcol.processor.transform "argo_events"` block.
-
-Then redeploy Alloy:
-
-```bash
-helm upgrade --install alloy-metrics-traces grafana/alloy \
-  -n observability \
-  --kube-context=k3d-bookinfo-local \
-  -f deploy/observability/local/alloy-metrics-traces-values.yaml \
-  --wait --timeout 120s
-```
-
-- [ ] **Step 7: Verify end-to-end**
+- [ ] **Step 6: Verify end-to-end**
 
 Trigger a POST request:
 

--- a/docs/superpowers/plans/2026-04-10-argo-events-messaging-spans.md
+++ b/docs/superpowers/plans/2026-04-10-argo-events-messaging-spans.md
@@ -6,13 +6,19 @@
 
 **Architecture:** Extend the existing `pkg/shared/tracing` package with span kind helpers and a messaging attributes builder. Modify `eventsource.publish` to PRODUCER, `sensor.trigger` to CLIENT, add new `sensor.consume` CONSUMER span, and add `eventsource.receive` SERVER span for webhook sources. The EventBus link (`eventsource -> sensor`) uses PRODUCER/CONSUMER edge matching in Tempo via CloudEvent traceparent propagation.
 
-**Tech Stack:** Go, OpenTelemetry Go SDK, Argo Events fork (`ghcr.io/kaio6fellipe/argo-events`, branch based on PRs #3961 + #3983)
+**Tech Stack:** Go, OpenTelemetry Go SDK, Argo Events fork (`ghcr.io/kaio6fellipe/argo-events`)
 
 **Spec:** `docs/superpowers/specs/2026-04-10-argo-events-messaging-spans-design.md`
 
 **Repos involved:**
-- **Argo Events fork** — all Go code changes (Tasks 1-7)
-- **go-http-server** — Tempo config and image version bump (Task 8)
+- **Argo Events fork** (`kaio6fellipe/argo-events`) — all Go code changes (Tasks 1-7), branch `feat/cloudevents-compliance-otel-tracing`
+- **go-http-server** — Tempo config update (Task 8), image tag stays `prs-3961-3983`
+
+**Git rules for Argo Events fork:**
+- All commits must use `git commit -s` (sign-off with `Signed-off-by:` trailer)
+- **No** `Co-Authored-By` trailer
+- Only push OTel/CloudEvents-related commits to `feat/cloudevents-compliance-otel-tracing` — no Kafka optimization or unrelated changes
+- After pushing, merge both PR branches into `feat/combined-prs-3961-3983` on the fork, run codegen, build and push image as `ghcr.io/kaio6fellipe/argo-events:prs-3961-3983`
 
 ---
 
@@ -229,7 +235,7 @@ Expected: All `TestStartServerSpan`, `TestStartProducerSpan`, `TestStartConsumer
 
 ```bash
 git add pkg/shared/tracing/tracing.go pkg/shared/tracing/tracing_test.go
-git commit -m "feat(tracing): add span kind helper functions for SERVER/PRODUCER/CONSUMER/CLIENT"
+git commit -s -m "feat(tracing): add span kind helper functions for SERVER/PRODUCER/CONSUMER/CLIENT"
 ```
 
 ---
@@ -469,7 +475,7 @@ Expected: All tests pass, including `TestStartSpanWithAttributes` from Task 1 (w
 
 ```bash
 git add pkg/shared/tracing/messaging.go pkg/shared/tracing/messaging_test.go
-git commit -m "feat(tracing): add messaging attributes builder and source type span kind classifier"
+git commit -s -m "feat(tracing): add messaging attributes builder and source type span kind classifier"
 ```
 
 ---
@@ -553,7 +559,7 @@ Expected: All existing tests pass. The span kind change doesn't affect test asse
 
 ```bash
 git add pkg/eventsources/eventing.go
-git commit -m "feat(eventsource): change eventsource.publish span to PRODUCER with messaging attributes"
+git commit -s -m "feat(eventsource): change eventsource.publish span to PRODUCER with messaging attributes"
 ```
 
 ---
@@ -612,7 +618,7 @@ Expected: All existing tests pass.
 
 ```bash
 git add pkg/sensors/listener.go
-git commit -m "feat(sensor): add sensor.consume CONSUMER span for EventBus message consumption"
+git commit -s -m "feat(sensor): add sensor.consume CONSUMER span for EventBus message consumption"
 ```
 
 ---
@@ -675,7 +681,7 @@ Expected: All existing tests pass.
 
 ```bash
 git add pkg/sensors/listener.go
-git commit -m "feat(sensor): change sensor.trigger span to CLIENT with server.address attribute"
+git commit -s -m "feat(sensor): change sensor.trigger span to CLIENT with server.address attribute"
 ```
 
 ---
@@ -722,16 +728,18 @@ Expected: All existing tests pass.
 
 ```bash
 git add eventsources/sources/webhook/start.go
-git commit -m "feat(eventsource/webhook): add eventsource.receive SERVER span for inbound webhooks"
+git commit -s -m "feat(eventsource/webhook): add eventsource.receive SERVER span for inbound webhooks"
 ```
 
 ---
 
-### Task 7: Build and Push Updated Argo Events Image
+### Task 7: Push, Merge Branches, Codegen, Build and Push Image
 
 **Repo:** Argo Events fork
 
-- [ ] **Step 1: Run the full test suite**
+This task handles the branch workflow: push tracing commits to the OTel branch, merge both PR branches into the combined branch, run codegen, and build/push the image.
+
+- [ ] **Step 1: Run the full test suite on `feat/cloudevents-compliance-otel-tracing`**
 
 ```bash
 go test -race -count=1 ./...
@@ -739,27 +747,76 @@ go test -race -count=1 ./...
 
 Expected: All tests pass.
 
-- [ ] **Step 2: Build the container image**
+- [ ] **Step 2: Push tracing commits to the OTel branch**
 
-Build the updated Argo Events image with a new tag that includes the tracing changes:
+Ensure you're on `feat/cloudevents-compliance-otel-tracing` and push only the OTel/CloudEvents-related commits:
 
 ```bash
-docker build -t ghcr.io/kaio6fellipe/argo-events:prs-3961-3983-messaging-spans .
+git log --oneline origin/feat/cloudevents-compliance-otel-tracing..HEAD
+```
+
+Review the log — it should only contain commits from Tasks 1-6 (span kind helpers, messaging attributes, PRODUCER/CONSUMER/CLIENT changes, webhook receive span). No Kafka optimization or unrelated changes.
+
+```bash
+git push origin feat/cloudevents-compliance-otel-tracing
+```
+
+- [ ] **Step 3: Switch to the combined branch and merge both PR branches**
+
+```bash
+git checkout feat/combined-prs-3961-3983
+git merge feat/cloudevents-compliance-otel-tracing
+```
+
+If the PR #3983 branch also needs to be merged (and isn't already in the combined branch):
+
+```bash
+git merge <pr-3983-branch-name>
+```
+
+Resolve any merge conflicts if they arise.
+
+- [ ] **Step 4: Run codegen**
+
+```bash
+PATH="$(go env GOPATH)/bin:$PATH" make codegen
+```
+
+If codegen produces changes, commit them:
+
+```bash
+git add -A
+git diff --cached --quiet || git commit -s -m "chore: run codegen after merging tracing span kind changes"
+```
+
+- [ ] **Step 5: Run the full test suite on the combined branch**
+
+```bash
+go test -race -count=1 ./...
+```
+
+Expected: All tests pass on the combined branch.
+
+- [ ] **Step 6: Build the container image**
+
+Build using the existing image tag (overwrites the previous image):
+
+```bash
+docker build -t ghcr.io/kaio6fellipe/argo-events:prs-3961-3983 .
 ```
 
 Adjust the Dockerfile path and build args based on the fork's build system (check the existing Makefile or Dockerfile).
 
-- [ ] **Step 3: Push the image**
+- [ ] **Step 7: Push the image**
 
 ```bash
-docker push ghcr.io/kaio6fellipe/argo-events:prs-3961-3983-messaging-spans
+docker push ghcr.io/kaio6fellipe/argo-events:prs-3961-3983
 ```
 
-- [ ] **Step 4: Commit any remaining changes**
+- [ ] **Step 8: Push the combined branch**
 
 ```bash
-git add -A
-git commit -m "feat(tracing): complete PRODUCER/CONSUMER span instrumentation for service graph"
+git push origin feat/combined-prs-3961-3983
 ```
 
 ---
@@ -771,6 +828,8 @@ git commit -m "feat(tracing): complete PRODUCER/CONSUMER span instrumentation fo
 **Repo:** go-http-server
 **Files:**
 - Modify: `deploy/observability/local/tempo-values.yaml`
+
+The image tag stays `prs-3961-3983` (Task 7 overwrites the same tag), so no deploy manifest changes needed — just Tempo config and a rollout restart to pull the updated image.
 
 - [ ] **Step 1: Enable messaging system histogram and add messaging.system dimension**
 
@@ -790,25 +849,19 @@ In `deploy/observability/local/tempo-values.yaml`, update the `service_graphs` b
 
 Note: `enable_virtual_node_label` may already be present from the Alloy transform plan. If so, only add `enable_messaging_system_latency_histogram` and the `messaging.system` dimension.
 
-- [ ] **Step 2: Update Argo Events image tag in deploy manifests**
-
-Update the Argo Events Helm values or Makefile to use the new image tag. Search for the current tag `prs-3961-3983` in the Makefile and Argo Events Helm values:
-
-```bash
-grep -r "prs-3961-3983" deploy/ Makefile
-```
-
-Update all occurrences to the new tag `prs-3961-3983-messaging-spans`.
-
-- [ ] **Step 3: Commit**
+- [ ] **Step 2: Commit**
 
 ```bash
 git add deploy/observability/local/tempo-values.yaml
-git add -A  # Include any Makefile or deploy changes for the image tag
-git commit -m "feat(observability): enable messaging system histogram and update Argo Events image tag"
+git commit -m "$(cat <<'EOF'
+feat(observability): enable messaging system latency histogram in Tempo service graph
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
 ```
 
-- [ ] **Step 4: Redeploy Tempo**
+- [ ] **Step 3: Redeploy Tempo**
 
 ```bash
 helm upgrade --install tempo grafana/tempo \
@@ -818,15 +871,22 @@ helm upgrade --install tempo grafana/tempo \
   --wait --timeout 120s
 ```
 
-- [ ] **Step 5: Redeploy Argo Events**
+- [ ] **Step 4: Restart Argo Events pods to pull updated image**
 
-Redeploy the Argo Events components to pick up the new image. Use the Makefile target or helm upgrade for the Argo Events deployment:
+The image tag is the same (`prs-3961-3983`) but the content changed. Force a rollout restart of EventSource and Sensor pods to pull the new image:
 
 ```bash
-make k8s-platform
+kubectl --context=k3d-bookinfo-local -n bookinfo rollout restart deployment -l app.kubernetes.io/part-of=argo-events
 ```
 
-Then reapply the bookinfo app manifests to restart EventSources and Sensors:
+If the above selector doesn't match, restart the specific deployments:
+
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo delete pods -l managed-by=events-source
+kubectl --context=k3d-bookinfo-local -n bookinfo delete pods -l managed-by=sensor-controller
+```
+
+Alternatively, redeploy the full app stack which recreates them:
 
 ```bash
 make k8s-apps

--- a/docs/superpowers/plans/2026-04-10-database-tracing.md
+++ b/docs/superpowers/plans/2026-04-10-database-tracing.md
@@ -1,0 +1,487 @@
+# Database Operation Tracing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add OpenTelemetry tracing to all PostgreSQL and Redis operations so database calls appear as child spans in distributed traces.
+
+**Architecture:** Adapter-level instrumentation using `otelpgx` for pgx connection pools and `redisotel` for go-redis clients. Changes are centralized in `pkg/database/pool.go` and `services/productpage/internal/pending/redis.go` — all downstream consumers get tracing for free.
+
+**Tech Stack:** Go, pgx/v5, go-redis/v9, OpenTelemetry, otelpgx, redisotel
+
+---
+
+### Task 1: Add otelpgx and redisotel dependencies
+
+**Files:**
+- Modify: `go.mod`
+- Modify: `go.sum`
+
+- [ ] **Step 1: Add otelpgx dependency**
+
+Run:
+```bash
+go get github.com/exaring/otelpgx
+```
+
+Expected: `go.mod` gains `github.com/exaring/otelpgx` in the require block.
+
+- [ ] **Step 2: Add redisotel dependency**
+
+Run:
+```bash
+go get github.com/redis/go-redis/extra/redisotel/v9
+```
+
+Expected: `go.mod` gains `github.com/redis/go-redis/extra/redisotel/v9` in the require block.
+
+- [ ] **Step 3: Tidy modules**
+
+Run:
+```bash
+go mod tidy
+```
+
+Expected: Clean exit, no unused dependencies removed.
+
+- [ ] **Step 4: Verify build still passes**
+
+Run:
+```bash
+make build-all
+```
+
+Expected: All 5 services build successfully. No compilation errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go.mod go.sum
+git commit -m "chore: add otelpgx and redisotel dependencies"
+```
+
+---
+
+### Task 2: Instrument PostgreSQL connection pool with otelpgx
+
+**Files:**
+- Modify: `pkg/database/pool.go`
+
+- [ ] **Step 1: Write the failing test for tracer configuration**
+
+Create `pkg/database/pool_test.go`:
+
+```go
+package database_test
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/database"
+)
+
+func TestNewPoolConfig_HasTracer(t *testing.T) {
+	// Use a dummy URL — we only need to verify config parsing, not connectivity.
+	databaseURL := "postgres://user:pass@localhost:5432/testdb"
+
+	cfg, err := database.NewPoolConfig(databaseURL)
+	if err != nil {
+		t.Fatalf("NewPoolConfig returned error: %v", err)
+	}
+	if cfg.ConnConfig.Tracer == nil {
+		t.Fatal("expected ConnConfig.Tracer to be set, got nil")
+	}
+}
+
+func TestNewPoolConfig_InvalidURL(t *testing.T) {
+	_, err := database.NewPoolConfig("not-a-valid-url://")
+	if err == nil {
+		t.Fatal("expected error for invalid URL, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+go test ./pkg/database/ -run TestNewPoolConfig -v
+```
+
+Expected: FAIL — `database.NewPoolConfig` is undefined.
+
+- [ ] **Step 3: Implement NewPoolConfig and update NewPool**
+
+Replace the contents of `pkg/database/pool.go` with:
+
+```go
+// Package database provides PostgreSQL connection pool, migration, and health check utilities.
+package database
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/exaring/otelpgx"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// NewPoolConfig parses a database URL and returns a pgxpool.Config with
+// OpenTelemetry tracing enabled. The tracer creates child spans for every
+// Query, QueryRow, Exec, Prepare, and Connect call.
+func NewPoolConfig(databaseURL string) (*pgxpool.Config, error) {
+	cfg, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing database URL: %w", err)
+	}
+	cfg.ConnConfig.Tracer = otelpgx.NewTracer(
+		otelpgx.WithTrimSQLInSpanName(),
+	)
+	return cfg, nil
+}
+
+// NewPool creates a new PostgreSQL connection pool from the given database URL
+// with OpenTelemetry tracing enabled.
+func NewPool(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
+	cfg, err := NewPoolConfig(databaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating connection pool: %w", err)
+	}
+
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("pinging database: %w", err)
+	}
+
+	return pool, nil
+}
+```
+
+Key changes:
+- Extracted `NewPoolConfig` so the tracer configuration is testable without a live database.
+- `NewPool` now calls `NewPoolConfig` then `pgxpool.NewWithConfig` instead of `pgxpool.New`.
+- `otelpgx.WithTrimSQLInSpanName()` keeps span names short (e.g., `SELECT details` instead of the full query).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+go test ./pkg/database/ -run TestNewPoolConfig -v
+```
+
+Expected: Both tests PASS.
+
+- [ ] **Step 5: Run full build to ensure no breakage**
+
+Run:
+```bash
+make build-all
+```
+
+Expected: All 5 services build. The `NewPool` signature is unchanged (`ctx, string -> *Pool, error`) so all callers remain valid.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/database/pool.go pkg/database/pool_test.go
+git commit -m "feat(pkg/database): add OpenTelemetry tracing to PostgreSQL connection pool"
+```
+
+---
+
+### Task 3: Instrument Redis client with redisotel
+
+**Files:**
+- Modify: `services/productpage/internal/pending/redis.go`
+- Modify: `services/productpage/internal/pending/pending_test.go`
+
+- [ ] **Step 1: Write the failing test for Redis tracing instrumentation**
+
+Add this test to `services/productpage/internal/pending/pending_test.go`:
+
+```go
+func TestNewRedisStore_HasTracingHook(t *testing.T) {
+	mr := miniredis.RunT(t)
+	store, err := pending.NewRedisStore("redis://" + mr.Addr())
+	if err != nil {
+		t.Fatalf("NewRedisStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Verify the store was created successfully with tracing.
+	// The tracing hook is transparent — existing operations must still work.
+	ctx := context.Background()
+	err = store.StorePending(ctx, "trace-test", pending.NewReview("tracer", "test", 5))
+	if err != nil {
+		t.Fatalf("StorePending with tracing hook failed: %v", err)
+	}
+
+	reviews, err := store.GetAndReconcile(ctx, "trace-test", nil)
+	if err != nil {
+		t.Fatalf("GetAndReconcile with tracing hook failed: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("got %d reviews, want 1", len(reviews))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes (baseline — tracing not yet added)**
+
+Run:
+```bash
+go test ./services/productpage/internal/pending/ -run TestNewRedisStore_HasTracingHook -v
+```
+
+Expected: PASS (miniredis works fine without tracing). This establishes the baseline.
+
+- [ ] **Step 3: Add redisotel tracing hook to NewRedisStore**
+
+Replace the contents of `services/productpage/internal/pending/redis.go` with:
+
+```go
+package pending
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/redis/go-redis/extra/redisotel/v9"
+	"github.com/redis/go-redis/v9"
+)
+
+const keyPrefix = "pending:reviews:"
+
+// RedisStore implements Store backed by Redis lists.
+type RedisStore struct {
+	client *redis.Client
+}
+
+// NewRedisStore creates a RedisStore from a Redis URL (e.g. "redis://localhost:6379").
+// The client is instrumented with OpenTelemetry tracing — every command
+// produces a child span with operation name and key.
+func NewRedisStore(redisURL string) (*RedisStore, error) {
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing redis URL: %w", err)
+	}
+
+	client := redis.NewClient(opts)
+
+	if err := redisotel.InstrumentTracing(client,
+		redisotel.WithDBStatement(false),
+	); err != nil {
+		return nil, fmt.Errorf("instrumenting redis tracing: %w", err)
+	}
+
+	return &RedisStore{client: client}, nil
+}
+
+// Ping verifies the connection to Redis.
+func (s *RedisStore) Ping(ctx context.Context) error {
+	return s.client.Ping(ctx).Err()
+}
+
+// Close closes the Redis connection.
+func (s *RedisStore) Close() error {
+	return s.client.Close()
+}
+
+// StorePending appends a pending review to the Redis list for the given product.
+func (s *RedisStore) StorePending(ctx context.Context, productID string, review Review) error {
+	data, err := json.Marshal(review)
+	if err != nil {
+		return fmt.Errorf("marshaling pending review: %w", err)
+	}
+	return s.client.RPush(ctx, keyPrefix+productID, data).Err()
+}
+
+// GetAndReconcile returns pending reviews after removing any that match confirmed reviews.
+func (s *RedisStore) GetAndReconcile(ctx context.Context, productID string, confirmed []ConfirmedReview) ([]Review, error) {
+	key := keyPrefix + productID
+
+	vals, err := s.client.LRange(ctx, key, 0, -1).Result()
+	if err != nil {
+		return nil, fmt.Errorf("fetching pending reviews: %w", err)
+	}
+
+	if len(vals) == 0 {
+		return nil, nil
+	}
+
+	confirmedSet := make(map[string]struct{}, len(confirmed))
+	for _, c := range confirmed {
+		confirmedSet[c.Reviewer+"\x00"+c.Text] = struct{}{}
+	}
+
+	var remaining []Review
+	for _, raw := range vals {
+		var r Review
+		if err := json.Unmarshal([]byte(raw), &r); err != nil {
+			continue // skip corrupted entries
+		}
+
+		matchKey := r.Reviewer + "\x00" + r.Text
+		if _, found := confirmedSet[matchKey]; found {
+			// Review confirmed — remove from Redis
+			s.client.LRem(ctx, key, 1, raw)
+			delete(confirmedSet, matchKey) // only remove first match
+		} else {
+			remaining = append(remaining, r)
+		}
+	}
+
+	return remaining, nil
+}
+```
+
+Key changes:
+- Added `redisotel` import.
+- Split client creation and store return: `redis.NewClient(opts)` then `redisotel.InstrumentTracing(client, ...)` then return.
+- `WithDBStatement(false)` excludes full command arguments (values) from spans — only command name + key are visible.
+
+- [ ] **Step 4: Run all pending tests to verify nothing broke**
+
+Run:
+```bash
+go test ./services/productpage/internal/pending/ -v
+```
+
+Expected: ALL tests pass (TestStorePending, TestGetAndReconcile_RemovesConfirmed, TestGetAndReconcile_EmptyProduct, TestGetAndReconcile_IsolatesProducts, TestNewRedisStore_HasTracingHook).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/productpage/internal/pending/redis.go services/productpage/internal/pending/pending_test.go
+git commit -m "feat(productpage): add OpenTelemetry tracing to Redis pending store"
+```
+
+---
+
+### Task 4: Full test suite and build verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite with race detector**
+
+Run:
+```bash
+make test-race
+```
+
+Expected: ALL tests pass across the entire monorepo. Zero failures.
+
+- [ ] **Step 2: Run linter**
+
+Run:
+```bash
+make lint
+```
+
+Expected: No new lint warnings. Clean exit.
+
+- [ ] **Step 3: Build all services**
+
+Run:
+```bash
+make build-all
+```
+
+Expected: All 5 services build successfully.
+
+- [ ] **Step 4: Run go vet**
+
+Run:
+```bash
+make vet
+```
+
+Expected: Clean exit, no issues.
+
+---
+
+### Task 5: Deploy to local k8s and verify traces in Grafana Tempo
+
+**Files:** None (deployment and verification only)
+
+- [ ] **Step 1: Rebuild images and redeploy to k8s**
+
+Run:
+```bash
+make k8s-rebuild
+```
+
+Expected: All images rebuilt with new tracing instrumentation. Pods restart with updated code.
+
+- [ ] **Step 2: Wait for pods to be ready**
+
+Run:
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo get pods -w
+```
+
+Expected: All pods reach `Running` / `Ready` state.
+
+- [ ] **Step 3: Submit a review via POST (trigger the async write path)**
+
+Run:
+```bash
+curl -s -D - -X POST http://localhost:8080/partials/rating \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "product_id=d0001&reviewer=trace-test&rating=5&text=Testing+database+tracing"
+```
+
+Expected: HTTP 200 response. Check the productpage logs for the trace ID:
+
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo logs -l app=productpage --tail=20 | grep trace_id
+```
+
+Note the `trace_id` value from the POST request log line.
+
+- [ ] **Step 4: Trigger a GET to load reviews (triggers Postgres SELECT + Redis reconciliation)**
+
+Run:
+```bash
+curl -s http://localhost:8080/partials/reviews?product_id=d0001 > /dev/null
+```
+
+Check logs again for the GET request's trace ID:
+
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo logs -l app=productpage --tail=10 | grep trace_id
+```
+
+- [ ] **Step 5: Verify Postgres spans in Grafana Tempo**
+
+Open Grafana at http://localhost:3000, navigate to Explore > Tempo.
+
+Search for the trace ID from Step 3. Verify:
+- The trace contains spans from the reviews-write service
+- A `db.postgresql` span (or span with `db.system=postgresql`) appears as a child of the write service HTTP handler span
+- The span has `db.statement` attribute with sanitized SQL (e.g., `INSERT INTO reviews ... VALUES ($1, $2, ...)`)
+
+Search for the trace ID from Step 4. Verify:
+- Postgres `SELECT` spans appear under the read service handler spans (details-read, reviews-read, ratings-read)
+- Each SELECT span shows the sanitized SQL query
+
+- [ ] **Step 6: Verify Redis spans in Grafana Tempo**
+
+Using the trace ID from Step 3 (POST request):
+- A Redis `RPUSH` span should appear under the productpage handler span
+- The span name should include the key (e.g., `RPUSH pending:reviews:d0001`)
+
+Using the trace ID from Step 4 (GET request):
+- Redis `LRANGE` span should appear under the productpage handler span
+- If reconciliation occurred, a `LREM` span should also be present
+
+- [ ] **Step 7: Commit verification notes (optional)**
+
+No code changes needed. If all traces verified, the task is complete.

--- a/docs/superpowers/specs/2026-04-10-alloy-span-kind-transform-design.md
+++ b/docs/superpowers/specs/2026-04-10-alloy-span-kind-transform-design.md
@@ -1,0 +1,116 @@
+# Alloy Span Kind Transform for Argo Events Service Graph Visibility
+
+## Problem
+
+Argo Events (PR #3961) instruments EventSources and Sensors with OpenTelemetry tracing, but all spans use `SPAN_KIND_INTERNAL`. Tempo's service graph processor only builds edges from `CLIENT`/`SERVER` (and optionally `PRODUCER`/`CONSUMER`) span pairs, so Argo Events components are invisible in the Grafana Tempo service graph despite appearing correctly in individual trace views.
+
+**Current state:** The service graph shows `gateway -> write-services` but the intermediary Argo Events components (`eventsource`, `sensor`) are missing.
+
+**Desired state:** The service graph shows `gateway -> eventsource` and `sensor -> write-service` edges, making the full request flow visible.
+
+## Scope
+
+Infrastructure-only change — no application code modifications. Two files affected:
+
+1. `deploy/observability/local/alloy-metrics-traces-config.alloy` — add transform processor
+2. `deploy/observability/local/tempo-values.yaml` — add virtual node support for unpaired spans
+
+## Design
+
+### Span Kind Transform in Alloy
+
+Add an `otelcol.processor.transform` block to the Alloy trace pipeline that rewrites span kinds for known Argo Events span patterns:
+
+| Span name pattern | Current kind | New kind | Rationale |
+|---|---|---|---|
+| `sensor.trigger*` | Internal | Client | Sensor makes outbound HTTP call to write service; pairs with write service's SERVER span |
+| `eventsource.publish*` | Internal | Server | EventSource handles inbound webhook from gateway; pairs with gateway's CLIENT span |
+
+**Why `eventsource.publish` -> Server:** This span represents the EventSource processing an inbound webhook and publishing to the EventBus. Semantically it's a PRODUCER (publishing to Kafka/JetStream), but there's no matching CONSUMER span on the sensor side (PR #3961 doesn't create one). Setting it to Server pairs with the gateway's CLIENT span for the webhook call, creating a `gateway -> eventsource` edge. This is a pragmatic workaround until the Argo Events fork adds proper PRODUCER/CONSUMER spans.
+
+**Pattern matching over hardcoded names:** The transform matches on span name patterns (`sensor.trigger`, `eventsource.publish`) and the Argo Events library names (`argo-events-sensor`, `argo-events-eventsource`), not on individual service names. Any new sensor or EventSource automatically gets the correction.
+
+### Pipeline Insertion Point
+
+The transform slots between the cluster attributes processor and the batch processor:
+
+```
+OTLP Receiver -> K8s Attributes -> Cluster Name -> [Transform] -> Batch -> Tempo
+```
+
+This ensures K8s metadata is already enriched before the transform runs, allowing conditions to reference resource attributes if needed.
+
+### Alloy Configuration
+
+```alloy
+// -- Fix Argo Events span kinds for Tempo service graph --
+otelcol.processor.transform "argo_events" {
+  error_mode = "ignore"
+
+  trace_statements {
+    context = "span"
+    conditions = [
+      `IsMatch(resource.attributes["service.name"], ".*-sensor$")`,
+    ]
+    statements = [
+      `set(span.kind.string, "Client") where IsMatch(name, "^sensor\\.trigger")`,
+    ]
+  }
+
+  trace_statements {
+    context = "span"
+    conditions = [
+      `IsMatch(resource.attributes["service.name"], ".*-eventsource$")`,
+    ]
+    statements = [
+      `set(span.kind.string, "Server") where IsMatch(name, "^eventsource\\.publish")`,
+    ]
+  }
+}
+```
+
+**Key syntax details:**
+- `span.kind.string` with title-case values ("Client", "Server") — the `SPAN_KIND_*` constants are deprecated in OTTL
+- `conditions` pre-filter by service name pattern so statements only evaluate on Argo Events spans
+- `error_mode = "ignore"` ensures non-matching spans pass through unmodified
+
+### Tempo Configuration Enhancement
+
+Add `enable_virtual_node_label` to the service graph processor so unpaired spans (e.g., a sensor CLIENT span where the write service is temporarily down) still appear as nodes with a "virtual_node" label rather than being silently dropped:
+
+```yaml
+service_graphs:
+  enable_virtual_node_label: true
+  histogram_buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+  dimensions:
+    - http.method
+    - k8s.namespace.name
+    - k8s.cluster.name
+```
+
+## Resulting Service Graph Edges
+
+After this change, the service graph will show:
+
+| Client | Server | Created by |
+|---|---|---|
+| `default-gw` (Envoy Gateway) | `*-eventsource` | Gateway CLIENT + eventsource "Server" |
+| `*-sensor` | `*-write` services | Sensor "Client" + write service SERVER |
+| `productpage` | `details-read`, `reviews-read` | Existing (unchanged) |
+| `reviews-read` | `ratings-read` | Existing (unchanged) |
+
+**Not visible:** The `eventsource -> sensor` edge (Kafka/EventBus link) — this requires PRODUCER/CONSUMER spans with messaging attributes, which is a separate Argo Events code change.
+
+## Lifecycle
+
+This transform is a **workaround** with a planned deprecation path. When the Argo Events fork adds proper span kinds (CLIENT for sensor triggers, SERVER for webhook receive, PRODUCER/CONSUMER for EventBus messaging), the Alloy transform conditions will stop matching (the spans will no longer be INTERNAL) and can be removed. The transform is idempotent — it only acts on spans that are currently INTERNAL.
+
+## Verification
+
+After deploying, verify by:
+
+1. Trigger a POST request through the gateway (e.g., submit a review)
+2. Find the trace in Tempo — confirm spans still appear correctly linked
+3. Check the service graph in Grafana — confirm `*-eventsource` and `*-sensor` nodes now appear
+4. Query Prometheus for `traces_service_graph_request_total` — confirm new client/server label pairs exist
+5. Check `traces_service_graph_unpaired_spans_total` — should be low/zero for Argo Events spans

--- a/docs/superpowers/specs/2026-04-10-argo-events-messaging-spans-design.md
+++ b/docs/superpowers/specs/2026-04-10-argo-events-messaging-spans-design.md
@@ -1,0 +1,276 @@
+# Argo Events PRODUCER/CONSUMER Span Instrumentation
+
+## Problem
+
+Argo Events PR #3961 added OpenTelemetry tracing with two spans (`eventsource.publish` and `sensor.trigger`), both using `SPAN_KIND_INTERNAL`. This creates two gaps:
+
+1. **Wrong span kinds:** `sensor.trigger` is an outbound HTTP call (should be CLIENT), `eventsource.publish` publishes to the EventBus (should be PRODUCER)
+2. **Missing inbound span:** There is no span representing the EventSource receiving an event from its external source (HTTP webhook, message subscription, etc.). The correct span kind for this depends on the EventSource type.
+3. **Missing messaging spans:** There are no PRODUCER or CONSUMER spans for the EventBus communication. The EventSource publishes to the EventBus and the Sensor consumes from it, but neither operation has a span with the correct messaging span kind or OTel messaging semantic conventions.
+
+Without PRODUCER/CONSUMER spans, the `eventsource -> [EventBus] -> sensor` edge is invisible in Tempo's service graph, even with `enable_messaging_system_latency_histogram` enabled.
+
+## Scope
+
+Code changes to the Argo Events fork (`ghcr.io/kaio6fellipe/argo-events`, branch based on PRs #3961 + #3983). The changes must be **backend-agnostic** — covering all three supported EventBus types and being extensible to the 32+ EventSource types and 11 trigger types.
+
+### EventBus Types
+
+| Backend | Config field | `messaging.system` value | Notes |
+|---|---|---|---|
+| Kafka | `.kafka` | `kafka` | External broker, active-active sensor HA |
+| JetStream | `.jetStream` | `nats` | Argo-managed, leader election only |
+| NATS Streaming (Stan) | `.nats` | `nats` | Deprecated, leader election only |
+
+### Current Trace Flow (PR #3961)
+
+```
+Gateway (CLIENT)
+  -> webhook EventSource receives HTTP
+    -> eventsource.publish (INTERNAL) — starts span from CloudEvent traceparent
+      -> InjectTraceIntoCloudEvent() — writes traceparent into CloudEvent extensions
+        -> EventBus publish (Kafka/JetStream/Stan) — no span
+          -> EventBus consume — no span
+            -> sensor extractTraceFromEvents() — extracts traceparent
+              -> sensor.trigger (INTERNAL) — child of eventsource.publish
+                -> Inject() — writes traceparent into outbound HTTP headers
+                  -> Write Service (SERVER)
+```
+
+Trace context propagation uses **CloudEvent extensions** (`traceparent`/`tracestate` keys), not EventBus message headers. This is backend-agnostic by design.
+
+## Design
+
+### Target Trace Flow (Webhook EventSource Example)
+
+```text
+Gateway (CLIENT)
+  -> eventsource.receive (SERVER) — new span, pairs with gateway CLIENT
+    -> eventsource.publish (PRODUCER) — changed from INTERNAL, with messaging attributes
+      -> [EventBus message with traceparent in CloudEvent extensions]
+        -> sensor.consume (CONSUMER) — new span, pairs with eventsource.publish PRODUCER
+          -> sensor.trigger (CLIENT) — changed from INTERNAL, pairs with write service SERVER
+            -> Write Service (SERVER)
+```
+
+### Target Trace Flow (Subscriber EventSource Example — e.g., Kafka, SQS, Pub/Sub)
+
+```text
+External System (Kafka topic, SQS queue, Pub/Sub subscription, etc.)
+  -> eventsource.receive (CONSUMER) — new span, kind depends on source type
+    -> eventsource.publish (PRODUCER) — publishes to EventBus with messaging attributes
+      -> [EventBus message with traceparent in CloudEvent extensions]
+        -> sensor.consume (CONSUMER) — new span, pairs with eventsource.publish PRODUCER
+          -> sensor.trigger (CLIENT) — pairs with write service SERVER
+            -> Write Service (SERVER)
+```
+
+### EventSource Inbound Classification (All 32 Types)
+
+The `eventsource.receive` span kind depends on how the EventSource receives events from its external source. All 32 EventSource types fall into one of four categories:
+
+**HTTP webhook receivers (external system pushes to EventSource HTTP server) -> `eventsource.receive` as SERVER:**
+
+| EventSource type | External system behavior |
+| --- | --- |
+| Webhook | Generic HTTP POST receiver |
+| GitHub | GitHub sends webhook POST |
+| GitLab | GitLab sends webhook POST |
+| Bitbucket (Cloud) | Bitbucket sends webhook POST |
+| Bitbucket Server | Bitbucket Server sends webhook POST |
+| Slack | Slack sends event payload POST |
+| Stripe | Stripe sends webhook POST |
+| NetApp StorageGrid | StorageGrid sends notification POST |
+| AWS SNS | SNS pushes notification to HTTP endpoint |
+
+**gRPC server receivers -> `eventsource.receive` as SERVER:**
+
+| EventSource type | External system behavior |
+| --- | --- |
+| Generic (gRPC) | External client sends gRPC call |
+
+**Message/event subscribers (EventSource subscribes to external system) -> `eventsource.receive` as CONSUMER:**
+
+| EventSource type | Subscription mechanism |
+| --- | --- |
+| Kafka | Subscribes to Kafka topic |
+| AMQP | Subscribes to AMQP queue/exchange (RabbitMQ, etc.) |
+| NATS | Subscribes to NATS subject |
+| NSQ | Subscribes to NSQ topic |
+| MQTT | Subscribes to MQTT topic |
+| GCP Pub/Sub | Subscribes to Pub/Sub subscription |
+| Redis | Subscribes to Redis Pub/Sub channel |
+| Redis Streams | Reads from Redis Stream (XREAD/XREADGROUP) |
+| AWS SQS | Polls SQS queue |
+| Azure Events Hub | Subscribes to Azure Event Hub partition |
+| Azure Queue Storage | Polls Azure Queue Storage |
+| Azure Service Bus | Subscribes to Azure Service Bus topic/queue |
+| Pulsar | Subscribes to Pulsar topic |
+| Emitter | Subscribes to Emitter channel |
+| Alibaba Cloud MNS | Polls MNS queue |
+| Minio | Subscribes to bucket notifications via Minio client SDK |
+
+**Pollers/watchers (EventSource connects outbound to watch for changes) -> `eventsource.receive` as CLIENT:**
+
+| EventSource type | Connection pattern |
+| --- | --- |
+| Gerrit | Outbound SSH connection running `gerrit stream-events` |
+| SFTP | Polls SFTP server for new/changed files |
+| HDFS | Watches HDFS via client connection |
+| Kubernetes Resource | Watches k8s API server via watch API |
+
+**Local/scheduled (no external network source) -> no `eventsource.receive` span:**
+
+| EventSource type | Event generation pattern |
+| --- | --- |
+| Calendar | Generates events on cron/interval schedule |
+| File | Watches local filesystem via fsnotify |
+
+### Span Changes Summary
+
+| Span | Status | Kind | Key attributes |
+| --- | --- | --- | --- |
+| `eventsource.receive` | **New** | **Varies by source type:** SERVER (webhook/gRPC), CONSUMER (subscribers), CLIENT (pollers), omitted (local) | `eventsource.name`, `eventsource.type`, plus type-specific attributes (e.g., `http.method` for SERVER, `messaging.system` for CONSUMER) |
+| `eventsource.publish` | **Modified** | PRODUCER (was INTERNAL) | `messaging.system`, `messaging.destination.name`, `messaging.operation.type: send`, `messaging.operation.name: send` |
+| `sensor.consume` | **New** | CONSUMER | `messaging.system`, `messaging.destination.name`, `messaging.operation.type: process`, `messaging.operation.name: process`, `messaging.consumer.group.name` |
+| `sensor.trigger` | **Modified** | CLIENT (was INTERNAL) | `server.address`, `http.request.method` (existing trigger attributes preserved) |
+
+### Messaging Attributes by EventBus Type
+
+The `messaging.system` and related attributes must be set based on the EventBus backend in use:
+
+| Attribute | Kafka | JetStream | Stan (deprecated) |
+|---|---|---|---|
+| `messaging.system` | `kafka` | `nats` | `nats` |
+| `messaging.destination.name` | Kafka topic name | JetStream subject | NATS channel |
+| `messaging.consumer.group.name` | Consumer group ID | Durable consumer name | Queue group |
+| `server.address` | Broker bootstrap address | NATS server URL | NATS server URL |
+
+### Implementation Approach
+
+#### 1. Tracing Helper Additions (`pkg/shared/tracing/`)
+
+Extend the existing `tracing` package with:
+
+- **`StartServerSpan(ctx, tracer, name, attrs...) (context.Context, trace.Span)`** — creates a SERVER span, used by HTTP webhook EventSource receive
+- **`StartProducerSpan(ctx, tracer, name, attrs...) (context.Context, trace.Span)`** — creates a PRODUCER span with messaging attributes
+- **`StartConsumerSpan(ctx, tracer, name, attrs...) (context.Context, trace.Span)`** — creates a CONSUMER span with messaging attributes
+- **`StartClientSpan(ctx, tracer, name, attrs...) (context.Context, trace.Span)`** — creates a CLIENT span, used by sensor HTTP trigger and poller EventSources
+- **`MessagingAttributes(busType, destination, consumerGroup, serverAddr string) []attribute.KeyValue`** — returns the standard OTel messaging semantic convention attributes based on EventBus type or external source type
+- **`SourceTypeSpanKind(sourceType string) trace.SpanKind`** — maps an EventSource type string to the correct inbound span kind (SERVER for webhook types, CONSUMER for subscriber types, CLIENT for poller types, INTERNAL for local types). Based on the classification table. Used by source handlers to determine which `Start*Span` helper to call.
+
+This keeps the span kind and attribute logic centralized and testable, with each EventBus backend and source type only needing to pass its type identifier and connection details.
+
+#### 2. EventSource Changes (`pkg/eventsources/`)
+
+**`eventsource.receive` (new span, kind varies by source type):**
+
+Each EventSource type must create an `eventsource.receive` span with the appropriate kind based on its inbound pattern. The span is created in the individual source handler (e.g., `sources/webhook/start.go`, `sources/kafka/start.go`) before the event enters the common `eventing.go` publish loop.
+
+The `SpanKindForSourceType(sourceType string) trace.SpanKind` helper function maps EventSource types to the correct span kind using the classification table above. Each source handler calls the appropriate `Start*Span` helper:
+
+- **Webhook/gRPC sources** (`sources/webhook/`, `sources/generic/`): `StartServerSpan(ctx, tracer, "eventsource.receive", ...)` — creates the `gateway -> eventsource` or `client -> eventsource` edge
+- **Subscriber sources** (`sources/kafka/`, `sources/amqp/`, `sources/nats/`, etc.): `StartConsumerSpan(ctx, tracer, "eventsource.receive", ...)` with external messaging attributes (`messaging.system` matching the external source, e.g., `kafka` for a Kafka EventSource, distinct from the EventBus `messaging.system`)
+- **Poller sources** (`sources/sftp/`, `sources/hdfs/`, `sources/gerrit/`, `sources/resource/`): `StartClientSpan(ctx, tracer, "eventsource.receive", ...)` — outbound connection to external system
+- **Local sources** (`sources/calendar/`, `sources/file/`): No `eventsource.receive` span — the event is locally generated, no external system to pair with
+
+Since PR #3961 already passes `ctx` from each source handler into the common publish loop, the `eventsource.receive` span context naturally becomes the parent of `eventsource.publish`.
+
+**`eventsource.publish` (change to PRODUCER):**
+
+In `eventing.go`, the existing `eventsource.publish` span creation changes from:
+- `tracer.Start(ctx, "eventsource.publish")` (INTERNAL)
+- to `StartProducerSpan(ctx, tracer, "eventsource.publish", MessagingAttributes(...))` (PRODUCER)
+
+The EventBus type and destination details are available from the `EventSourceAdaptor` configuration. The `BusConfig` struct tells which backend is active (`.kafka`, `.jetStream`, or `.nats`), and the topic/subject name is derivable from the event source name.
+
+**Important distinction:** Subscriber EventSources (e.g., Kafka EventSource) have **two** messaging systems in their trace: the external source they subscribe to (e.g., an external Kafka cluster) and the internal EventBus they publish to (e.g., the Argo Events Kafka EventBus). The `eventsource.receive` CONSUMER span has `messaging.system` attributes for the external source, while the `eventsource.publish` PRODUCER span has `messaging.system` attributes for the EventBus. These are separate spans with separate messaging attributes.
+
+#### 3. Sensor Changes (`pkg/sensors/`)
+
+**`sensor.consume` (new CONSUMER span):**
+
+In `listener.go`, after `extractTraceFromEvents()` extracts the traceparent from CloudEvent extensions and before `triggerOne()` is called, create a CONSUMER span. This span's parent is the remote span context from the CloudEvent, and its span ID becomes the parent of `sensor.trigger`. This creates the `eventsource -> sensor` edge in the service graph.
+
+The messaging attributes come from the sensor's EventBus configuration, available through the `SensorContext` or the EventBus driver.
+
+**`sensor.trigger` (change to CLIENT):**
+
+In `listener.go`, the existing `sensor.trigger` span creation changes from:
+- `tracer.Start(ctx, "sensor.trigger")` (INTERNAL)
+- to `StartClientSpan(ctx, tracer, "sensor.trigger", attrs...)` (CLIENT)
+
+Add `server.address` attribute extracted from the trigger's HTTP URL configuration.
+
+#### 4. Tempo Service Graph Matching
+
+For the PRODUCER/CONSUMER edge to appear in Tempo's service graph:
+
+- **Edge matching rule:** The consumer's `parent_span_id` must equal the producer's `span_id`. This is already satisfied by the CloudEvent traceparent propagation — the `sensor.consume` span's parent context comes from the `eventsource.publish` span's context via the CloudEvent extensions.
+- **Tempo config:** `enable_messaging_system_latency_histogram: true` must be set, and `messaging.system` should be added to `dimensions` for useful label cardinality.
+
+### Implementation Prioritization
+
+PR #3961's `eventsource.publish` span is created in the common `eventing.go` publish loop, which all 32 EventSource types share. The PRODUCER span change and the `sensor.consume`/`sensor.trigger` changes apply to all of them automatically.
+
+The `eventsource.receive` span requires per-source-type work since each source handler has different inbound logic. Recommended implementation order:
+
+1. **Phase 1 (core):** Common changes — `eventsource.publish` PRODUCER, `sensor.consume` CONSUMER, `sensor.trigger` CLIENT, tracing helpers. This gives the `eventsource -> [EventBus] -> sensor -> write-service` edges for all source types.
+2. **Phase 2 (webhook sources):** `eventsource.receive` SERVER for webhook, GitHub, GitLab, Bitbucket, Slack, Stripe, SNS, StorageGrid, Generic. This adds the `external -> eventsource` edge for HTTP-based sources.
+3. **Phase 3 (subscriber sources):** `eventsource.receive` CONSUMER for Kafka, AMQP, NATS, MQTT, SQS, Pub/Sub, Redis, Azure, Pulsar, etc. This adds the `external-system -> eventsource` edge for subscription sources.
+4. **Phase 4 (poller/watcher sources):** `eventsource.receive` CLIENT for Gerrit, SFTP, HDFS, Kubernetes Resource.
+
+**For this project (bookinfo):** Only Phase 1 and Phase 2 (webhook only) are needed since all EventSources use the webhook type.
+
+### Considerations for Non-HTTP Sensor Triggers
+
+The `sensor.trigger` CLIENT span change applies to **HTTP triggers** (used in this project). For other trigger types:
+
+- **HTTP trigger**: CLIENT span (outbound HTTP call) — addressed in this design
+- **Kafka trigger**: PRODUCER span (publishing to external Kafka topic)
+- **Argo Workflow trigger**: CLIENT span (API call to Argo server)
+- **AWS Lambda trigger**: CLIENT span (API call to AWS)
+- **Kubernetes Object trigger**: CLIENT span (API call to k8s)
+- **Log trigger**: INTERNAL span (local I/O, no network call)
+
+**Recommendation:** Start with HTTP trigger CLIENT span. Other trigger types can be addressed incrementally using the same `StartClientSpan`/`StartProducerSpan` helpers.
+
+## Resulting Service Graph Edges
+
+With all changes applied and Tempo configured with `enable_messaging_system_latency_histogram: true`:
+
+| Client/Producer | Server/Consumer | Edge type | Created by |
+|---|---|---|---|
+| `default-gw` (Gateway) | `*-eventsource` | CLIENT/SERVER | Gateway CLIENT + eventsource.receive SERVER |
+| `*-eventsource` | `*-sensor` | PRODUCER/CONSUMER | eventsource.publish PRODUCER + sensor.consume CONSUMER |
+| `*-sensor` | `*-write` services | CLIENT/SERVER | sensor.trigger CLIENT + write service SERVER |
+| `productpage` | `details-read`, `reviews-read` | CLIENT/SERVER | Existing (unchanged) |
+| `reviews-read` | `ratings-read` | CLIENT/SERVER | Existing (unchanged) |
+
+The full write-side flow becomes visible: `gateway -> eventsource -> [EventBus] -> sensor -> write-service`.
+
+## Impact on Alloy Transform Workaround
+
+Once these changes are deployed, the Alloy `otelcol.processor.transform "argo_events"` workaround becomes unnecessary:
+
+- `eventsource.publish` will be PRODUCER (not INTERNAL), so the `set(span.kind.string, "Server")` condition won't match
+- `sensor.trigger` will be CLIENT (not INTERNAL), so the `set(span.kind.string, "Client")` condition won't match
+
+The transform can be removed after verifying the Argo Events changes are producing correct service graph edges.
+
+## Verification
+
+1. Deploy the updated Argo Events image to the local k8s cluster
+2. Enable `enable_messaging_system_latency_histogram: true` in Tempo config
+3. Add `messaging.system` to Tempo service graph `dimensions`
+4. Trigger POST requests through the gateway for each event type (details, reviews, ratings)
+5. Verify in Tempo trace view:
+   - `eventsource.receive` span with kind=SERVER (for webhook sources) or kind=CONSUMER (for subscriber sources)
+   - `eventsource.publish` span with kind=PRODUCER and messaging attributes
+   - `sensor.consume` span with kind=CONSUMER and messaging attributes
+   - `sensor.trigger` span with kind=CLIENT
+6. Verify in Grafana service graph:
+   - `gateway -> eventsource` edge visible
+   - `eventsource -> sensor` edge visible (messaging system edge)
+   - `sensor -> write-service` edge visible
+7. Query `traces_service_graph_request_messaging_system_seconds` in Prometheus — confirm histogram data exists with `messaging.system` labels

--- a/docs/superpowers/specs/2026-04-10-database-tracing-design.md
+++ b/docs/superpowers/specs/2026-04-10-database-tracing-design.md
@@ -97,14 +97,18 @@ Only affects productpage service (the only Redis consumer). Transparent to `Noop
 - **`pkg/database/`**: Verify pool is created with tracer configured (parse config, assert `ConnConfig.Tracer` is non-nil).
 - **`pending/redis.go`**: Existing `miniredis`-based tests continue to pass — the tracing hook is transparent. Add a test verifying `InstrumentTracing` succeeds on a valid client.
 
-### Integration Verification
+### Integration Verification (POST Trace End-to-End)
 
-After deployment to local k8s, validate in Grafana Tempo:
+After deployment to local k8s, validate the full async write path in Grafana Tempo:
 
-1. Submit a review via productpage
-2. Open the resulting trace
-3. Confirm Postgres spans appear as children of HTTP handler spans (e.g., `SELECT` under `GET /partials/reviews`)
-4. Confirm Redis spans appear for pending review operations (e.g., `RPUSH`, `LRANGE`)
+1. Submit a review via POST through the productpage UI
+2. Grab the trace ID from the response or logs
+3. Open the trace in Grafana Tempo (http://localhost:3000)
+4. Confirm Redis spans appear for pending review storage (e.g., `RPUSH pending:reviews:<product_id>`)
+5. Follow the async path through Kafka to the reviews-write service
+6. Confirm Postgres `INSERT` spans appear as children of the write service HTTP handler span
+7. Trigger a GET to `/partials/reviews` and confirm Postgres `SELECT` spans appear on the read path
+8. Confirm Redis `LRANGE` / `LREM` spans appear for pending review reconciliation
 
 ## Files Changed
 

--- a/docs/superpowers/specs/2026-04-10-database-tracing-design.md
+++ b/docs/superpowers/specs/2026-04-10-database-tracing-design.md
@@ -1,0 +1,124 @@
+# Database Operation Tracing — Design Spec
+
+**Date**: 2026-04-10
+**Status**: Approved
+
+## Goal
+
+Add OpenTelemetry tracing to all PostgreSQL and Redis operations so that database calls appear as child spans in distributed traces. This fills the visibility gap between HTTP-level tracing (already instrumented) and storage-level operations (currently invisible).
+
+## Motivation
+
+Current traces show HTTP request flow between services but go dark once a request hits a database or cache call. This makes it impossible to:
+
+- Identify slow queries contributing to request latency
+- Correlate database errors with the HTTP requests that triggered them
+- See which SQL statements ran and how long they took
+
+## Approach: Adapter-Level Instrumentation
+
+Instrument at the shared infrastructure layer rather than in individual repository methods. This follows the same pattern used for HTTP tracing (`otelhttp` wrapping in `pkg/server`).
+
+## PostgreSQL Tracing
+
+### Implementation
+
+Modify `pkg/database/pool.go` to:
+
+1. Parse the connection string into a `pgxpool.Config` (instead of passing the raw URL)
+2. Attach an `otelpgx` tracer to `Config.ConnConfig.Tracer`
+3. Create the pool from the config
+
+```go
+cfg, err := pgxpool.ParseConfig(databaseURL)
+if err != nil {
+    return nil, fmt.Errorf("parsing database URL: %w", err)
+}
+cfg.ConnConfig.Tracer = otelpgx.NewTracer(
+    otelpgx.WithTrimSQLInSpanName(),
+)
+pool, err := pgxpool.NewWithConfig(ctx, cfg)
+```
+
+### Span Attributes
+
+The `otelpgx` tracer automatically creates child spans for `Query`, `QueryRow`, `Exec`, `Prepare`, and `Connect` operations with:
+
+- `db.system`: `"postgresql"`
+- `db.statement`: full SQL with `$1` placeholders (sanitized — no bind parameter values)
+- `db.operation`: `SELECT` / `INSERT` / `UPDATE` / `DELETE`
+- Error status propagated to span
+
+### Impact
+
+All 4 services using `pkg/database.NewPool` (details, ratings, reviews, notification) get tracing automatically. Zero changes needed in any adapter or repository file.
+
+### Dependency
+
+- `github.com/exaring/otelpgx`
+
+## Redis Tracing
+
+### Implementation
+
+Modify `services/productpage/internal/pending/redis.go` to add the `redisotel` tracing hook after client creation:
+
+```go
+client := redis.NewClient(opts)
+if err := redisotel.InstrumentTracing(client,
+    redisotel.WithDBStatement(false),
+); err != nil {
+    return nil, fmt.Errorf("instrumenting redis tracing: %w", err)
+}
+```
+
+### Span Attributes
+
+The `redisotel` hook automatically creates spans for every Redis command with:
+
+- `db.system`: `"redis"`
+- `db.operation`: `RPUSH` / `LRANGE` / `LREM` / `PING`
+- `net.peer.name` / `net.peer.port`: Redis host info
+- Span name includes command + key (e.g., `RPUSH pending:reviews:p001`)
+- `WithDBStatement(false)` excludes full command arguments (values) from span attributes
+
+### Impact
+
+Only affects productpage service (the only Redis consumer). Transparent to `NoopStore` — no changes needed there.
+
+### Dependency
+
+- `github.com/redis/go-redis/extra/redisotel/v9`
+
+## Testing Strategy
+
+### Unit Tests
+
+- **`pkg/database/`**: Verify pool is created with tracer configured (parse config, assert `ConnConfig.Tracer` is non-nil).
+- **`pending/redis.go`**: Existing `miniredis`-based tests continue to pass — the tracing hook is transparent. Add a test verifying `InstrumentTracing` succeeds on a valid client.
+
+### Integration Verification
+
+After deployment to local k8s, validate in Grafana Tempo:
+
+1. Submit a review via productpage
+2. Open the resulting trace
+3. Confirm Postgres spans appear as children of HTTP handler spans (e.g., `SELECT` under `GET /partials/reviews`)
+4. Confirm Redis spans appear for pending review operations (e.g., `RPUSH`, `LRANGE`)
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `go.mod` | Add `otelpgx` and `redisotel` dependencies |
+| `pkg/database/pool.go` | Parse config, attach `otelpgx` tracer, create pool from config |
+| `services/productpage/internal/pending/redis.go` | Add `redisotel.InstrumentTracing` hook |
+| `pkg/database/pool_test.go` (new) | Test pool creation with tracer |
+| `services/productpage/internal/pending/pending_test.go` | Add tracing hook verification test |
+
+## Out of Scope
+
+- Manual spans in business logic or service layer
+- Database connection pool metrics (separate concern)
+- Docker Compose OTEL configuration (tracing stays k8s-only, matching current pattern)
+- Changes to adapter/repository files (instrumentation is transparent)

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,8 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.18.0 // indirect
+	github.com/redis/go-redis/extra/redisotel/v9 v9.18.0 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.26.2
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0
+	github.com/exaring/otelpgx v0.10.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/grafana/pyroscope-go v1.2.8
@@ -28,7 +29,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/exaring/otelpgx v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -44,8 +44,6 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.18.0 // indirect
-	github.com/redis/go-redis/extra/redisotel/v9 v9.18.0 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/exaring/otelpgx v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -43,6 +44,8 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.18.0 // indirect
+	github.com/redis/go-redis/extra/redisotel/v9 v9.18.0 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/exaring/otelpgx v0.10.0 h1:NGGegdoBQM3jNZDKG8ENhigUcgBN7d7943L0YlcIpZc=
+github.com/exaring/otelpgx v0.10.0/go.mod h1:R5/M5LWsPPBZc1SrRE5e0DiU48bI78C1/GPTWs6I66U=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -105,6 +107,10 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
+github.com/redis/go-redis/extra/rediscmd/v9 v9.18.0 h1:QY4nmPHLFAJjtT5O4OMUEOxP8WVaRNOFpcbmxT2NLZU=
+github.com/redis/go-redis/extra/rediscmd/v9 v9.18.0/go.mod h1:WH8cY/0fT41Bsf341qzo8v4nx0GCE8FykAA23IVbVmo=
+github.com/redis/go-redis/extra/redisotel/v9 v9.18.0 h1:2dKdoEYBJ0CZCLPiCdvvc7luz3DPwY6hKdzjL6m1eHE=
+github.com/redis/go-redis/extra/redisotel/v9 v9.18.0/go.mod h1:WzkrVG9ro9BwCQD0eJOWn6AGL4Z1CleGflM45w1hu10=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/go.sum
+++ b/go.sum
@@ -107,10 +107,6 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/redis/go-redis/extra/rediscmd/v9 v9.18.0 h1:QY4nmPHLFAJjtT5O4OMUEOxP8WVaRNOFpcbmxT2NLZU=
-github.com/redis/go-redis/extra/rediscmd/v9 v9.18.0/go.mod h1:WH8cY/0fT41Bsf341qzo8v4nx0GCE8FykAA23IVbVmo=
-github.com/redis/go-redis/extra/redisotel/v9 v9.18.0 h1:2dKdoEYBJ0CZCLPiCdvvc7luz3DPwY6hKdzjL6m1eHE=
-github.com/redis/go-redis/extra/redisotel/v9 v9.18.0/go.mod h1:WzkrVG9ro9BwCQD0eJOWn6AGL4Z1CleGflM45w1hu10=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,10 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
+github.com/redis/go-redis/extra/rediscmd/v9 v9.18.0 h1:QY4nmPHLFAJjtT5O4OMUEOxP8WVaRNOFpcbmxT2NLZU=
+github.com/redis/go-redis/extra/rediscmd/v9 v9.18.0/go.mod h1:WH8cY/0fT41Bsf341qzo8v4nx0GCE8FykAA23IVbVmo=
+github.com/redis/go-redis/extra/redisotel/v9 v9.18.0 h1:2dKdoEYBJ0CZCLPiCdvvc7luz3DPwY6hKdzjL6m1eHE=
+github.com/redis/go-redis/extra/redisotel/v9 v9.18.0/go.mod h1:WzkrVG9ro9BwCQD0eJOWn6AGL4Z1CleGflM45w1hu10=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/pkg/database/pool.go
+++ b/pkg/database/pool.go
@@ -5,12 +5,33 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/exaring/otelpgx"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// NewPool creates a new PostgreSQL connection pool from the given database URL.
+// NewPoolConfig parses a database URL and returns a pgxpool.Config with
+// OpenTelemetry tracing enabled. The tracer creates child spans for every
+// Query, QueryRow, Exec, Prepare, and Connect call.
+func NewPoolConfig(databaseURL string) (*pgxpool.Config, error) {
+	cfg, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing database URL: %w", err)
+	}
+	cfg.ConnConfig.Tracer = otelpgx.NewTracer(
+		otelpgx.WithTrimSQLInSpanName(),
+	)
+	return cfg, nil
+}
+
+// NewPool creates a new PostgreSQL connection pool from the given database URL
+// with OpenTelemetry tracing enabled.
 func NewPool(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
-	pool, err := pgxpool.New(ctx, databaseURL)
+	cfg, err := NewPoolConfig(databaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating connection pool: %w", err)
 	}

--- a/pkg/database/pool.go
+++ b/pkg/database/pool.go
@@ -4,9 +4,11 @@ package database
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/exaring/otelpgx"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // NewPoolConfig parses a database URL and returns a pgxpool.Config with
@@ -17,9 +19,16 @@ func NewPoolConfig(databaseURL string) (*pgxpool.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing database URL: %w", err)
 	}
-	cfg.ConnConfig.Tracer = otelpgx.NewTracer(
+	tracerOpts := []otelpgx.Option{
 		otelpgx.WithTrimSQLInSpanName(),
-	)
+	}
+	if u, err := url.Parse(databaseURL); err == nil && u.Hostname() != "" {
+		tracerOpts = append(tracerOpts, otelpgx.WithTracerAttributes(
+			attribute.String("server.address", u.Hostname()),
+			attribute.String("server.port", u.Port()),
+		))
+	}
+	cfg.ConnConfig.Tracer = otelpgx.NewTracer(tracerOpts...)
 	return cfg, nil
 }
 

--- a/pkg/database/pool_test.go
+++ b/pkg/database/pool_test.go
@@ -1,0 +1,27 @@
+package database_test
+
+import (
+	"testing"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/database"
+)
+
+func TestNewPoolConfig_HasTracer(t *testing.T) {
+	// Use a dummy URL — we only need to verify config parsing, not connectivity.
+	databaseURL := "postgres://user:pass@localhost:5432/testdb"
+
+	cfg, err := database.NewPoolConfig(databaseURL)
+	if err != nil {
+		t.Fatalf("NewPoolConfig returned error: %v", err)
+	}
+	if cfg.ConnConfig.Tracer == nil {
+		t.Fatal("expected ConnConfig.Tracer to be set, got nil")
+	}
+}
+
+func TestNewPoolConfig_InvalidURL(t *testing.T) {
+	_, err := database.NewPoolConfig("not-a-valid-url://")
+	if err == nil {
+		t.Fatal("expected error for invalid URL, got nil")
+	}
+}

--- a/services/productpage/internal/pending/pending_test.go
+++ b/services/productpage/internal/pending/pending_test.go
@@ -111,3 +111,28 @@ func TestGetAndReconcile_IsolatesProducts(t *testing.T) {
 		t.Errorf("product-1 reviewer = %q, want alice", reviews[0].Reviewer)
 	}
 }
+
+func TestNewRedisStore_HasTracingHook(t *testing.T) {
+	mr := miniredis.RunT(t)
+	store, err := pending.NewRedisStore("redis://" + mr.Addr())
+	if err != nil {
+		t.Fatalf("NewRedisStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Verify the store was created successfully with tracing.
+	// The tracing hook is transparent — existing operations must still work.
+	ctx := context.Background()
+	err = store.StorePending(ctx, "trace-test", pending.NewReview("tracer", "test", 5))
+	if err != nil {
+		t.Fatalf("StorePending with tracing hook failed: %v", err)
+	}
+
+	reviews, err := store.GetAndReconcile(ctx, "trace-test", nil)
+	if err != nil {
+		t.Fatalf("GetAndReconcile with tracing hook failed: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("got %d reviews, want 1", len(reviews))
+	}
+}

--- a/services/productpage/internal/pending/redis.go
+++ b/services/productpage/internal/pending/redis.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/redis/go-redis/extra/redisotel/v9"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -16,12 +17,23 @@ type RedisStore struct {
 }
 
 // NewRedisStore creates a RedisStore from a Redis URL (e.g. "redis://localhost:6379").
+// The client is instrumented with OpenTelemetry tracing — every command
+// produces a child span with operation name and key.
 func NewRedisStore(redisURL string) (*RedisStore, error) {
 	opts, err := redis.ParseURL(redisURL)
 	if err != nil {
 		return nil, fmt.Errorf("parsing redis URL: %w", err)
 	}
-	return &RedisStore{client: redis.NewClient(opts)}, nil
+
+	client := redis.NewClient(opts)
+
+	if err := redisotel.InstrumentTracing(client,
+		redisotel.WithDBStatement(false),
+	); err != nil {
+		return nil, fmt.Errorf("instrumenting redis tracing: %w", err)
+	}
+
+	return &RedisStore{client: client}, nil
 }
 
 // Ping verifies the connection to Redis.


### PR DESCRIPTION
## Summary

- Add OpenTelemetry tracing to PostgreSQL (otelpgx) and Redis (redisotel) database operations across all services
- Configure Tempo service graph with `peer_attributes` and `enable_virtual_node_label` so PostgreSQL, Redis, and Kafka appear as nodes/edges
- Enable `enable_messaging_system_latency_histogram` for PRODUCER/CONSUMER edge metrics from Argo Events
- Add `server.address` attribute to otelpgx tracer for virtual database node resolution in service graph
- Add `make k8s-traffic` target for generating sample traffic through productpage
- Add design specs and implementation plans for database tracing and Argo Events messaging spans

## Service graph now shows

- `gateway → eventsource → sensor → write-service` (Argo Events CQRS flow)
- `details/ratings/reviews/notification → postgresql` (database virtual nodes)
- `productpage → redis` (cache virtual node)
- `eventsource → sensor` edge with `messaging_system=kafka` label

## Test plan

- [ ] `make test` passes
- [ ] `make k8s-traffic` generates traces visible in Grafana Tempo
- [ ] Service graph shows database virtual nodes (postgresql, redis)
- [ ] Argo Events sensors and EventSources appear in service graph
- [ ] Individual trace view shows correct span kinds (SERVER, CLIENT, PRODUCER, CONSUMER)

🤖 Generated with [Claude Code](https://claude.com/claude-code)