### PR TITLE
fix(release): handle prefixed tags in GoReleaser OSS monorepo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Create local version tag for GoReleaser
+        run: git tag "${{ steps.version.outputs.version }}"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -77,3 +80,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.version.outputs.version }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ inputs.tag }}" \
+            --title "${{ inputs.service }} ${{ steps.version.outputs.version }}" \
+            --generate-notes \
+            dist/*.tar.gz

--- a/services/details/.goreleaser.yaml
+++ b/services/details/.goreleaser.yaml
@@ -58,5 +58,8 @@ docker_manifests:
       - "ghcr.io/kaio6fellipe/event-driven-bookinfo/details:{{ .Tag }}-amd64"
       - "ghcr.io/kaio6fellipe/event-driven-bookinfo/details:{{ .Tag }}-arm64"
 
+release:
+  disable: true
+
 changelog:
   use: github

--- a/services/notification/.goreleaser.yaml
+++ b/services/notification/.goreleaser.yaml
@@ -58,5 +58,8 @@ docker_manifests:
       - "ghcr.io/kaio6fellipe/event-driven-bookinfo/notification:{{ .Tag }}-amd64"
       - "ghcr.io/kaio6fellipe/event-driven-bookinfo/notification:{{ .Tag }}-arm64"
 
+release:
+  disable: true
+
 changelog:
   use: github

--- a/services/productpage/.goreleaser.yaml
+++ b/services/productpage/.goreleaser.yaml
@@ -58,5 +58,8 @@ docker_manifests:
       - "ghcr.io/kaio6fellipe/event-driven-bookinfo/productpage:{{ .Tag }}-amd64"
       - "ghcr.io/kaio6fellipe/event-driven-bookinfo/productpage:{{ .Tag }}-arm64"
 
+release:
+  disable: true
+
 changelog:
   use: github

--- a/services/ratings/.goreleaser.yaml
+++ b/services/ratings/.goreleaser.yaml
@@ -58,5 +58,8 @@ docker_manifests:
       - "ghcr.io/kaio6fellipe/event-driven-bookinfo/ratings:{{ .Tag }}-amd64"
       - "ghcr.io/kaio6fellipe/event-driven-bookinfo/ratings:{{ .Tag }}-arm64"
 
+release:
+  disable: true
+
 changelog:
   use: github

--- a/services/reviews/.goreleaser.yaml
+++ b/services/reviews/.goreleaser.yaml
@@ -58,5 +58,8 @@ docker_manifests:
       - "ghcr.io/kaio6fellipe/event-driven-bookinfo/reviews:{{ .Tag }}-amd64"
       - "ghcr.io/kaio6fellipe/event-driven-bookinfo/reviews:{{ .Tag }}-arm64"
 
+release:
+  disable: true
+
 changelog:
   use: github


### PR DESCRIPTION
## Summary

- GoReleaser OSS validates `GORELEASER_CURRENT_TAG` exists as a git tag on HEAD
- With prefixed tags (`details-v0.1.0`), the stripped version (`v0.1.0`) doesn't exist, causing failure
- Fix: disable GoReleaser's GitHub Release (Docker push still works), create local version tag, create release manually with `gh release create` using the prefixed tag

Found during validation of `details-v0.1.0` first release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)