### PR TITLE
feat(ci): OSSF Scorecard 7+ hardening with PR quality gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files
+* @kaio6fellipe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           go-version: "1.26.2"
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.2.0
 
       - name: Run govulncheck
         run: make vuln

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -8,13 +8,14 @@ on:
     paths:
       - "charts/**"
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   release:
     name: Release Chart
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/scorecard-pr.yml
+++ b/.github/workflows/scorecard-pr.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           set -euo pipefail
           scorecard --repo="github.com/${{ github.repository }}" \
+            --commit="${{ github.event.pull_request.head.sha }}" \
             --format=json --show-details > scorecard.json
           SCORE=$(jq -r '.score' scorecard.json)
           echo "score=${SCORE}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/scorecard-pr.yml
+++ b/.github/workflows/scorecard-pr.yml
@@ -1,0 +1,125 @@
+name: Scorecard PR Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  scorecard-check:
+    name: Scorecard Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      checks: read
+    env:
+      SCORECARD_VERSION: "5.4.0"
+      SCORECARD_CHECKSUM: "e5183aeaa5aa548fbb7318a6deb3e1038be0ef9aca24e655422ae88dfbe67502"
+      SCORE_THRESHOLD: "7.0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install scorecard CLI
+        run: |
+          set -euo pipefail
+          TARBALL="scorecard_${SCORECARD_VERSION}_linux_amd64.tar.gz"
+          curl -sLO "https://github.com/ossf/scorecard/releases/download/v${SCORECARD_VERSION}/${TARBALL}"
+          echo "${SCORECARD_CHECKSUM}  ${TARBALL}" | sha256sum --check --strict
+          tar xzf "${TARBALL}" scorecard
+          chmod +x scorecard
+          sudo mv scorecard /usr/local/bin/scorecard
+          rm "${TARBALL}"
+
+      - name: Run scorecard
+        id: scorecard
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          scorecard --repo="github.com/${{ github.repository }}" \
+            --format=json --show-details > scorecard.json
+          SCORE=$(jq -r '.score' scorecard.json)
+          echo "score=${SCORE}" >> "$GITHUB_OUTPUT"
+          echo "Scorecard overall score: ${SCORE}"
+
+      - name: Comment on PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const data = JSON.parse(fs.readFileSync('scorecard.json', 'utf8'));
+            const score = data.score;
+            const threshold = parseFloat('${{ env.SCORE_THRESHOLD }}');
+            const passed = score >= threshold;
+            const icon = passed ? ':white_check_mark:' : ':x:';
+            const repo = '${{ github.repository }}';
+
+            // Build check table sorted by name
+            const checks = data.checks
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map(c => {
+                const s = c.score === -1 ? 'N/A' : `${c.score}/10`;
+                // Escape pipe characters and truncate reason to 80 chars
+                const raw = (c.reason || '').replace(/\|/g, '\\|');
+                const reason = raw.length > 80
+                  ? raw.substring(0, 77) + '...'
+                  : raw;
+                return `| ${c.name} | ${s} | ${reason} |`;
+              })
+              .join('\n');
+
+            let body = `## OpenSSF Scorecard — ${score}/10 ${icon}\n\n`;
+            body += `| Check | Score | Details |\n`;
+            body += `|-------|-------|---------|`;
+            body += `\n${checks}\n\n`;
+
+            if (!passed) {
+              body += `> :rotating_light: Score ${score} is below threshold ${threshold} — this check will fail.\n\n`;
+            }
+
+            body += `> Threshold: ${threshold} | [Full report](https://securityscorecards.dev/viewer/?uri=github.com/${repo})\n`;
+
+            // Marker to find/update this comment
+            const marker = '<!-- ossf-scorecard-pr-check -->';
+            body = marker + '\n' + body;
+
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }
+
+      - name: Enforce threshold
+        run: |
+          SCORE="${{ steps.scorecard.outputs.score }}"
+          THRESHOLD="${{ env.SCORE_THRESHOLD }}"
+          if [ "$(echo "${SCORE} < ${THRESHOLD}" | bc -l)" -eq 1 ]; then
+            echo "::error::OpenSSF Scorecard score ${SCORE} is below threshold ${THRESHOLD}"
+            exit 1
+          fi
+          echo "Scorecard score ${SCORE} meets threshold ${THRESHOLD}"

