### PR TITLE
fix(release): correct templates path in productpage goreleaser Dockerfile

### DIFF
--- a/build/Dockerfile.goreleaser.productpage
+++ b/build/Dockerfile.goreleaser.productpage
@@ -1,5 +1,5 @@
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY productpage /bin/productpage
-COPY templates/ /templates/
+COPY services/productpage/templates/ /templates/
 ENV TEMPLATE_DIR=/templates
 ENTRYPOINT ["/bin/productpage"]


### PR DESCRIPTION
## Summary

- GoReleaser `extra_files` preserves directory structure in Docker context
- Templates end up at `services/productpage/templates/`, not `templates/`
- Fix COPY path in Dockerfile.goreleaser.productpage

🤖 Generated with [Claude Code](https://claude.com/claude-code)