### PR TITLE
feat: k6 load generator for service graph and observability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -481,7 +481,7 @@ k8s-load: ##@Kubernetes Run k6 load test via Docker (default 30s). Usage: DURATI
 k8s-load-start: ##@Kubernetes Deploy k6 CronJob for continuous background load
 	$(k8s-guard)
 	@printf "$(BOLD)Deploying k6 load generator CronJob...$(NC)\n"
-	@$(KUBECTL) apply -k deploy/k6/overlays/local/
+	@$(KUBECTL) kustomize --load-restrictor LoadRestrictionsNone deploy/k6/overlays/local/ | $(KUBECTL) apply -f -
 	@printf "$(GREEN)k6 CronJob deployed. Runs every 10 minutes in namespace $(K8S_NS_BOOKINFO).$(NC)\n"
 	@printf "Use $(CYAN)make k8s-load-stop$(NC) to remove.\n"
 
@@ -489,7 +489,7 @@ k8s-load-start: ##@Kubernetes Deploy k6 CronJob for continuous background load
 k8s-load-stop: ##@Kubernetes Remove k6 CronJob from the cluster
 	$(k8s-guard)
 	@printf "$(BOLD)Removing k6 load generator CronJob...$(NC)\n"
-	@$(KUBECTL) delete -k deploy/k6/overlays/local/ --ignore-not-found
+	@$(KUBECTL) kustomize --load-restrictor LoadRestrictionsNone deploy/k6/overlays/local/ | $(KUBECTL) delete --ignore-not-found -f -
 	@printf "$(GREEN)k6 CronJob removed.$(NC)\n"
 
 # ─── Help ───────────────────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -475,6 +475,7 @@ k8s-load: ##@Kubernetes Run k6 load test via Docker (default 30s). Usage: DURATI
 		-e DURATION=$(DURATION) \
 		-e BASE_RATE=$(BASE_RATE) \
 		-e K6_PROMETHEUS_RW_SERVER_URL=http://host.docker.internal:9090/api/v1/write \
+		-e K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM=true \
 		grafana/k6 run -o experimental-prometheus-rw /scripts/bookinfo-traffic.js
 
 .PHONY: k8s-load-start

--- a/Makefile
+++ b/Makefile
@@ -461,33 +461,36 @@ k8s-logs: ##@Kubernetes Tail logs from bookinfo namespace
 	$(k8s-guard)
 	$(KUBECTL) logs -n $(K8S_NS_BOOKINFO) -l part-of=event-driven-bookinfo -f --max-log-requests=10
 
-# ─── Traffic ─────────────────────────────────────────────────────────────────
+# ─── Load Testing ────────────────────────────────────────────────────────────
 
-GATEWAY_URL := http://localhost:8080
+DURATION  ?= 30s
+BASE_RATE ?= 2
 
-.PHONY: k8s-traffic
-k8s-traffic: ##@Kubernetes Generate sample traffic through the productpage
-	@printf "$(BOLD)Generating sample traffic against $(GATEWAY_URL)...$(NC)\n\n"
-	@printf "$(BOLD)── Read path (GET via productpage → fan-out to backends) ──$(NC)\n"
-	@printf "$(CYAN)[GET]$(NC)  / — home page (productpage → details)\n"
-	@curl -s $(GATEWAY_URL)/ -o /dev/null -w "  HTTP %{http_code}\n"
-	@PRODUCT_ID=$$(curl -s $(GATEWAY_URL)/ | grep -o '/products/[^"]*' | head -1 | sed 's|/products/||'); \
-	if [ -z "$$PRODUCT_ID" ]; then \
-		printf "  $(RED)No products found, skipping product-specific requests$(NC)\n"; \
-	else \
-		printf "$(CYAN)[GET]$(NC)  /products/$$PRODUCT_ID — product page (productpage → details + reviews + ratings)\n"; \
-		curl -s $(GATEWAY_URL)/products/$$PRODUCT_ID -o /dev/null -w "  HTTP %{http_code}\n"; \
-		printf "$(CYAN)[GET]$(NC)  /partials/details/$$PRODUCT_ID — HTMX partial details\n"; \
-		curl -s $(GATEWAY_URL)/partials/details/$$PRODUCT_ID -o /dev/null -w "  HTTP %{http_code}\n"; \
-		printf "$(CYAN)[GET]$(NC)  /partials/reviews/$$PRODUCT_ID — HTMX partial reviews\n"; \
-		curl -s $(GATEWAY_URL)/partials/reviews/$$PRODUCT_ID -o /dev/null -w "  HTTP %{http_code}\n"; \
-		printf "\n$(BOLD)── Write path (POST via productpage → gateway → Argo Events CQRS) ──$(NC)\n"; \
-		printf "$(CYAN)[POST]$(NC) /partials/rating — submit rating+review (productpage → ratings + reviews via gateway)\n"; \
-		curl -s -o /dev/null -X POST $(GATEWAY_URL)/partials/rating \
-			-d "product_id=$$PRODUCT_ID&reviewer=alice&stars=5&text=Excellent+book+on+Go" \
-			-w "  HTTP %{http_code}\n"; \
-	fi
-	@printf "\n$(GREEN)Done. Check traces at http://localhost:3000 (Grafana > Explore > Tempo)$(NC)\n"
+.PHONY: k8s-load
+k8s-load: ##@Kubernetes Run k6 load test via Docker (default 30s). Usage: DURATION=5m BASE_RATE=3 make k8s-load
+	@printf "$(BOLD)Running k6 load test (duration=$(DURATION), rate=$(BASE_RATE) req/s)...$(NC)\n"
+	@docker run --rm \
+		-v $(CURDIR)/test/k6:/scripts \
+		-e BASE_URL=http://host.docker.internal:8080 \
+		-e DURATION=$(DURATION) \
+		-e BASE_RATE=$(BASE_RATE) \
+		-e K6_PROMETHEUS_RW_SERVER_URL=http://host.docker.internal:9090/api/v1/write \
+		grafana/k6 run -o experimental-prometheus-rw /scripts/bookinfo-traffic.js
+
+.PHONY: k8s-load-start
+k8s-load-start: ##@Kubernetes Deploy k6 CronJob for continuous background load
+	$(k8s-guard)
+	@printf "$(BOLD)Deploying k6 load generator CronJob...$(NC)\n"
+	@$(KUBECTL) apply -k deploy/k6/overlays/local/
+	@printf "$(GREEN)k6 CronJob deployed. Runs every 10 minutes in namespace $(K8S_NS_BOOKINFO).$(NC)\n"
+	@printf "Use $(CYAN)make k8s-load-stop$(NC) to remove.\n"
+
+.PHONY: k8s-load-stop
+k8s-load-stop: ##@Kubernetes Remove k6 CronJob from the cluster
+	$(k8s-guard)
+	@printf "$(BOLD)Removing k6 load generator CronJob...$(NC)\n"
+	@$(KUBECTL) delete -k deploy/k6/overlays/local/ --ignore-not-found
+	@printf "$(GREEN)k6 CronJob removed.$(NC)\n"
 
 # ─── Help ───────────────────────────────────────────────────────────────────
 

--- a/deploy/k6/base/cronjob.yaml
+++ b/deploy/k6/base/cronjob.yaml
@@ -38,6 +38,8 @@ spec:
                   value: "1"
                 - name: K6_PROMETHEUS_RW_SERVER_URL
                   value: "http://prometheus-kube-prometheus-prometheus.observability.svc.cluster.local:9090/api/v1/write"
+                - name: K6_PROMETHEUS_RW_TREND_AS_NATIVE_HISTOGRAM
+                  value: "true"
               volumeMounts:
                 - name: k6-scripts
                   mountPath: /scripts

--- a/deploy/k6/base/cronjob.yaml
+++ b/deploy/k6/base/cronjob.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: k6-load-generator
+  labels:
+    app: k6-load-generator
+    part-of: event-driven-bookinfo
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 300
+      template:
+        metadata:
+          labels:
+            app: k6-load-generator
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: k6
+              image: grafana/k6:latest
+              command:
+                - k6
+                - run
+                - -o
+                - experimental-prometheus-rw
+                - /scripts/bookinfo-traffic.js
+              env:
+                - name: BASE_URL
+                  value: "http://gateway.envoy-gateway-system.svc.cluster.local"
+                - name: DURATION
+                  value: "5m"
+                - name: BASE_RATE
+                  value: "1"
+                - name: K6_PROMETHEUS_RW_SERVER_URL
+                  value: "http://prometheus-kube-prometheus-prometheus.observability.svc.cluster.local:9090/api/v1/write"
+              volumeMounts:
+                - name: k6-scripts
+                  mountPath: /scripts
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi
+          volumes:
+            - name: k6-scripts
+              configMap:
+                name: k6-bookinfo-traffic