--- a/docs/superpowers/plans/2026-04-14-ossf-scorecard-7plus.md
+++ b/docs/superpowers/plans/2026-04-14-ossf-scorecard-7plus.md
@@ -1,0 +1,428 @@
+# OSSF Scorecard 7+ Hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Raise OSSF Scorecard from 6.9 to 7.0+ and add a PR quality gate that comments the score and blocks merges below threshold.
+
+**Architecture:** Five targeted fixes to existing workflow files and GitHub settings, plus one new workflow for PR-level scorecard checking. All code changes ship in a single PR; ruleset updates apply post-merge via `gh api`.
+
+**Tech Stack:** GitHub Actions YAML, OSSF Scorecard CLI v5.4.0, `actions/github-script` for PR commenting, `gh` CLI for ruleset updates.
+
+**Spec:** `docs/superpowers/specs/2026-04-14-ossf-scorecard-7plus-design.md`
+
+---
+
+### Task 1: Fix helm-release.yml Token Permissions
+
+**Files:**
+- Modify: `.github/workflows/helm-release.yml:11-12`
+
+- [ ] **Step 1: Move permissions from workflow level to job level**
+
+In `.github/workflows/helm-release.yml`, replace the top-level `permissions` block and add job-level permissions:
+
+```yaml
+# Line 11-12: replace
+permissions:
+  contents: write
+
+# With
+permissions: {}
+```
+
+And add `permissions` to the job:
+
+```yaml
+# Line 14-16: replace
+jobs:
+  release:
+    name: Release Chart
+    runs-on: ubuntu-latest
+
+# With
+jobs:
+  release:
+    name: Release Chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/helm-release.yml'))" && echo "YAML valid"`
+
+Expected: `YAML valid`
+
+- [ ] **Step 3: Verify all workflows have restrictive top-level permissions**
+
+Run: `for f in .github/workflows/*.yml; do echo "=== $f ==="; head -15 "$f" | grep -A2 "^permissions"; done`
+
+Expected: Every workflow shows either `permissions: {}` or `permissions: read-all` at the top level. No workflow has write permissions at the top level.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/helm-release.yml
+git commit -m "fix(ci): scope helm-release permissions to job level
+
+Scorecard Token-Permissions check requires write permissions
+scoped to individual jobs, not at the workflow level."
+```
+
+---
+
+### Task 2: Pin govulncheck Version
+
+**Files:**
+- Modify: `.github/workflows/ci.yml:125`
+
+- [ ] **Step 1: Pin govulncheck to v1.2.0**
+
+In `.github/workflows/ci.yml`, replace line 125:
+
+```yaml
+# Before
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+# After
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.2.0
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo "YAML valid"`
+
+Expected: `YAML valid`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "fix(ci): pin govulncheck to v1.2.0
+
+Scorecard Pinned-Dependencies check flags @latest as unpinned.
+Dependabot github-actions ecosystem will keep this updated."
+```
+
+---
+
+### Task 3: Add CODEOWNERS File
+
+**Files:**
+- Create: `.github/CODEOWNERS`
+
+- [ ] **Step 1: Create CODEOWNERS file**
+
+Create `.github/CODEOWNERS` with the following content:
+
+```
+# Default code owners for all files
+* @kaio6fellipe
+```
+
+- [ ] **Step 2: Verify file is recognized by GitHub's CODEOWNERS parser**
+
+Run: `cat .github/CODEOWNERS`
+
+Expected: The file contains `* @kaio6fellipe` — a single rule matching all files, assigning the repository owner.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/CODEOWNERS
+git commit -m "chore: add CODEOWNERS for branch protection scoring
+
+Scorecard Branch-Protection check requires a CODEOWNERS file
+and codeowner review enforcement in the ruleset."
+```
+
+---
+
+### Task 4: Add Scorecard PR Check Workflow
+
+**Files:**
+- Create: `.github/workflows/scorecard-pr.yml`
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/scorecard-pr.yml`:
+
+```yaml
+name: Scorecard PR Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  scorecard-check:
+    name: Scorecard Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      checks: read
+    env:
+      SCORECARD_VERSION: "5.4.0"
+      SCORECARD_CHECKSUM: "e5183aeaa5aa548fbb7318a6deb3e1038be0ef9aca24e655422ae88dfbe67502"
+      SCORE_THRESHOLD: "7.0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install scorecard CLI
+        run: |
+          set -euo pipefail
+          TARBALL="scorecard_${SCORECARD_VERSION}_linux_amd64.tar.gz"
+          curl -sLO "https://github.com/ossf/scorecard/releases/download/v${SCORECARD_VERSION}/${TARBALL}"
+          echo "${SCORECARD_CHECKSUM}  ${TARBALL}" | sha256sum --check --strict
+          tar xzf "${TARBALL}" scorecard
+          chmod +x scorecard
+          sudo mv scorecard /usr/local/bin/scorecard
+          rm "${TARBALL}"
+
+      - name: Run scorecard
+        id: scorecard
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          scorecard --repo="github.com/${{ github.repository }}" \
+            --format=json --show-details > scorecard.json
+          SCORE=$(jq -r '.score' scorecard.json)
+          echo "score=${SCORE}" >> "$GITHUB_OUTPUT"
+          echo "Scorecard overall score: ${SCORE}"
+
+      - name: Comment on PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const data = JSON.parse(fs.readFileSync('scorecard.json', 'utf8'));
+            const score = data.score;
+            const threshold = parseFloat('${{ env.SCORE_THRESHOLD }}');
+            const passed = score >= threshold;
+            const icon = passed ? ':white_check_mark:' : ':x:';
+            const repo = '${{ github.repository }}';
+
+            // Build check table sorted by name
+            const checks = data.checks
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map(c => {
+                const s = c.score === -1 ? 'N/A' : `${c.score}/10`;
+                // Truncate reason to 80 chars
+                const reason = (c.reason || '').length > 80
+                  ? c.reason.substring(0, 77) + '...'
+                  : (c.reason || '');
+                return `| ${c.name} | ${s} | ${reason} |`;
+              })
+              .join('\n');
+
+            let body = `## OpenSSF Scorecard — ${score}/10 ${icon}\n\n`;
+            body += `| Check | Score | Details |\n`;
+            body += `|-------|-------|---------|`;
+            body += `\n${checks}\n\n`;
+
+            if (!passed) {
+              body += `> :rotating_light: Score ${score} is below threshold ${threshold} — this check will fail.\n\n`;
+            }
+
+            body += `> Threshold: ${threshold} | [Full report](https://securityscorecards.dev/viewer/?uri=github.com/${repo})\n`;
+
+            // Marker to find/update this comment
+            const marker = '<!-- ossf-scorecard-pr-check -->';
+            body = marker + '\n' + body;
+
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }
+
+      - name: Enforce threshold
+        run: |
+          SCORE="${{ steps.scorecard.outputs.score }}"
+          THRESHOLD="${{ env.SCORE_THRESHOLD }}"
+          if [ "$(echo "${SCORE} < ${THRESHOLD}" | bc -l)" -eq 1 ]; then
+            echo "::error::OpenSSF Scorecard score ${SCORE} is below threshold ${THRESHOLD}"
+            exit 1
+          fi
+          echo "Scorecard score ${SCORE} meets threshold ${THRESHOLD}"
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scorecard-pr.yml'))" && echo "YAML valid"`
+
+Expected: `YAML valid`
+
+- [ ] **Step 3: Verify permissions follow the project pattern**
+
+Run: `head -12 .github/workflows/scorecard-pr.yml`
+
+Expected: Top-level `permissions: {}` with write permissions scoped to the job.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/scorecard-pr.yml
+git commit -m "feat(ci): add scorecard PR quality gate
+
+Runs OSSF Scorecard CLI on every PR, comments the score
+breakdown on the PR, and fails the check if below 7.0.
+
+Uses scorecard v5.4.0 with SHA256 checksum verification."
+```
+
+---
+
+### Task 5: Update Ruleset via GitHub API
+
+This task runs AFTER the PR from Tasks 1-4 is merged, to avoid blocking that PR itself with the new requirements.
+
+**Files:** None (GitHub API calls only)
+
+- [ ] **Step 1: Enable codeowner review requirement**
+
+Run:
+
+```bash
+gh api --method PUT repos/kaio6fellipe/event-driven-bookinfo/rulesets/14813558 \
+  --input - <<'EOF'
+{
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["~DEFAULT_BRANCH"]
+    }
+  },
+  "rules": [
+    {"type": "deletion"},
+    {"type": "non_fast_forward"},
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [],
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["squash"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {"context": "E2E Tests", "integration_id": 15368},
+          {"context": "E2E Tests (PostgreSQL)", "integration_id": 15368},
+          {"context": "Lint", "integration_id": 15368},
+          {"context": "Vet", "integration_id": 15368},
+          {"context": "Test", "integration_id": 15368},
+          {"context": "Build", "integration_id": 15368},
+          {"context": "Docker Build + Scan", "integration_id": 15368},
+          {"context": "Analyze Go", "integration_id": 15368}
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "pull_request"}
+  ]
+}
+EOF
+```
+
+Expected: HTTP 200 response with the updated ruleset JSON showing `require_code_owner_review: true` and `Analyze Go` in the required status checks.
+
+- [ ] **Step 2: Verify the ruleset update**
+
+Run:
+
+```bash
+gh api repos/kaio6fellipe/event-driven-bookinfo/rulesets/14813558 \
+  --jq '.rules[] | select(.type == "pull_request") | .parameters.require_code_owner_review'
+```
+
+Expected: `true`
+
+- [ ] **Step 3: Verify CodeQL is a required check**
+
+Run:
+
+```bash
+gh api repos/kaio6fellipe/event-driven-bookinfo/rulesets/14813558 \
+  --jq '.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[].context'
+```
+
+Expected: Output includes `Analyze Go` alongside the existing checks.
+
+---
+
+### Task 6: Verify Score Improvement
+
+This task runs after the PR is merged and the ruleset is updated.
+
+- [ ] **Step 1: Trigger a fresh scorecard analysis**
+
+Run:
+
+```bash
+gh workflow run "OSSF Scorecard" --ref main
+```
+
+Expected: Workflow dispatched successfully.
+
+- [ ] **Step 2: Wait for the scorecard run to complete**
+
+Run:
+
+```bash
+gh run list --workflow=scorecard.yml --limit=1
+```
+
+Expected: Most recent run shows `completed` with `success` status.
+
+- [ ] **Step 3: Verify the score on the public dashboard**
+
+Check: `https://securityscorecards.dev/viewer/?uri=github.com/kaio6fellipe/event-driven-bookinfo`
+
+Expected: Overall score >= 7.0. Specific improvements:
+- Token-Permissions: 10/10 (was 0)
+- Pinned-Dependencies: 9/10 (was 8)
+- Branch-Protection: 10/10 (was 8)
+
+Note: SAST will improve gradually as new commits accumulate CodeQL results. Vulnerabilities stays at 8/10 until upstream pgx fix is released (GO-2026-4771, GO-2026-4772 have `Fixed in: N/A`).

