### PR TITLE
fix(release): correct auto-tag sort flag from refversion to refname

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -90,7 +90,7 @@ jobs:
 
           for SERVICE in $(echo "$SERVICES" | jq -r '.[]'); do
             # Get latest tag for this service
-            LATEST_TAG=$(git tag -l "${SERVICE}-v*" --sort=-v:refversion | head -1)
+            LATEST_TAG=$(git tag -l "${SERVICE}-v*" --sort=-v:refname | head -1)
 
             if [ -z "$LATEST_TAG" ]; then
               CURRENT="0.0.0"


### PR DESCRIPTION
## Summary

The auto-tag workflow failed on merge of #20 with:

\`\`\`
fatal: unknown field name: refversion
Tagging productpage: 0.0.0 -> 0.1.0 (minor)
fatal: tag 'productpage-v0.1.0' already exists
\`\`\`

\`git tag --sort\` does not recognize \`refversion\`. The correct field is \`refname\` (the \`v:\` prefix makes it version-aware). The invalid flag caused \`git tag -l\` to fail silently, \`LATEST_TAG\` ended up empty, every service defaulted to \`CURRENT=0.0.0\`, and the script tried to recreate the already-existing \`*-v0.1.0\` tags.

## Fix

\`--sort=-v:refversion\` → \`--sort=-v:refname\` in \`.github/workflows/auto-tag.yml\`.

## Follow-up

After this merges, the idempotency release (merged as #20) will need manual tag+release dispatch for all 5 services at \`v0.2.0\` since auto-tag missed them.

## Test plan

- [x] Fix applied, workflow YAML valid
- [ ] Verify on next PR merge that auto-tag succeeds
- [ ] Manually dispatch \`*-v0.2.0\` releases for the 5 services after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)