### PR TITLE
fix(release): disable GoReleaser changelog for local-only tags

### DIFF
--- a/services/details/.goreleaser.yaml
+++ b/services/details/.goreleaser.yaml
@@ -62,4 +62,4 @@ release:
   disable: true
 
 changelog:
-  use: github
+  disable: true

--- a/services/notification/.goreleaser.yaml
+++ b/services/notification/.goreleaser.yaml
@@ -62,4 +62,4 @@ release:
   disable: true
 
 changelog:
-  use: github
+  disable: true

--- a/services/productpage/.goreleaser.yaml
+++ b/services/productpage/.goreleaser.yaml
@@ -62,4 +62,4 @@ release:
   disable: true
 
 changelog:
-  use: github
+  disable: true

--- a/services/ratings/.goreleaser.yaml
+++ b/services/ratings/.goreleaser.yaml
@@ -62,4 +62,4 @@ release:
   disable: true
 
 changelog:
-  use: github
+  disable: true

--- a/services/reviews/.goreleaser.yaml
+++ b/services/reviews/.goreleaser.yaml
@@ -62,4 +62,4 @@ release:
   disable: true
 
 changelog:
-  use: github
+  disable: true


### PR DESCRIPTION
## Summary

- GoReleaser's GitHub changelog provider tries to compare previous tag with current tag via GitHub API
- The local-only version tag (v0.1.0) doesn't exist on GitHub, causing a 404
- Disable GoReleaser changelog — release notes are generated by `gh release create --generate-notes` instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)