--- a/docs/superpowers/specs/2026-04-14-ossf-scorecard-7plus-design.md
+++ b/docs/superpowers/specs/2026-04-14-ossf-scorecard-7plus-design.md
@@ -1,0 +1,226 @@
+# OSSF Scorecard 7+ Hardening — Design Spec
+
+**Date:** 2026-04-14
+**Baseline:** 6.9/10 (after initial hardening from 3.6)
+**Goal:** Raise OSSF Scorecard to 7.0+ and add a PR quality gate
+**Approach:** Max all remaining fixable checks; add scorecard PR check workflow
+
+## Current State (6.9/10)
+
+| Check | Current | Target | Action |
+|-------|---------|--------|--------|
+| Token-Permissions | 0 | 10 | Fix `helm-release.yml` top-level permissions |
+| Pinned-Dependencies | 8 | 9 | Pin `govulncheck@latest` to specific version |
+| Branch-Protection | 8 | 10 | Add CODEOWNERS + enable codeowner review |
+| Vulnerabilities | 8 | 10 | Update Go deps for GO-2026-4771/4772 |
+| SAST | 7 | 10 | Add CodeQL as required status check (improves over time) |
+| Code-Review | 0 | 0 | No change — solo project |
+| Maintained | 0 | 0 | No change — time-based, auto-resolves |
+| CII-Best-Practices | 0 | 0 | No change — not needed for 7+ |
+| Contributors | 3 | 3 | No change — requires multi-org contributions |
+| All others | 10 | 10 | Already maxed |
+
+**Projected: ~7.6-7.9/10** (143/18 = 7.9 assuming all targets hit)
+
+## Section 1: Workflow Permission Fix (Token-Permissions 0 -> 10)
+
+### Problem
+
+`helm-release.yml` has `permissions: contents: write` at the workflow level. Scorecard requires write permissions scoped to job level, not workflow level.
+
+### Fix
+
+Move permissions to job level, set top-level to `{}`:
+
+```yaml
+# Before
+permissions:
+  contents: write
+
+jobs:
+  release:
+    steps: ...
+
+# After
+permissions: {}
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    steps: ...
+```
+
+All other workflows already follow this pattern correctly.
+
+## Section 2: Pin govulncheck Version (Pinned-Dependencies 8 -> 9)
+
+### Problem
+
+`ci.yml` uses `go install golang.org/x/vuln/cmd/govulncheck@latest` — scorecard flags `@latest` as an unpinned dependency.
+
+### Fix
+
+Pin to a specific version:
+
+```bash
+go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+```
+
+### Not Fixable
+
+`slsa-framework/slsa-github-generator@v2.1.0` is a reusable workflow that cannot be SHA-pinned. The SLSA generator uses the tag ref for OIDC token verification — their documentation explicitly prohibits SHA pinning. This is an accepted limitation; target is 9/10, not 10/10.
+
+## Section 3: CODEOWNERS + Branch Protection (Branch-Protection 8 -> 10)
+
+### Problem
+
+Scorecard flags: "requires only 1 approval, lacks codeowner requirement."
+
+### Fix — CODEOWNERS File
+
+Create `.github/CODEOWNERS`:
+
+```
+# Default owners for everything
+* @kaio6fellipe
+```
+
+### Fix — Ruleset Update
+
+Update the existing `main` ruleset (ID: 14813558) via GitHub API to set `require_code_owner_review: true`.
+
+Current ruleset pull_request rule parameters:
+- `required_approving_review_count: 1` — keep
+- `dismiss_stale_reviews_on_push: true` — keep
+- `require_code_owner_review: false` — change to `true`
+- `require_last_push_approval: true` — keep
+- `allowed_merge_methods: ["squash"]` — keep
+
+The 1-approval requirement stays — increasing to 2 would block a solo maintainer. CODEOWNERS + codeowner review is what scorecard specifically checks for.
+
+## Section 4: Go Vulnerability Fixes (Vulnerabilities 8 -> 10)
+
+### Problem
+
+Two known unfixed vulnerabilities: `GO-2026-4771` and `GO-2026-4772`.
+
+### Fix
+
+```bash
+govulncheck ./...          # identify affected packages
+go get -u <affected-deps>  # update specific vulnerable modules
+go mod tidy                # clean up
+```
+
+The `govulncheck` CI job validates the fix — it runs on every PR and fails on known vulns.
+
+## Section 5: SAST Coverage (SAST 7 -> 10)
+
+### Problem
+
+"CodeQL configured but only covers 9 of 30 commits." The 30-commit window includes older commits that predate the CodeQL workflow.
+
+### Fix
+
+Add `Analyze Go` (the CodeQL job name) as a required status check in the `main` ruleset. This ensures every future PR has a CodeQL run before merge.
+
+No workflow file changes needed — the `codeql.yml` workflow already triggers on `push: main` and `pull_request: main`.
+
+The SAST score will improve naturally as new commits with CodeQL results replace old uncovered commits in the 30-commit window. After ~21 more PRs merge, the ratio reaches 30/30.
+
+## Section 6: Scorecard PR Check Workflow (Quality Gate)
+
+### Purpose
+
+Prevent score regressions by running the scorecard CLI on every PR and failing if the score drops below 7.0.
+
+### Workflow: `.github/workflows/scorecard-pr.yml`
+
+**Trigger:** `pull_request` targeting `main`
+
+**Permissions:**
+```yaml
+permissions: {}
+
+jobs:
+  scorecard-check:
+    permissions:
+      contents: read
+      pull-requests: write   # comment on PR
+      issues: read           # scorecard reads issue data
+      checks: read           # scorecard reads check results
+```
+
+**Steps:**
+
+1. **Checkout** — `actions/checkout` with `persist-credentials: false`
+
+2. **Install scorecard CLI** — download v5.4.0 binary for linux/amd64, verify SHA256 checksum against published `scorecard_checksums.txt`, extract to PATH.
+
+3. **Run scorecard** — execute against the GitHub API (not local):
+   ```bash
+   GITHUB_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+     scorecard --repo=github.com/${{ github.repository }} \
+     --format=json --show-details > scorecard.json
+   ```
+   Extract overall score to job output.
+
+4. **Comment on PR** — use `actions/github-script` to:
+   - Parse `scorecard.json`
+   - Build markdown table with all checks, scores, and truncated reasons
+   - Post/update a single PR comment (use comment marker to avoid duplicates)
+   - Include pass/fail indicator and link to full report on securityscorecards.dev
+
+5. **Enforce threshold** — fail the job if overall score < threshold (default 7.0, configurable via `workflow_dispatch` input).
+
+### PR Comment Format
+
+```markdown
+## OpenSSF Scorecard — 7.9/10 :white_check_mark:
+
+| Check | Score | Details |
+|-------|-------|---------|
+| Binary-Artifacts | 10/10 | no binary artifacts found |
+| Branch-Protection | 10/10 | branch protection settings found |
+| CI-Tests | 10/10 | 30 out of 30 merged PRs checked |
+| ... | ... | ... |
+
+> Threshold: 7.0 | [Full report](https://securityscorecards.dev/viewer/?uri=github.com/kaio6fellipe/event-driven-bookinfo)
+```
+
+When score < threshold:
+```markdown
+## OpenSSF Scorecard — 6.5/10 :x:
+
+...same table...
+
+> :rotating_light: Score 6.5 is below threshold 7.0 — this check will fail.
+```
+
+### Caveat
+
+The scorecard scores the current repo state (main branch + GitHub settings), not the post-merge state. This acts as a quality gate: if the score is below 7, no PRs can merge until repo-level fixes bring it back up. It cannot preview what a specific PR's diff would do to the score.
+
+### Rate Limiting
+
+The scorecard CLI makes GitHub API calls. To avoid rate limiting on repos with high PR volume, the workflow only runs on PRs targeting `main` (not feature-to-feature branches).
+
+## Implementation Order
+
+1. Fix `helm-release.yml` permissions (trivial, unblocks Token-Permissions)
+2. Pin `govulncheck` version in `ci.yml`
+3. Add `.github/CODEOWNERS`
+4. Update Go dependencies for vulnerability fixes
+5. Add scorecard PR check workflow (`scorecard-pr.yml`)
+6. Update ruleset via GitHub API (codeowner review + CodeQL required check)
+
+Steps 1-5 are code changes in a single PR. Step 6 is a GitHub API call executed after the PR merges (to avoid blocking the PR itself with the new requirements).
+
+## Out of Scope
+
+- **CII-Best-Practices badge:** Requires external questionnaire at bestpractices.coreinfrastructure.org — not needed for 7+
+- **Code-Review:** Solo project, no second reviewer available. Score stays at 0.
+- **Maintained:** Time-based check, auto-resolves after 90 days of activity
+- **Contributors:** Requires contributions from multiple organizations
+- **SLSA generator SHA pinning:** Reusable workflow cannot be SHA-pinned per SLSA project requirements


