### PR TITLE
fix(release): checkout at tag ref for GoReleaser validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag }}
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary

- GoReleaser validates that `GORELEASER_CURRENT_TAG` exists as a git tag on the checked-out commit
- Without `ref`, checkout defaults to HEAD which doesn't have the stripped `v0.1.0` tag
- Adding `ref: ${{ inputs.tag }}` ensures GoReleaser finds the prefixed tag on the correct commit

Found during validation of `details-v0.1.0` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)