### PR TITLE
fix(ci): run go tool cover from main checkout for coverage badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,10 +232,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout badges branch
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
-          ref: badges
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.2"
 
       - name: Download per-service coverage profiles
         uses: actions/download-artifact@v4
@@ -243,14 +248,10 @@ jobs:
           name: coverage-per-service
           path: ${{ runner.temp }}/coverage
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.26.2"
-
       - name: Generate badge JSON
         run: |
           set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/badges-out"
           color_for() {
             local pct=$1
             local n=${pct%.*}
@@ -267,21 +268,28 @@ jobs:
             if [ ! -s "$profile" ] || [ "$(wc -l < "$profile")" -le 1 ]; then
               pct="0.0"
             else
+              # go tool cover needs to run from a dir with go.mod (we're on main)
               pct=$(go tool cover -func="$profile" | awk '/^total:/ {gsub(/%/,"",$3); print $3}')
               if [ -z "$pct" ]; then pct="0.0"; fi
             fi
             color=$(color_for "$pct")
             printf '{"schemaVersion":1,"label":"coverage","message":"%s%%","color":"%s","cacheSeconds":60}\n' \
-              "$pct" "$color" > "coverage-$svc.json"
+              "$pct" "$color" > "${RUNNER_TEMP}/badges-out/coverage-$svc.json"
             echo "$svc -> $pct% ($color)"
           done
 
-      - name: Commit updated badges
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
-        with:
-          branch: badges
-          commit_message: "chore(badges): update coverage [skip ci]"
-          file_pattern: "coverage-*.json"
-          commit_user_name: "github-actions[bot]"
-          commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
-          commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+      - name: Publish to badges branch
+        run: |
+          set -euo pipefail
+          git worktree add -B badges badges-wt origin/badges
+          cp "${RUNNER_TEMP}/badges-out/"coverage-*.json badges-wt/
+          cd badges-wt
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add coverage-*.json
+          if git diff --cached --quiet; then
+            echo "No badge changes — nothing to publish"
+            exit 0
+          fi
+          git commit -m "chore(badges): update coverage [skip ci]"
+          git push origin badges


### PR DESCRIPTION
## Summary

Follow-up to #25. The `coverage-badges` job failed because `go tool cover -func` requires a `go.mod` context, and the previous setup checked out the `badges` branch (which has no module). The awk-based fallback I tried drifts 0.5–1pp from the authoritative value.

## Fix

- Checkout `main` for Go module context.
- Set up Go, run `go tool cover -func` against each downloaded per-service profile, write JSON to `$RUNNER_TEMP/badges-out`.
- Materialize the `badges` branch via `git worktree`, copy the JSON in, commit, and push via the default `GITHUB_TOKEN`.
- Drop `stefanzweifel/git-auto-commit-action` in favor of plain git (clearer control flow for this multi-checkout scenario).

## Test plan

- [ ] PR CI runs green; `coverage-badges` is skipped on the PR.
- [ ] After merge to `main`, `coverage-badges` runs, pushes to `badges`, and `coverage-<service>.json` files on the `badges` branch update with real percentages.
- [ ] Shields.io endpoint badges in the Services table reflect the new percentages.