### PR DESCRIPTION
## Summary

- Fix `helm-release.yml` token permissions — move `contents: write` from workflow level to job level (Token-Permissions 0 → 10)
- Pin `govulncheck@latest` to `v1.2.0` in CI workflow (Pinned-Dependencies 8 → 9)
- Add `CODEOWNERS` file for branch protection scoring (Branch-Protection 8 → 10)
- Add new `scorecard-pr.yml` workflow — runs OSSF Scorecard CLI on PRs, comments score breakdown, fails if below 7.0

**Projected score improvement:** 6.9 → ~7.6

### Post-merge follow-up (not in this PR)

- Update `main` ruleset: enable codeowner review + add CodeQL as required status check
- Trigger fresh scorecard analysis to verify score >= 7.0

### Not addressed (by design)

- Code-Review (0) — solo project, no second reviewer
- Maintained (0) — time-based, auto-resolves after 90 days
- CII-Best-Practices (0) — not needed for 7+
- Vulnerabilities (8) — pgx CVEs have `Fixed in: N/A`

## Test plan

- [ ] Verify `helm-release.yml` has `permissions: {}` top-level, `contents: write` at job level
- [ ] Verify `ci.yml` has `govulncheck@v1.2.0` (not `@latest`)
- [ ] Verify `.github/CODEOWNERS` exists with `* @kaio6fellipe`
- [ ] Verify `scorecard-pr.yml` YAML is valid and follows permission patterns
- [ ] Post-merge: update ruleset via `gh api` and trigger scorecard analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)