--- a/deploy/k6/base/kustomization.yaml
+++ b/deploy/k6/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cronjob.yaml
+
+configMapGenerator:
+  - name: k6-bookinfo-traffic
+    options:
+      disableNameSuffixHash: true
+    files:
+      - bookinfo-traffic.js=../../../test/k6/bookinfo-traffic.js

--- a/deploy/k6/overlays/local/kustomization.yaml
+++ b/deploy/k6/overlays/local/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: bookinfo
+
+resources:
+  - ../../base

--- a/deploy/observability/local/dashboards/k6-load-testing.json
+++ b/deploy/observability/local/dashboards/k6-load-testing.json
@@ -15,7 +15,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "10.0.0"
+      "version": "10.1.2"
     },
     {
       "type": "datasource",
@@ -64,11 +64,10 @@
       }
     ]
   },
-  "description": "Visualize k6 OSS results stored in Prometheus",
+  "description": "Visualize k6 OSS results stored in Prometheus with Native Histograms.",
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "gnetId": 19665,
-  "graphTooltip": 2,
+  "graphTooltip": 0,
   "links": [
     {
       "asDropdown": false,
@@ -96,7 +95,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -226,7 +224,7 @@
           {
             "matcher": {
               "id": "byRegexp",
-              "options": "http_req_duration_[a-zA-Z0-9_]+"
+              "options": "http_req_duration_q.*"
             },
             "properties": [
               {
@@ -263,7 +261,7 @@
           "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
@@ -274,7 +272,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(k6_vus{testid=~\"$testid\"})",
+          "expr": "avg(k6_vus{testid=~\"$testid\"})",
           "instant": false,
           "legendFormat": "vus",
           "range": true,
@@ -286,10 +284,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(k6_http_req_duration_$quantile_stat{testid=~\"$testid\"})",
+          "expr": "histogram_quantile($quantile, sum by (le) (rate(k6_http_req_duration_seconds{testid=~\"$testid\"}[$__rate_interval])))",
           "hide": false,
           "instant": false,
-          "legendFormat": "http_req_duration_$quantile_stat",
+          "legendFormat": "http_req_duration_q$quantile",
           "range": true,
           "refId": "C"
         },
@@ -390,10 +388,9 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "textMode": "auto"
       },
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
@@ -453,10 +450,9 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "textMode": "auto"
       },
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
@@ -515,10 +511,9 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "textMode": "auto"
       },
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
@@ -528,19 +523,12 @@
           "editorMode": "code",
           "expr": "sum(irate(k6_http_reqs_total{testid=~\"$testid\"}[$__rate_interval]))",
           "instant": false,
-          "interval": "",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
       "title": "Peak RPS",
-      "transformations": [
-        {
-          "id": "reduce",
-          "options": {}
-        }
-      ],
       "type": "stat"
     },
     {
@@ -548,7 +536,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Select a different Stat to change the query",
+      "description": "Select a different quantile to change the query",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -585,10 +573,9 @@
           "fields": "",
           "values": false
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+        "textMode": "auto"
       },
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
@@ -596,7 +583,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(k6_http_req_duration_$quantile_stat{testid=~\"$testid\"})",
+          "expr": "histogram_quantile($quantile, sum by(le) (rate(k6_http_req_duration_seconds{testid=~\"$testid\"}[$__rate_interval])))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -617,7 +604,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -723,7 +709,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -807,9 +792,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(k6_iteration_duration_$quantile_stat{testid=~\"$testid\"})",
+          "expr": "histogram_quantile($quantile, sum by(le) (rate(k6_iteration_duration_seconds{testid=~\"$testid\"}[$__rate_interval])))",
           "instant": false,
-          "legendFormat": "iteration_duration_$quantile_stat",
+          "legendFormat": "iteration_duration_q$quantile",
           "range": true,
           "refId": "A"
         },
@@ -849,14 +834,13 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Select a different Stat to change the query\n\n<a href=\"https://k6.io/docs/using-k6/metrics/reference/#http\" target=\"_blank\">HTTP-specific built-in metrics</a>",
+      "description": "Select a different quantile to change the query\n\n<a href=\"https://k6.io/docs/using-k6/metrics/reference/#http\" target=\"_blank\">HTTP-specific built-in metrics</a>",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -942,10 +926,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(k6_http_req_blocked_$quantile_stat{testid=~\"$testid\"})",
+          "expr": "histogram_quantile($quantile, sum by(le) (rate(k6_http_req_blocked_seconds{testid=~\"$testid\"}[$__rate_interval])))",
           "hide": false,
           "instant": false,
-          "legendFormat": "http_req_blocked_$quantile_stat",
+          "legendFormat": "http_req_blocked_q$quantile",
           "range": true,
           "refId": "B"
         },
@@ -955,10 +939,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(k6_http_req_tls_handshaking_$quantile_stat{testid=~\"$testid\"})",
+          "expr": "histogram_quantile($quantile, sum by(le) (rate(k6_http_req_tls_handshaking_seconds{testid=~\"$testid\"}[$__rate_interval])))",
           "hide": false,
           "instant": false,
-          "legendFormat": "http_req_tls_handshaking_$quantile_stat",
+          "legendFormat": "http_req_tls_handshaking_q$quantile",
           "range": true,
           "refId": "C"
         },
@@ -968,10 +952,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(k6_http_req_sending_$quantile_stat{testid=~\"$testid\"})",
+          "expr": "histogram_quantile($quantile, sum by(le) (rate(k6_http_req_sending_seconds{testid=~\"$testid\"}[$__rate_interval])))",
           "hide": false,
           "instant": false,
-          "legendFormat": "http_req_sending_$quantile_stat",
+          "legendFormat": "http_req_sending_q$quantile",
           "range": true,
           "refId": "D"
         },
@@ -981,10 +965,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(k6_http_req_waiting_$quantile_stat{testid=~\"$testid\"})",
+          "expr": "histogram_quantile($quantile, sum by(le) (rate(k6_http_req_waiting_seconds{testid=~\"$testid\"}[$__rate_interval])))",
           "hide": false,
           "instant": false,
-          "legendFormat": "http_req_waiting_$quantile_stat",
+          "legendFormat": "http_req_waiting_q$quantile",
           "range": true,
           "refId": "E"
         },
@@ -994,10 +978,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(k6_http_req_receiving_$quantile_stat{testid=~\"$testid\"})",
+          "expr": "histogram_quantile($quantile, sum by(le) (rate(k6_http_req_receiving_seconds{testid=~\"$testid\"}[$__rate_interval])))",
           "hide": false,
           "instant": false,
-          "legendFormat": "http_req_receiving_$quantile_stat",
+          "legendFormat": "http_req_receiving_q$quantile",
           "range": true,
           "refId": "F"
         },
@@ -1007,10 +991,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(k6_http_req_duration_$quantile_stat{testid=~\"$testid\"})",
+          "expr": "histogram_quantile($quantile, sum by(le) (rate(k6_http_req_duration_seconds{testid=~\"$testid\"}[$__rate_interval])))",
           "hide": false,
           "instant": false,
-          "legendFormat": "http_req_duration_$quantile_stat",
+          "legendFormat": "http_req_duration_q$quantile",
           "range": true,
           "refId": "A"
         }
@@ -1023,14 +1007,13 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Select a different Stat to change the query",
+      "description": "Select a different quantile to change the query",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1077,7 +1060,7 @@
           {
             "matcher": {
               "id": "byRegexp",
-              "options": "errors_http_req_duration_[a-zA-Z0-9_]+"
+              "options": "errors_http_req_duration_q.*"
             },
             "properties": [
               {
@@ -1092,7 +1075,7 @@
           {
             "matcher": {
               "id": "byRegexp",
-              "options": "success_http_req_duration_[a-zA-Z0-9_]+"
+              "options": "success_http_req_duration_q.*"
             },
             "properties": [
               {
@@ -1107,22 +1090,7 @@
           {
             "matcher": {
               "id": "byRegexp",
-              "options": "http_req_duration_[a-zA-Z0-9_]+"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "http_req_duration_[a-zA-Z0-9_]+"
+              "options": "http_req_duration_q.*"
             },
             "properties": [
               {
@@ -1162,10 +1130,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(k6_http_req_duration_$quantile_stat{testid=~\"$testid\"})",
+          "expr": "histogram_quantile($quantile, sum by (le) ((rate(k6_http_req_duration_seconds{testid=~\"$testid\"}[$__rate_interval]))))",
           "hide": false,
           "instant": false,
-          "legendFormat": "http_req_duration_$quantile_stat",
+          "legendFormat": "http_req_duration_q$quantile",
           "range": true,
           "refId": "A"
         },
@@ -1175,9 +1143,9 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(k6_http_req_duration_$quantile_stat{testid=~\"$testid\", expected_response=\"true\"})",
+          "expr": "histogram_quantile($quantile, sum by(le) (rate(k6_http_req_waiting_seconds{testid=~\"$testid\", expected_response=\"true\"}[$__rate_interval])))",
           "instant": false,
-          "legendFormat": "success_http_req_duration_$quantile_stat",
+          "legendFormat": "success_http_req_duration_q$quantile",
           "range": true,
           "refId": "C"
         },
@@ -1187,10 +1155,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(k6_http_req_duration_$quantile_stat{testid=~\"$testid\", expected_response=\"false\"})",
+          "expr": "histogram_quantile($quantile, sum by(le) (rate(k6_http_req_waiting_seconds{testid=~\"$testid\", expected_response=\"false\"}[$__rate_interval])))",
           "hide": false,
           "instant": false,
-          "legendFormat": "errors_http_req_duration_$quantile_stat",
+          "legendFormat": "errors_http_req_duration_q$quantile",
           "range": true,
           "refId": "B"
         }
@@ -1210,7 +1178,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1529,6 +1496,7 @@
         "frameIndex": 2,
         "showHeader": true
       },
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
@@ -1536,7 +1504,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg by(name, method, status) (k6_http_req_duration_min{testid=~\"$testid\"})",
+          "expr": "histogram_quantile(0, sum by(le, name, method, status) (rate(k6_http_req_duration_seconds{testid=~\"$testid\"}[$__rate_interval])))",
           "format": "table",
           "hide": false,
           "instant": false,
@@ -1550,7 +1518,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg by(name, method, status) (k6_http_req_duration_max{testid=~\"$testid\"})",
+          "expr": "histogram_quantile(1, sum by(le, name, method, status) (rate(k6_http_req_duration_seconds{testid=~\"$testid\"}[$__rate_interval])))",
           "format": "table",
           "hide": false,
           "instant": false,
@@ -1564,7 +1532,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg by(name, method, status) (k6_http_req_duration_p95{testid=~\"$testid\"})",
+          "expr": "histogram_quantile(0.95, sum by(le, name, method, status) (rate(k6_http_req_duration_seconds{testid=~\"$testid\"}[$__rate_interval])))",
           "format": "table",
           "hide": false,
           "instant": false,
@@ -1578,7 +1546,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg by(name, method, status) (k6_http_req_duration_p99{testid=~\"$testid\"})",
+          "expr": "histogram_quantile(0.99, sum by(le, name, method, status) (rate(k6_http_req_duration_seconds{testid=~\"$testid\"}[$__rate_interval])))",
           "format": "table",
           "hide": false,
           "instant": false,
@@ -1777,6 +1745,7 @@
           }
         ]
       },
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
@@ -1791,6 +1760,19 @@
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "round(k6_checks_rate{testid=~\"$testid\"}, 0.1)",
+          "hide": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Checks list",
@@ -1867,7 +1849,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -1970,14 +1951,17 @@
         "content": "### Visualize other k6 results  \n\nAt the top of the dashboard, click `Add` and select `Visualization` from the dropdown menu. Choose the visualization type and input the PromQL queries for the `k6_` metric(s).\n\nAlternatively, click on the `Explore` icon on the menu bar and input the queries for the `k6_` metric(s). From `Explore`, you can add new Panels to this dashboard. \n\nNote that all <a href=\"https://k6.io/docs/using-k6/metrics/\" target=\"_blank\">k6 metrics</a> are prefixed with the `k6_` namespace when sent to Prometheus.",
         "mode": "markdown"
       },
+      "pluginVersion": "10.1.2",
       "type": "text"
     }
   ],
   "refresh": "",
-  "schemaVersion": 39,
+  "schemaVersion": 38,
+  "style": "dark",
   "tags": [
     "prometheus",
-    "k6"
+    "k6",
+    "native-histogram"
   ],
   "templating": {
     "list": [
@@ -2026,28 +2010,25 @@
         "type": "query"
       },
       {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
+        "current": {
+          "selected": false,
+          "text": "0.99",
+          "value": "0.99"
         },
-        "definition": "metrics(k6_http_req_duration_)",
-        "description": "Statistic for Trend Metrics Queries. The available options depend on the values of the K6_PROMETHEUS_RW_TREND_STATS setting.",
+        "description": "Statistic for Trend Metrics Queries. Calculate the \u03c6-quantile (0 \u2264 \u03c6 \u2264 1) in native histogram metrics.  0=min, 0.5=mean, 0.9=p90, 0.95=p95, 0.99=p99, 1=max",
         "hide": 0,
-        "includeAll": false,
         "label": "Trend Metrics Query",
-        "multi": false,
-        "name": "quantile_stat",
-        "options": [],
-        "query": {
-          "query": "metrics(k6_http_req_duration_)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 2,
-        "regex": "/http_req_duration_(min|max|count|sum|avg|med|p[0-9]+)/g",
+        "name": "quantile",
+        "options": [
+          {
+            "selected": true,
+            "text": "0.95",
+            "value": "0.95"
+          }
+        ],
+        "query": "0.99",
         "skipUrlSync": false,
-        "sort": 2,
-        "type": "query"
+        "type": "textbox"
       },
       {
         "datasource": {
@@ -2065,14 +2046,14 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
-  "timeRangeUpdatedDuringEditOrView": false,
   "timepicker": {},
   "timezone": "",
   "title": "k6 Load Testing",
   "uid": "k6-load-testing",
-  "version": 3,
-  "weekStart": ""
+  "version": 1,
+  "weekStart": "",
+  "gnetId": 18030
 }

--- a/deploy/observability/local/dashboards/k6-load-testing.json
+++ b/deploy/observability/local/dashboards/k6-load-testing.json
@@ -1,0 +1,2078 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Visualize k6 OSS results stored in Prometheus",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 19665,
+  "graphTooltip": 2,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Grafana k6 OSS Docs: Prometheus Remote Write",
+      "tooltip": "Open docs in a new tab",
+      "type": "link",
+      "url": "https://k6.io/docs/results-output/real-time/prometheus-remote-write/"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_req_s_errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "reqps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_req_s"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "vus"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "unit",
+                "value": "VUs"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "http_req_duration_[a-zA-Z0-9_]+"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(k6_vus{testid=~\"$testid\"})",
+          "instant": false,
+          "legendFormat": "vus",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(k6_http_req_duration_$quantile_stat{testid=~\"$testid\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "http_req_duration_$quantile_stat",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(k6_http_reqs_total{testid=~\"$testid\"}[$__rate_interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "http_req_s",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(round(k6_http_req_failed_rate{testid=~\"$testid\"}, 0.1)*100)",
+          "hide": true,
+          "instant": false,
+          "legendFormat": "http_req_failed",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(k6_http_reqs_total{testid=~\"$testid\", expected_response=\"false\"}[$__rate_interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "http_req_s_errors",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Performance Overview",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Performance Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 12
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(k6_http_reqs_total{testid=~\"$testid\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 6,
+        "y": 12
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(k6_http_reqs_total{testid=~\"$testid\", expected_response=\"false\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP request failures",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 12,
+        "y": 12
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(k6_http_reqs_total{testid=~\"$testid\"}[$__rate_interval]))",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Peak RPS",
+      "transformations": [
+        {
+          "id": "reduce",
+          "options": {}
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Select a different Stat to change the query",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 12
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(k6_http_req_duration_$quantile_stat{testid=~\"$testid\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(irate(k6_data_sent_total{testid=~\"$testid\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "data_sent",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(irate(k6_data_received_total{testid=~\"$testid\"}[$__rate_interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "data_received",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Transfer Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dropped_iterations"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(k6_iteration_duration_$quantile_stat{testid=~\"$testid\"})",
+          "instant": false,
+          "legendFormat": "iteration_duration_$quantile_stat",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(k6_dropped_iterations_total{testid=~\"$testid\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "dropped_iterations",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Iterations",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 16,
+      "panels": [],
+      "title": "HTTP",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Select a different Stat to change the query\n\n<a href=\"https://k6.io/docs/using-k6/metrics/reference/#http\" target=\"_blank\">HTTP-specific built-in metrics</a>",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "http_req_duration_[a-zA-Z0-9_]+"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(k6_http_req_blocked_$quantile_stat{testid=~\"$testid\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "http_req_blocked_$quantile_stat",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(k6_http_req_tls_handshaking_$quantile_stat{testid=~\"$testid\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "http_req_tls_handshaking_$quantile_stat",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(k6_http_req_sending_$quantile_stat{testid=~\"$testid\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "http_req_sending_$quantile_stat",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(k6_http_req_waiting_$quantile_stat{testid=~\"$testid\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "http_req_waiting_$quantile_stat",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(k6_http_req_receiving_$quantile_stat{testid=~\"$testid\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "http_req_receiving_$quantile_stat",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(k6_http_req_duration_$quantile_stat{testid=~\"$testid\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "http_req_duration_$quantile_stat",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Latency Timings",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Select a different Stat to change the query",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "errors_http_req_duration_[a-zA-Z0-9_]+"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "success_http_req_duration_[a-zA-Z0-9_]+"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "http_req_duration_[a-zA-Z0-9_]+"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "http_req_duration_[a-zA-Z0-9_]+"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(k6_http_req_duration_$quantile_stat{testid=~\"$testid\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "http_req_duration_$quantile_stat",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(k6_http_req_duration_$quantile_stat{testid=~\"$testid\", expected_response=\"true\"})",
+          "instant": false,
+          "legendFormat": "success_http_req_duration_$quantile_stat",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(k6_http_req_duration_$quantile_stat{testid=~\"$testid\", expected_response=\"false\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "errors_http_req_duration_$quantile_stat",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "HTTP Latency Stats",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_req_s_errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_req_s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_req_s_success"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(k6_http_reqs_total{testid=~\"$testid\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "http_req_s",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(k6_http_reqs_total{testid=~\"$testid\", expected_response=\"false\"}[$__rate_interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "http_req_s_errors",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(k6_http_reqs_total{testid=~\"$testid\", expected_response=\"true\"}[$__rate_interval]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "http_req_s_success",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "HTTP Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "min/max/p95/p99 depends on the available Quantile Stats",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "name"
+            },
+            "properties": [
+              {
+                "id": "filterable",
+                "value": false
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "method"
+            },
+            "properties": [
+              {
+                "id": "filterable",
+                "value": false
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "filterable",
+                "value": false
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "min"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "max"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p95"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 17,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": true,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 2,
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg by(name, method, status) (k6_http_req_duration_min{testid=~\"$testid\"})",
+          "format": "table",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "min",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg by(name, method, status) (k6_http_req_duration_max{testid=~\"$testid\"})",
+          "format": "table",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "max",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg by(name, method, status) (k6_http_req_duration_p95{testid=~\"$testid\"})",
+          "format": "table",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg by(name, method, status) (k6_http_req_duration_p99{testid=~\"$testid\"})",
+          "format": "table",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Requests by URL",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Value #B": {
+                "aggregations": [
+                  "min"
+                ],
+                "operation": "aggregate"
+              },
+              "Value #C": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Value #D": {
+                "aggregations": [
+                  "mean"
+                ],
+                "operation": "aggregate"
+              },
+              "Value #E": {
+                "aggregations": [
+                  "mean"
+                ],
+                "operation": "aggregate"
+              },
+              "method": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "name": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "status": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value #B": 4,
+              "Value #C": 5,
+              "Value #D": 6,
+              "Value #E": 7,
+              "method": 2,
+              "name": 1,
+              "status": 3
+            },
+            "renameByName": {
+              "Value #B": "min",
+              "Value #B (min)": "min",
+              "Value #C": "max",
+              "Value #C (max)": "max",
+              "Value #D": "p95",
+              "Value #D (mean)": "p95",
+              "Value #E": "p99",
+              "Value #E (mean)": "p99"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Checks",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Success Rate"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": false
+              },
+              {
+                "id": "unit",
+                "value": "%"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value (mean)"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "check"
+            },
+            "properties": [
+              {
+                "id": "filterable",
+                "value": false
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 12,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": true,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 2,
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value (count)"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "round(k6_checks_rate{testid=~\"$testid\"}, 0.1)",
+          "format": "table",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Checks list",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "keepLabels": [
+              "__name__",
+              "check"
+            ],
+            "mode": "columns"
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Value": {
+                "aggregations": [
+                  "mean"
+                ],
+                "operation": "aggregate"
+              },
+              "check": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "k6_checks_rate": {
+                "aggregations": [
+                  "sum",
+                  "count"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Success Rate",
+            "binary": {
+              "left": "Value (mean)",
+              "operator": "*",
+              "reducer": "sum",
+              "right": "100"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [],
+            "fields": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Filter by check name to query a particular check",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 100,
+            "axisSoftMin": 0,
+            "barAlignment": -1,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "%"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg(round(k6_checks_rate{testid=~\"$testid\"}, 0.1)*100)",
+          "instant": false,
+          "legendFormat": "k6_checks_rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Checks Success Rate (aggregate individual checks)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 23,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "### Visualize other k6 results  \n\nAt the top of the dashboard, click `Add` and select `Visualization` from the dropdown menu. Choose the visualization type and input the PromQL queries for the `k6_` metric(s).\n\nAlternatively, click on the `Explore` icon on the menu bar and input the queries for the `k6_` metric(s). From `Explore`, you can add new Panels to this dashboard. \n\nNote that all <a href=\"https://k6.io/docs/using-k6/metrics/\" target=\"_blank\">k6 metrics</a> are prefixed with the `k6_` namespace when sent to Prometheus.",
+        "mode": "markdown"
+      },
+      "type": "text"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [
+    "prometheus",
+    "k6"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "${DS_PROMETHEUS}"
+        },
+        "description": "Choose a Prometheus Data Source",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus DS",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(testid)",
+        "description": "Filter by \"testid\" tag. Define it by tagging: k6 run --tag testid=xyz",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Test ID",
+        "multi": true,
+        "name": "testid",
+        "options": [],
+        "query": {
+          "query": "label_values(testid)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "metrics(k6_http_req_duration_)",
+        "description": "Statistic for Trend Metrics Queries. The available options depend on the values of the K6_PROMETHEUS_RW_TREND_STATS setting.",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Trend Metrics Query",
+        "multi": false,
+        "name": "quantile_stat",
+        "options": [],
+        "query": {
+          "query": "metrics(k6_http_req_duration_)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/http_req_duration_(min|max|count|sum|avg|med|p[0-9]+)/g",
+        "skipUrlSync": false,
+        "sort": 2,
+        "type": "query"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "description": "Adhoc filters are applied to all panels. To enable it, go to Dashboard Settings / Variables / adhoc_filter and select the target Prometheus data source.",
+        "filters": [],
+        "hide": 0,
+        "label": "AdhocFilter",
+        "name": "adhoc_filter",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timeRangeUpdatedDuringEditOrView": false,
+  "timepicker": {},
+  "timezone": "",
+  "title": "k6 Load Testing",
+  "uid": "k6-load-testing",
+  "version": 3,
+  "weekStart": ""
+}

--- a/deploy/observability/local/dashboards/kustomization.yaml
+++ b/deploy/observability/local/dashboards/kustomization.yaml
@@ -18,3 +18,10 @@ configMapGenerator:
         grafana_dashboard: "1"
     files:
       - envoy-gateway.json
+  - name: grafana-dashboard-k6-load-testing
+    options:
+      disableNameSuffixHash: true
+      labels:
+        grafana_dashboard: "1"
+    files:
+      - k6-load-testing.json

--- a/docs/superpowers/plans/2026-04-10-k6-load-generator.md
+++ b/docs/superpowers/plans/2026-04-10-k6-load-generator.md
@@ -1,0 +1,508 @@
+# k6 Load Generator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `make k8s-traffic` with a k6-based load generator that runs locally via Docker and continuously inside the cluster via CronJob, with Prometheus metrics and a Grafana dashboard.
+
+**Architecture:** A single k6 JavaScript test script (`test/k6/bookinfo-traffic.js`) exercises all productpage routes with variable request rates. It's used by both a Docker-based local runner (`make k8s-load`) and a Kubernetes CronJob that runs 5-minute load sessions every 10 minutes. k6 pushes metrics to Prometheus via remote write, visualized in a dedicated Grafana dashboard.
+
+**Tech Stack:** k6 (Grafana), Docker (`grafana/k6` image), Kubernetes CronJob, Prometheus remote write, Grafana dashboard
+
+**Spec:** `docs/superpowers/specs/2026-04-10-k6-load-generator-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `test/k6/bookinfo-traffic.js` | Create | k6 test script with read + write paths, variable rate stages |
+| `deploy/k6/base/configmap.yaml` | Create | k6 script as ConfigMap for in-cluster CronJob |
+| `deploy/k6/base/cronjob.yaml` | Create | CronJob running `grafana/k6` every 10 minutes |
+| `deploy/k6/overlays/local/kustomization.yaml` | Create | Kustomize overlay for local cluster |
+| `deploy/observability/local/dashboards/k6-load-testing.json` | Create | Grafana k6 dashboard |
+| `deploy/observability/local/dashboards/kustomization.yaml` | Modify | Add k6 dashboard ConfigMap |
+| `Makefile` | Modify | Replace `k8s-traffic` with `k8s-load`, add `k8s-load-start`/`k8s-load-stop` |
+
+---
+
+### Task 1: Create k6 Test Script
+
+**Files:**
+- Create: `test/k6/bookinfo-traffic.js`
+
+- [ ] **Step 1: Create the k6 test script**
+
+Create `test/k6/bookinfo-traffic.js`:
+
+```javascript
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+// Configuration via environment variables with defaults
+const BASE_URL = __ENV.BASE_URL || 'http://host.docker.internal:8080';
+const BASE_RATE = parseInt(__ENV.BASE_RATE || '2', 10);
+const DURATION = __ENV.DURATION || '30s';
+
+// Parse duration string to seconds for stage calculation
+function parseDuration(d) {
+  const match = d.match(/^(\d+)(s|m|h)$/);
+  if (!match) return 30;
+  const val = parseInt(match[1], 10);
+  switch (match[2]) {
+    case 'h': return val * 3600;
+    case 'm': return val * 60;
+    default:  return val;
+  }
+}
+
+const totalSeconds = parseDuration(DURATION);
+
+// Build aleatory stages: cycle through variable rates
+// Each stage is ~1/6 of total duration
+function buildStages() {
+  const segment = Math.max(Math.ceil(totalSeconds / 6), 1);
+  return [
+    { duration: `${segment}s`, target: BASE_RATE },                    // base
+    { duration: `${segment}s`, target: Math.ceil(BASE_RATE * 2) },     // ramp up
+    { duration: `${segment}s`, target: BASE_RATE },                    // base
+    { duration: `${segment}s`, target: Math.max(1, Math.ceil(BASE_RATE * 0.5)) }, // low
+    { duration: `${segment}s`, target: Math.ceil(BASE_RATE * 3) },     // spike
+    { duration: `${segment}s`, target: BASE_RATE },                    // base
+  ];
+}
+
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    bookinfo: {
+      executor: 'ramping-arrival-rate',
+      startRate: BASE_RATE,
+      timeUnit: '1s',
+      preAllocatedVUs: 5,
+      maxVUs: 20,
+      stages: buildStages(),
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<2000'],
+    http_req_failed: ['rate<0.1'],
+  },
+};
+
+// Discover a product ID from the home page
+function discoverProductId() {
+  const res = http.get(`${BASE_URL}/`);
+  if (res.status === 200 && res.body) {
+    const match = res.body.match(/\/products\/([^"]+)/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+// Cache the product ID across iterations (discovered in setup)
+export function setup() {
+  const productId = discoverProductId();
+  return { productId };
+}
+
+export default function (data) {
+  const productId = data.productId;
+
+  // --- Read path ---
+  // Home page: productpage -> details fan-out
+  const homeRes = http.get(`${BASE_URL}/`);
+  check(homeRes, { 'home 200': (r) => r.status === 200 });
+
+  if (productId) {
+    // Product page: productpage -> details + reviews + ratings
+    http.get(`${BASE_URL}/products/${productId}`);
+
+    // HTMX partials
+    http.get(`${BASE_URL}/partials/details/${productId}`);
+    http.get(`${BASE_URL}/partials/reviews/${productId}`);
+
+    // --- Write path ---
+    // Submit rating + review: productpage -> gateway -> EventSource -> Sensor -> write services
+    const reviewers = ['alice', 'bob', 'carol', 'dave', 'eve'];
+    const reviewer = reviewers[Math.floor(Math.random() * reviewers.length)];
+    const stars = Math.floor(Math.random() * 5) + 1;
+
+    http.post(`${BASE_URL}/partials/rating`, {
+      product_id: productId,
+      reviewer: reviewer,
+      stars: String(stars),
+      text: `k6 load test review by ${reviewer}`,
+    });
+  }
+
+  // Small random sleep to add jitter between requests within an iteration
+  sleep(Math.random() * 0.5);
+}
+```
+
+- [ ] **Step 2: Verify the script parses correctly with Docker**
+
+```bash
+docker run --rm -v $(pwd)/test/k6:/scripts grafana/k6 inspect /scripts/bookinfo-traffic.js
+```
+
+Expected: JSON output showing the script's options (scenarios, thresholds) without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/k6/bookinfo-traffic.js
+git commit -m "feat(k6): add bookinfo traffic load test script
+
+Exercises all productpage routes (read + write paths) with configurable
+ramping-arrival-rate stages for aleatory traffic volume."
+```
+
+---
+
+### Task 2: Replace `make k8s-traffic` with `make k8s-load`
+
+**Files:**
+- Modify: `Makefile:464-491` (Traffic section)
+
+- [ ] **Step 1: Replace the Traffic section in the Makefile**
+
+Replace the entire `# ─── Traffic` section (from line 464 to the blank line before `# ─── Help`) with:
+
+```makefile
+# ─── Load Testing ────────────────────────────────────────────────────────────
+
+DURATION  ?= 30s
+BASE_RATE ?= 2
+
+.PHONY: k8s-load
+k8s-load: ##@Kubernetes Run k6 load test via Docker (default 30s). Usage: DURATION=5m BASE_RATE=3 make k8s-load
+	@printf "$(BOLD)Running k6 load test (duration=$(DURATION), rate=$(BASE_RATE) req/s)...$(NC)\n"
+	@docker run --rm \
+		-v $(CURDIR)/test/k6:/scripts \
+		-e BASE_URL=http://host.docker.internal:8080 \
+		-e DURATION=$(DURATION) \
+		-e BASE_RATE=$(BASE_RATE) \
+		-e K6_PROMETHEUS_RW_SERVER_URL=http://host.docker.internal:9090/api/v1/write \
+		grafana/k6 run -o experimental-prometheus-rw /scripts/bookinfo-traffic.js
+
+.PHONY: k8s-load-start
+k8s-load-start: ##@Kubernetes Deploy k6 CronJob for continuous background load
+	$(k8s-guard)
+	@printf "$(BOLD)Deploying k6 load generator CronJob...$(NC)\n"
+	@$(KUBECTL) apply -k deploy/k6/overlays/local/
+	@printf "$(GREEN)k6 CronJob deployed. Runs every 10 minutes in namespace $(K8S_NS_BOOKINFO).$(NC)\n"
+	@printf "Use $(CYAN)make k8s-load-stop$(NC) to remove.\n"
+
+.PHONY: k8s-load-stop
+k8s-load-stop: ##@Kubernetes Remove k6 CronJob from the cluster
+	$(k8s-guard)
+	@printf "$(BOLD)Removing k6 load generator CronJob...$(NC)\n"
+	@$(KUBECTL) delete -k deploy/k6/overlays/local/ --ignore-not-found
+	@printf "$(GREEN)k6 CronJob removed.$(NC)\n"
+```
+
+- [ ] **Step 2: Verify the Makefile parses correctly**
+
+```bash
+make help | grep k8s-load
+```
+
+Expected: Three entries: `k8s-load`, `k8s-load-start`, `k8s-load-stop`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Makefile
+git commit -m "feat(makefile): replace k8s-traffic with k8s-load using k6 Docker runner
+
+Adds k8s-load (local Docker k6 run), k8s-load-start (deploy CronJob),
+and k8s-load-stop (remove CronJob). Removes old k8s-traffic target."
+```
+
+---
+
+### Task 3: Create Kubernetes CronJob Manifests
+
+**Files:**
+- Create: `deploy/k6/base/configmap.yaml`
+- Create: `deploy/k6/base/cronjob.yaml`
+- Create: `deploy/k6/base/kustomization.yaml`
+- Create: `deploy/k6/overlays/local/kustomization.yaml`
+
+- [ ] **Step 1: Create the base kustomization**
+
+Create `deploy/k6/base/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cronjob.yaml
+
+configMapGenerator:
+  - name: k6-bookinfo-traffic
+    options:
+      disableNameSuffixHash: true
+    files:
+      - bookinfo-traffic.js=../../../test/k6/bookinfo-traffic.js
+```
+
+- [ ] **Step 2: Create the CronJob manifest**
+
+Create `deploy/k6/base/cronjob.yaml`:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: k6-load-generator
+  labels:
+    app: k6-load-generator
+    part-of: event-driven-bookinfo
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 300
+      template:
+        metadata:
+          labels:
+            app: k6-load-generator
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: k6
+              image: grafana/k6:latest
+              command:
+                - k6
+                - run
+                - -o
+                - experimental-prometheus-rw
+                - /scripts/bookinfo-traffic.js
+              env:
+                - name: BASE_URL
+                  value: "http://gateway.envoy-gateway-system.svc.cluster.local"
+                - name: DURATION
+                  value: "5m"
+                - name: BASE_RATE
+                  value: "1"
+                - name: K6_PROMETHEUS_RW_SERVER_URL
+                  value: "http://prometheus-kube-prometheus-prometheus.observability.svc.cluster.local:9090/api/v1/write"
+              volumeMounts:
+                - name: k6-scripts
+                  mountPath: /scripts
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi
+          volumes:
+            - name: k6-scripts
+              configMap:
+                name: k6-bookinfo-traffic
+```
+
+- [ ] **Step 3: Create the local overlay**
+
+Create `deploy/k6/overlays/local/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: bookinfo
+
+resources:
+  - ../../base
+```
+
+- [ ] **Step 4: Verify kustomize renders correctly**
+
+```bash
+kubectl kustomize deploy/k6/overlays/local/
+```
+
+Expected: Valid YAML output with CronJob and ConfigMap in the `bookinfo` namespace.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deploy/k6/
+git commit -m "feat(k6): add CronJob for continuous in-cluster load generation
+
+Runs k6 every 10 minutes with 5m duration and 1 req/s base rate.
+Script mounted from ConfigMap, metrics pushed to Prometheus."
+```
+
+---
+
+### Task 4: Add k6 Grafana Dashboard
+
+**Files:**
+- Create: `deploy/observability/local/dashboards/k6-load-testing.json`
+- Modify: `deploy/observability/local/dashboards/kustomization.yaml`
+
+- [ ] **Step 1: Download the official k6 Prometheus dashboard and save it**
+
+Fetch the official k6 + Prometheus remote write dashboard (Grafana dashboard ID 19665) and save it. Use the Grafana.com API to download:
+
+```bash
+curl -s https://grafana.com/api/dashboards/19665/revisions/latest/download | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+# Patch the datasource to use the local Prometheus uid
+for panel in d.get('panels', []):
+    if 'datasource' in panel:
+        panel['datasource'] = {'type': 'prometheus', 'uid': 'prometheus'}
+    for target in panel.get('targets', []):
+        if 'datasource' in target:
+            target['datasource'] = {'type': 'prometheus', 'uid': 'prometheus'}
+# Remove id so Grafana auto-assigns
+d.pop('id', None)
+d['uid'] = 'k6-load-testing'
+d['title'] = 'k6 Load Testing'
+print(json.dumps(d, indent=2))
+" > deploy/observability/local/dashboards/k6-load-testing.json
+```
+
+If the download or patching fails, create a minimal custom dashboard. The key panels are:
+
+- Request Rate: `sum(rate(k6_http_reqs_total[1m]))`
+- Error Rate: `sum(rate(k6_http_reqs_total{expected_response="false"}[1m]))`
+- P95 Latency: `histogram_quantile(0.95, sum(rate(k6_http_req_duration_seconds_bucket[1m])) by (le))`
+- Active VUs: `k6_vus`
+- Iterations: `sum(rate(k6_iterations_total[1m]))`
+
+- [ ] **Step 2: Add the dashboard to the kustomization**
+
+In `deploy/observability/local/dashboards/kustomization.yaml`, add the k6 dashboard ConfigMap entry:
+
+```yaml
+  - name: grafana-dashboard-k6-load-testing
+    options:
+      disableNameSuffixHash: true
+      labels:
+        grafana_dashboard: "1"
+    files:
+      - k6-load-testing.json
+```
+
+Append this to the existing `configMapGenerator` list.
+
+- [ ] **Step 3: Verify kustomize renders with the new dashboard**
+
+```bash
+kubectl kustomize deploy/observability/local/dashboards/ | head -20
+```
+
+Expected: ConfigMap for `grafana-dashboard-k6-load-testing` appears in the output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/observability/local/dashboards/k6-load-testing.json deploy/observability/local/dashboards/kustomization.yaml
+git commit -m "feat(observability): add k6 load testing Grafana dashboard
+
+Official k6 + Prometheus remote write dashboard (ID 19665) patched
+for local Prometheus datasource UID."
+```
+
+---
+
+### Task 5: Deploy and Verify
+
+**Prerequisites:** The k3d cluster must be running (`make k8s-status`).
+
+- [ ] **Step 1: Run `make k8s-load` locally**
+
+```bash
+make k8s-load
+```
+
+Expected: k6 runs for 30 seconds via Docker, shows progress output with request rate, latency, and check results. All requests should succeed (check rate ~100%).
+
+- [ ] **Step 2: Verify k6 metrics in Prometheus**
+
+```bash
+curl -s 'http://localhost:9090/api/v1/query?query=k6_http_reqs_total' | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+results = data.get('data', {}).get('result', [])
+print(f'k6 metric series: {len(results)}')
+for r in results[:3]:
+    print(f'  {r[\"metric\"].get(\"url\",\"?\")} count={r[\"value\"][1]}')
+"
+```
+
+Expected: Non-zero k6 HTTP request metrics.
+
+- [ ] **Step 3: Apply Grafana dashboards**
+
+```bash
+kubectl --context=k3d-bookinfo-local apply -k deploy/observability/local/dashboards/
+```
+
+Expected: ConfigMaps applied including `grafana-dashboard-k6-load-testing`.
+
+- [ ] **Step 4: Verify k6 dashboard in Grafana**
+
+Open `http://localhost:3000` and navigate to Dashboards. The "k6 Load Testing" dashboard should appear and show data from the previous `make k8s-load` run.
+
+- [ ] **Step 5: Deploy the CronJob for continuous load**
+
+```bash
+make k8s-load-start
+```
+
+Expected: Output confirms CronJob deployed to `bookinfo` namespace.
+
+- [ ] **Step 6: Verify CronJob is scheduled**
+
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo get cronjobs
+```
+
+Expected: `k6-load-generator` CronJob with schedule `*/10 * * * *`.
+
+- [ ] **Step 7: Wait for a CronJob run and verify**
+
+Wait up to 10 minutes for the first CronJob execution, or trigger it manually:
+
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo create job k6-manual-test --from=cronjob/k6-load-generator
+```
+
+Then check the job:
+
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo get jobs -l app=k6-load-generator
+kubectl --context=k3d-bookinfo-local -n bookinfo logs job/k6-manual-test
+```
+
+Expected: k6 output showing successful requests against the in-cluster gateway.
+
+- [ ] **Step 8: Verify service graph stability**
+
+After the k6 job completes, check the Grafana Tempo service graph. With continuous load, all edges should be consistently visible including `gateway -> eventsource` and database virtual nodes.
+
+- [ ] **Step 9: Test `make k8s-load-stop`**
+
+```bash
+make k8s-load-stop
+```
+
+Expected: CronJob removed from the cluster.
+
+- [ ] **Step 10: Commit any fixes from verification**
+
+If any adjustments were needed during verification, commit them now.

--- a/docs/superpowers/specs/2026-04-10-k6-load-generator-design.md
+++ b/docs/superpowers/specs/2026-04-10-k6-load-generator-design.md
@@ -1,0 +1,143 @@
+# k6 Load Generator for Service Graph and Observability
+
+## Problem
+
+The Tempo service graph requires continuous trace data to maintain stable edges between services. In the local k8s environment, low traffic causes Tempo's metrics generator to reset counters between Prometheus scrape intervals, resulting in intermittent or missing edges (e.g., `gateway -> eventsource` appearing and disappearing).
+
+The current `make k8s-traffic` target sends a handful of one-shot requests — insufficient for a consistently populated service graph.
+
+## Goal
+
+Replace `make k8s-traffic` with a k6-based load generator that:
+1. Runs locally via Docker for quick ad-hoc load (`make k8s-load`, default 30s)
+2. Runs continuously inside the cluster via k6 Operator CronJob for always-populated observability data
+3. Produces aleatory (variable) traffic volume to create realistic patterns without overwhelming services
+4. Pushes k6 metrics to Prometheus for a dedicated Grafana dashboard
+
+## Scope
+
+- k6 test script exercising all productpage routes (read + write paths)
+- Docker-based local runner (Makefile target)
+- k6 Operator deployment with CronJob for sustained background load
+- k6 Grafana dashboard
+- Remove existing `make k8s-traffic` target
+
+## Design
+
+### k6 Test Script (`test/k6/bookinfo-traffic.js`)
+
+A single script used by both the local Docker runner and the in-cluster operator. Exercises the full application flow through productpage routes only (no direct `/v1` API calls):
+
+**Read path (every iteration):**
+- `GET /` — home page (productpage -> details fan-out)
+- `GET /products/{id}` — product page (productpage -> details + reviews + ratings fan-out)
+- `GET /partials/details/{id}` — HTMX partial (productpage -> details)
+- `GET /partials/reviews/{id}` — HTMX partial (productpage -> reviews -> ratings)
+
+**Write path (every iteration):**
+- `POST /partials/rating` — submit rating + review (productpage -> gateway -> EventSource -> Sensor -> write services)
+
+The script discovers a real product ID from the home page response (same approach as the current `make k8s-traffic`), falling back gracefully if no products exist.
+
+**Executor:** `ramping-arrival-rate` with stages that cycle through variable request rates. The base rate and duration are configurable via environment variables:
+
+| Env var | Default (local) | Default (cluster) | Description |
+| --- | --- | --- | --- |
+| `BASE_URL` | `http://host.docker.internal:8080` | `http://gateway.envoy-gateway-system.svc.cluster.local` | Target URL |
+| `DURATION` | `30s` | `5m` | Total test duration |
+| `BASE_RATE` | `2` | `1` | Base request rate per second |
+
+Stages cycle through: base rate -> 2x base -> base -> 0.5x base -> 3x base spike -> base. This produces aleatory volume while keeping average throughput predictable.
+
+**Thresholds:** The script includes k6 thresholds (p95 < 2s, error rate < 10%) for basic health validation, but failures don't block — this is load generation, not acceptance testing.
+
+### Local Docker Runner (`make k8s-load`)
+
+Runs k6 via the `grafana/k6` Docker image. Replaces `make k8s-traffic`.
+
+```bash
+make k8s-load                    # 30s default, 2 req/s base rate
+DURATION=5m make k8s-load        # 5 minutes
+BASE_RATE=5 make k8s-load        # higher rate
+```
+
+The Makefile target:
+- Mounts `test/k6/bookinfo-traffic.js` into the container
+- Sets `BASE_URL=http://host.docker.internal:8080` (Docker host networking)
+- Sets `K6_PROMETHEUS_RW_SERVER_URL` to push metrics to local Prometheus (`http://host.docker.internal:9090/api/v1/write`)
+- Uses `-o experimental-prometheus-rw` output for Prometheus metrics
+- Passes `DURATION` and `BASE_RATE` as environment variables
+
+### k6 Operator (Continuous In-Cluster Load)
+
+**Operator deployment:** Add k6-operator Helm chart to `make k8s-observability` (it's an observability concern, not a platform concern). Deployed in the `observability` namespace.
+
+**CronJob approach:** A Kubernetes CronJob creates a k6 TestRun every 10 minutes. Each run lasts 5 minutes with a low base rate (~0.5-1 req/s). This produces:
+- ~150-300 requests per 5-minute run
+- Natural 5-minute gaps between runs (storage breathing room)
+- Self-healing: if a run fails, the next CronJob iteration starts fresh
+- Average ~15-30 req/min sustained, producing enough traces for a stable service graph without overwhelming log/trace/metric storage
+
+**Resource estimates per run (conservative):**
+- Traces: ~150-300 traces x ~10 spans each = ~1500-3000 spans per run
+- Logs: minimal (k6 pods are ephemeral)
+- Metrics: k6 push interval 5s, ~60 data points per metric per run
+
+**Deploy structure:**
+```
+deploy/k6/
+  base/
+    configmap.yaml          # k6 script as ConfigMap
+    cronjob.yaml            # CronJob that creates TestRun-like Jobs
+  overlays/local/
+    kustomization.yaml      # Local patches (namespace, URL, rate)
+```
+
+Note: Since the k6 Operator's TestRun CRD is designed for one-off runs and doesn't support CronJob natively, we use a standard Kubernetes CronJob that runs the `grafana/k6` image directly (not a TestRun CRD). This avoids the operator dependency entirely while achieving the same result: periodic k6 runs inside the cluster.
+
+Actually, this simplifies the design — **we don't need the k6 Operator at all**. A plain CronJob running the `grafana/k6` image with the script mounted from a ConfigMap achieves the same thing with zero operator overhead. The script ConfigMap is shared between the CronJob and the local Docker runner.
+
+### k6 Prometheus Metrics
+
+k6 pushes metrics to Prometheus via remote write (`-o experimental-prometheus-rw`). Both the local Docker runner and the in-cluster CronJob push to the same Prometheus instance.
+
+Key k6 metrics available in Prometheus:
+- `k6_http_req_duration` — request latency histogram
+- `k6_http_reqs` — total request count
+- `k6_http_req_failed` — failure rate
+- `k6_iterations` — completed iterations
+- `k6_vus` — active virtual users
+
+### k6 Grafana Dashboard
+
+Add a k6 dashboard to `deploy/observability/local/dashboards/k6-load-testing.json`. Use the official Grafana community dashboard for k6 + Prometheus remote write (dashboard ID 19665) as a base, customized if needed.
+
+The dashboard shows: request rate, latency percentiles, error rate, active VUs, and iteration throughput — giving visibility into the load generator's behavior alongside the application's observability stack.
+
+## File Map
+
+| File | Action | Purpose |
+| --- | --- | --- |
+| `test/k6/bookinfo-traffic.js` | Create | k6 test script |
+| `deploy/k6/base/configmap.yaml` | Create | Script as ConfigMap for in-cluster CronJob |
+| `deploy/k6/base/cronjob.yaml` | Create | CronJob running k6 every 10 minutes |
+| `deploy/k6/overlays/local/kustomization.yaml` | Create | Local overlay (namespace, URL) |
+| `deploy/observability/local/dashboards/k6-load-testing.json` | Create | Grafana k6 dashboard |
+| `Makefile` | Modify | Replace `k8s-traffic` with `k8s-load`, add `k8s-load-start`/`k8s-load-stop` for CronJob |
+
+## Makefile Targets
+
+| Target | Description |
+| --- | --- |
+| `make k8s-load` | Run k6 locally via Docker (default 30s). Configurable: `DURATION=5m BASE_RATE=3 make k8s-load` |
+| `make k8s-load-start` | Deploy the k6 CronJob to the cluster for continuous background load |
+| `make k8s-load-stop` | Remove the k6 CronJob from the cluster |
+
+## Verification
+
+1. `make k8s-load` runs k6 via Docker, shows k6 output with request stats
+2. k6 metrics appear in Prometheus (`k6_http_req_duration`, `k6_http_reqs`)
+3. k6 Grafana dashboard shows request rate and latency
+4. After `make k8s-load-start`, CronJob creates pods every 10 minutes
+5. Service graph in Grafana shows all edges consistently (no more intermittent nodes)
+6. After `make k8s-load-stop`, CronJob is removed and load stops

--- a/test/k6/bookinfo-traffic.js
+++ b/test/k6/bookinfo-traffic.js
@@ -1,0 +1,103 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+// Configuration via environment variables with defaults
+const BASE_URL = __ENV.BASE_URL || 'http://host.docker.internal:8080';
+const BASE_RATE = parseInt(__ENV.BASE_RATE || '2', 10);
+const DURATION = __ENV.DURATION || '30s';
+
+// Parse duration string to seconds for stage calculation
+function parseDuration(d) {
+  const match = d.match(/^(\d+)(s|m|h)$/);
+  if (!match) return 30;
+  const val = parseInt(match[1], 10);
+  switch (match[2]) {
+    case 'h': return val * 3600;
+    case 'm': return val * 60;
+    default:  return val;
+  }
+}
+
+const totalSeconds = parseDuration(DURATION);
+
+// Build aleatory stages: cycle through variable rates
+// Each stage is ~1/6 of total duration
+function buildStages() {
+  const segment = Math.max(Math.ceil(totalSeconds / 6), 1);
+  return [
+    { duration: `${segment}s`, target: BASE_RATE },                    // base
+    { duration: `${segment}s`, target: Math.ceil(BASE_RATE * 2) },     // ramp up
+    { duration: `${segment}s`, target: BASE_RATE },                    // base
+    { duration: `${segment}s`, target: Math.max(1, Math.ceil(BASE_RATE * 0.5)) }, // low
+    { duration: `${segment}s`, target: Math.ceil(BASE_RATE * 3) },     // spike
+    { duration: `${segment}s`, target: BASE_RATE },                    // base
+  ];
+}
+
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    bookinfo: {
+      executor: 'ramping-arrival-rate',
+      startRate: BASE_RATE,
+      timeUnit: '1s',
+      preAllocatedVUs: 5,
+      maxVUs: 20,
+      stages: buildStages(),
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<2000'],
+    http_req_failed: ['rate<0.1'],
+  },
+};
+
+// Discover a product ID from the home page
+function discoverProductId() {
+  const res = http.get(`${BASE_URL}/`);
+  if (res.status === 200 && res.body) {
+    const match = res.body.match(/\/products\/([^"]+)/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+// Cache the product ID across iterations (discovered in setup)
+export function setup() {
+  const productId = discoverProductId();
+  return { productId };
+}
+
+export default function (data) {
+  const productId = data.productId;
+
+  // --- Read path ---
+  // Home page: productpage -> details fan-out
+  const homeRes = http.get(`${BASE_URL}/`);
+  check(homeRes, { 'home 200': (r) => r.status === 200 });
+
+  if (productId) {
+    // Product page: productpage -> details + reviews + ratings
+    http.get(`${BASE_URL}/products/${productId}`);
+
+    // HTMX partials
+    http.get(`${BASE_URL}/partials/details/${productId}`);
+    http.get(`${BASE_URL}/partials/reviews/${productId}`);
+
+    // --- Write path ---
+    // Submit rating + review: productpage -> gateway -> EventSource -> Sensor -> write services
+    const reviewers = ['alice', 'bob', 'carol', 'dave', 'eve'];
+    const reviewer = reviewers[Math.floor(Math.random() * reviewers.length)];
+    const stars = Math.floor(Math.random() * 5) + 1;
+
+    http.post(`${BASE_URL}/partials/rating`, {
+      product_id: productId,
+      reviewer: reviewer,
+      stars: String(stars),
+      text: `k6 load test review by ${reviewer}`,
+    });
+  }
+
+  // Small random sleep to add jitter between requests within an iteration
+  sleep(Math.random() * 0.5);
+}

--- a/test/k6/bookinfo-traffic.js
+++ b/test/k6/bookinfo-traffic.js
@@ -35,7 +35,6 @@ function buildStages() {
 }
 
 export const options = {
-  discardResponseBodies: true,
   scenarios: {
     bookinfo: {
       executor: 'ramping-arrival-rate',
@@ -49,6 +48,9 @@ export const options = {
   thresholds: {
     http_req_duration: ['p(95)<2000'],
     http_req_failed: ['rate<0.1'],
+  },
+  tags: {
+    testid: `bookinfo-${new Date().toISOString().slice(0, 19)}`,
   },
 };
 
@@ -73,16 +75,20 @@ export default function (data) {
 
   // --- Read path ---
   // Home page: productpage -> details fan-out
-  const homeRes = http.get(`${BASE_URL}/`);
+  const homeRes = http.get(`${BASE_URL}/`, { tags: { name: 'GET /' } });
   check(homeRes, { 'home 200': (r) => r.status === 200 });
 
   if (productId) {
     // Product page: productpage -> details + reviews + ratings
-    http.get(`${BASE_URL}/products/${productId}`);
+    const productRes = http.get(`${BASE_URL}/products/${productId}`, { tags: { name: 'GET /products/{id}' } });
+    check(productRes, { 'product 200': (r) => r.status === 200 });
 
     // HTMX partials
-    http.get(`${BASE_URL}/partials/details/${productId}`);
-    http.get(`${BASE_URL}/partials/reviews/${productId}`);
+    const detailsRes = http.get(`${BASE_URL}/partials/details/${productId}`, { tags: { name: 'GET /partials/details/{id}' } });
+    check(detailsRes, { 'details 200': (r) => r.status === 200 });
+
+    const reviewsRes = http.get(`${BASE_URL}/partials/reviews/${productId}`, { tags: { name: 'GET /partials/reviews/{id}' } });
+    check(reviewsRes, { 'reviews 200': (r) => r.status === 200 });
 
     // --- Write path ---
     // Submit rating + review: productpage -> gateway -> EventSource -> Sensor -> write services
@@ -90,12 +96,13 @@ export default function (data) {
     const reviewer = reviewers[Math.floor(Math.random() * reviewers.length)];
     const stars = Math.floor(Math.random() * 5) + 1;
 
-    http.post(`${BASE_URL}/partials/rating`, {
+    const ratingRes = http.post(`${BASE_URL}/partials/rating`, {
       product_id: productId,
       reviewer: reviewer,
       stars: String(stars),
       text: `k6 load test review by ${reviewer}`,
-    });
+    }, { tags: { name: 'POST /partials/rating' } });
+    check(ratingRes, { 'rating 200': (r) => r.status === 200 });
   }
 
   // Small random sleep to add jitter between requests within an iteration


### PR DESCRIPTION
## Summary

- Add k6 load test script (`test/k6/bookinfo-traffic.js`) exercising all productpage routes with aleatory traffic volume via `ramping-arrival-rate` executor
- Replace `make k8s-traffic` with `make k8s-load` running k6 via Docker (configurable: `DURATION=5m BASE_RATE=3 make k8s-load`)
- Add Kubernetes CronJob (`make k8s-load-start`) for continuous background load — runs 5-minute k6 sessions every 10 minutes at ~1 req/s
- k6 metrics pushed to Prometheus via remote write for both local and in-cluster runs
- Add official k6 Grafana dashboard (ID 19665) for load test visibility

## Why

The Tempo service graph requires continuous trace data. Low traffic causes metrics counter resets between Prometheus scrape intervals, resulting in intermittent edges. Continuous k6 load keeps the graph stable.

## Test plan

- [ ] `make k8s-load` runs k6 via Docker, 100% checks passing
- [ ] k6 metrics visible in Prometheus (`k6_http_reqs_total`)
- [ ] k6 Grafana dashboard shows data
- [ ] `make k8s-load-start` deploys CronJob running every 10 minutes
- [ ] `make k8s-load-stop` removes the CronJob
- [ ] Service graph shows all edges consistently with continuous load

🤖 Generated with [Claude Code](https://claude.com/claude-code)