### PR TITLE
docs(readme): drop Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 <p align="center">
   <a href="https://github.com/kaio6fellipe/event-driven-bookinfo/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://github.com/kaio6fellipe/event-driven-bookinfo/actions/workflows/ci.yml/badge.svg" alt="CI Status" /></a>
   <a href="https://pkg.go.dev/github.com/kaio6fellipe/event-driven-bookinfo"><img src="https://pkg.go.dev/badge/github.com/kaio6fellipe/event-driven-bookinfo.svg" alt="Go Reference" /></a>
-  <a href="https://goreportcard.com/report/github.com/kaio6fellipe/event-driven-bookinfo"><img src="https://goreportcard.com/badge/github.com/kaio6fellipe/event-driven-bookinfo" alt="Go Report Card" /></a>
   <a href="https://go.dev/"><img src="https://img.shields.io/github/go-mod/go-version/kaio6fellipe/event-driven-bookinfo?color=%239F50DA&label=Go" alt="Go Version" /></a>
   <a href="https://unlicense.org/"><img src="https://img.shields.io/badge/license-Unlicense-blue.svg" alt="License" /></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/kaio6fellipe/event-driven-bookinfo"><img src="https://api.securityscorecards.dev/projects/github.com/kaio6fellipe/event-driven-bookinfo/badge" alt="OpenSSF Scorecard" /></a>


### PR DESCRIPTION
## Summary

Removes the Go Report Card badge from the top-of-README block.

## Why

Go Report Card resolves modules via `proxy.golang.org/<module>/@latest`, which requires at least one Go-semver tag at the module root (e.g. `v0.1.0`). This monorepo tags only per-service (`<service>-v<X.Y.Z>`) with no root tag, so Go Report Card always errors out:

```
go: module github.com/kaio6fellipe/event-driven-bookinfo: no matching versions for query "latest"
```

Keeping the badge in its "error" state is a bad look. Dropping until a per-service alternative is added.

## Test plan

- [ ] Top-block renders 6 badges (CI, Go Reference, Go Version, License, OpenSSF Scorecard, Conventional Commits) with no broken image slots.
- [ ] Services table unchanged.