### PR TITLE
docs(ingestion): update documentation and fix gateway URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Go hexagonal architecture monorepo adapting Istio's Bookinfo as a **book review system with event-driven architecture**. Services are plain REST APIs — all event-driven complexity (Kafka consumers, retries) is abstracted by Argo Events EventSources and Sensors. Failed events that exhaust sensor retries are captured by the `dlqueue` service for inspection and replay. Full observability: structured logging, distributed tracing, metrics, continuous profiling.
+Go hexagonal architecture monorepo adapting Istio's Bookinfo as a **book review system with event-driven architecture**. Services are plain REST APIs — all event-driven complexity (Kafka consumers, retries) is abstracted by Argo Events EventSources and Sensors. Failed events that exhaust sensor retries are captured by the `dlqueue` service for inspection and replay. A standalone `ingestion` service polls the Open Library API and publishes `book-added` events through the Gateway, demonstrating the system as a self-hosted event broker. Full observability: structured logging, distributed tracing, metrics, continuous profiling.
 
 **Module**: `github.com/kaio6fellipe/event-driven-bookinfo`
 
@@ -16,6 +16,7 @@ Go hexagonal architecture monorepo adapting Istio's Bookinfo as a **book review 
 | **ratings** | Backend (hex arch) | :8080 / :9090 admin | Star ratings |
 | **notification** | Backend (hex arch) | :8080 / :9090 admin | Event consumer audit log |
 | **dlqueue** | Backend (hex arch) | :8080 / :9090 admin | Dead letter queue for failed sensor deliveries; REST API for inspection, replay, and resolution |
+| **ingestion** | Producer (hex arch) | :8080 / :9090 admin | Open Library scraper; polls on interval, publishes book-added events to the Gateway |
 
 ## Architecture
 
@@ -29,15 +30,16 @@ Go hexagonal architecture monorepo adapting Istio's Bookinfo as a **book review 
 - **Local k8s** (`make run-k8s`): k3d cluster with Envoy Gateway API, Strimzi Kafka (KRaft), full observability stack (Prometheus, Grafana, Tempo, Loki, Pyroscope, Alloy)
 - **DLQ**: sensor `dlqTrigger` → `dlq-event-received` EventSource → `dlqueue-write` → PostgreSQL. Dedup by natural key (`sensor_name + failed_trigger + SHA-256(payload)`). State machine: `pending → replayed → resolved / poisoned`. REST API at `/v1/events` supports list/get/replay/resolve/reset plus batch operations.
 - **Idempotency**: all write services (reviews, ratings, details, notification, dlqueue) dedupe on client-supplied `idempotency_key` or derived natural key (SHA-256 of business fields). Prerequisite for safe DLQ replay — CloudEvents `id` cannot be used because Argo Events regenerates it per EventSource pass.
+- **Ingestion**: `ingestion` service polls Open Library on `POLL_INTERVAL` → for each query in `SEARCH_QUERIES` → `POST {GATEWAY_URL}/v1/details` with `idempotency_key=ingestion-isbn-<ISBN>`. Stateless, single deployment, no CQRS split, no EventSource/Sensor of its own. Exercises the full write pipeline end-to-end.
 
 ## Build Commands
 
 ```bash
-make build-all          # Build all 6 service binaries to bin/
+make build-all          # Build all 7 service binaries to bin/
 make test               # go test -race -count=1 ./...
 make lint               # golangci-lint run
 make e2e                # Docker Compose + shell smoke tests (memory backend)
-make docker-build-all   # Build all 6 Docker images
+make docker-build-all   # Build all 7 Docker images
 ```
 
 ## Helm Commands
@@ -70,7 +72,7 @@ make k8s-logs           # Tail bookinfo namespace logs
 
 ```
 charts/
-  bookinfo-service/          # Reusable Helm chart for all 6 services
+  bookinfo-service/          # Reusable Helm chart for all 7 services
     Chart.yaml
     values.yaml
     templates/
@@ -111,6 +113,16 @@ SERVICE_NAME=notification HTTP_PORT=8084 ADMIN_PORT=9094 go run ./services/notif
 SERVICE_NAME=dlqueue HTTP_PORT=8085 ADMIN_PORT=9095 go run ./services/dlqueue/cmd/
 ```
 
+**ingestion** (publishes to Gateway; requires Gateway/productpage reachable):
+```bash
+SERVICE_NAME=ingestion HTTP_PORT=8086 ADMIN_PORT=9096 \
+  GATEWAY_URL=http://localhost:8080 \
+  POLL_INTERVAL=5m \
+  SEARCH_QUERIES=programming,golang \
+  MAX_RESULTS_PER_QUERY=10 \
+  go run ./services/ingestion/cmd/
+```
+
 **productpage** (depends on details + reviews):
 ```bash
 SERVICE_NAME=productpage HTTP_PORT=8080 ADMIN_PORT=9090 \
@@ -119,7 +131,7 @@ SERVICE_NAME=productpage HTTP_PORT=8080 ADMIN_PORT=9090 \
   go run ./services/productpage/cmd/
 ```
 
-Optional env vars (all services): `LOG_LEVEL` (debug/info/warn/error, default info), `OTEL_EXPORTER_OTLP_ENDPOINT`, `PYROSCOPE_SERVER_ADDRESS`, `STORAGE_BACKEND` (memory/postgres), `DATABASE_URL`. Productpage-specific: `REDIS_URL` (enables pending review cache; disabled when unset).
+Optional env vars (all services): `LOG_LEVEL` (debug/info/warn/error, default info), `OTEL_EXPORTER_OTLP_ENDPOINT`, `PYROSCOPE_SERVER_ADDRESS`, `STORAGE_BACKEND` (memory/postgres), `DATABASE_URL`. Productpage-specific: `REDIS_URL` (enables pending review cache; disabled when unset). Ingestion-specific: `GATEWAY_URL`, `POLL_INTERVAL`, `SEARCH_QUERIES`, `MAX_RESULTS_PER_QUERY`.
 
 ## Shared Packages (`pkg/`)
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ flowchart LR
 
 Go hexagonal architecture monorepo adapting Istio's Bookinfo as a book review system, demonstrating real-time event-driven architecture with Argo Events and Kafka.
 
-Services are plain REST APIs — all event-driven complexity (Kafka consumers, retries, dead-letter queues) is abstracted by Argo Events EventSources and Sensors. The write path flows through Kafka via Argo Events, ensuring every mutation is event-sourced, while the read path remains synchronous HTTP. Failure recovery is built into the pipeline — a `dlqTrigger` on every sensor captures events that exhaust retries into the `dlqueue` service, where they can be inspected, replayed, or marked resolved. This demonstrates using Argo Events not only for workflow automation, but as a real-time event-driven architecture platform — a self-hosted alternative to Google Eventarc or AWS EventBridge.
+Services are plain REST APIs — all event-driven complexity (Kafka consumers, retries, dead-letter queues) is abstracted by Argo Events EventSources and Sensors. The write path flows through Kafka via Argo Events, ensuring every mutation is event-sourced, while the read path remains synchronous HTTP. Failure recovery is built into the pipeline — a `dlqTrigger` on every sensor captures events that exhaust retries into the `dlqueue` service, where they can be inspected, replayed, or marked resolved. This demonstrates using Argo Events not only for workflow automation, but as a real-time event-driven architecture platform — a self-hosted alternative to Google Eventarc or AWS EventBridge. A standalone `ingestion` service demonstrates the pipeline as a self-hosted event broker — it polls the Open Library API and publishes synthetic book-added events through the same Gateway → EventSource → Kafka → Sensor path used by the UI.
 
 ## Architecture Overview
 
@@ -101,6 +101,7 @@ graph TD
     PP["productpage (BFF)"]
     GW["Gateway (CQRS routing)"]
     WH["External POST /v1/*"]
+    ING["ingestion<br/>Open Library poller"]
     ES["Argo Events<br/>EventSource (webhook)"]
     K["Kafka EventBus<br/>CloudEvent + traceparent"]
 
@@ -122,6 +123,7 @@ graph TD
     Browser --> PP
     PP -->|"POST /v1/* via gateway"| GW
     WH --> GW
+    ING -->|"POST /v1/details"| GW
     GW -->|"method: POST"| ES
     ES --> K
 
@@ -158,6 +160,7 @@ graph TD
     style DLQES fill:#22c55e,color:#fff,stroke:#16a34a
     style DLQS fill:#1a1d27,color:#e4e4e7,stroke:#a855f7
     style DLQW fill:#1a1d27,color:#e4e4e7,stroke:#a855f7
+    style ING fill:#1a1d27,color:#e4e4e7,stroke:#10b981
 ```
 
 Reads are synchronous HTTP calls between services. Writes are fully async via the Envoy Gateway's method-based CQRS routing — POST requests are routed to Argo Events webhook EventSources, which publish to the Kafka EventBus. Sensors consume events and fire HTTP triggers against the write services. The gateway acts as the CQRS boundary, while services remain plain HTTP servers with no Kafka dependency.
@@ -184,6 +187,7 @@ All service wiring happens in `services/<name>/cmd/main.go`. The shared `pkg/` p
 | **ratings** | [![release](https://img.shields.io/github/v/release/kaio6fellipe/event-driven-bookinfo?filter=ratings-v*&sort=semver&display_name=tag&label=release)](https://github.com/kaio6fellipe/event-driven-bookinfo/releases?q=ratings-v&expanded=true) | [![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kaio6fellipe/event-driven-bookinfo/badges/coverage-ratings.json)](https://github.com/kaio6fellipe/event-driven-bookinfo/actions/workflows/ci.yml?query=branch%3Amain) | Backend | 8083 | 9093 | Star ratings per reviewer. Event-written via `rating-submitted` sensor. |
 | **notification** | [![release](https://img.shields.io/github/v/release/kaio6fellipe/event-driven-bookinfo?filter=notification-v*&sort=semver&display_name=tag&label=release)](https://github.com/kaio6fellipe/event-driven-bookinfo/releases?q=notification-v&expanded=true) | [![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kaio6fellipe/event-driven-bookinfo/badges/coverage-notification.json)](https://github.com/kaio6fellipe/event-driven-bookinfo/actions/workflows/ci.yml?query=branch%3Amain) | Event consumer | 8084 | 9094 | Receives POST from sensors, stores audit log. Exposes GET for review. |
 | **dlqueue** | [![release](https://img.shields.io/github/v/release/kaio6fellipe/event-driven-bookinfo?filter=dlqueue-v*&sort=semver&display_name=tag&label=release)](https://github.com/kaio6fellipe/event-driven-bookinfo/releases?q=dlqueue-v&expanded=true) | [![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kaio6fellipe/event-driven-bookinfo/badges/coverage-dlqueue.json)](https://github.com/kaio6fellipe/event-driven-bookinfo/actions/workflows/ci.yml?query=branch%3Amain) | Backend (hex arch) | 8085 | 9095 | Captures events failing sensor retry exhaustion; stores in PostgreSQL; supports replay via REST API |
+| **ingestion** | [![release](https://img.shields.io/github/v/release/kaio6fellipe/event-driven-bookinfo?filter=ingestion-v*&sort=semver&display_name=tag&label=release)](https://github.com/kaio6fellipe/event-driven-bookinfo/releases?q=ingestion-v&expanded=true) | [![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kaio6fellipe/event-driven-bookinfo/badges/coverage-ingestion.json)](https://github.com/kaio6fellipe/event-driven-bookinfo/actions/workflows/ci.yml?query=branch%3Amain) | Producer (hex arch) | 8086 | 9096 | Polls Open Library for books on a configurable interval and publishes `book-added` events to the Gateway. Stateless; no storage adapters. |
 
 All services expose their business API on the API port and observability endpoints (`/metrics`, `/healthz`, `/readyz`, `/debug/pprof/*`) on the admin port.
 
@@ -247,6 +251,14 @@ SERVICE_NAME=productpage HTTP_PORT=8080 ADMIN_PORT=9090 \
   TEMPLATE_DIR=services/productpage/templates \
   ./bin/productpage
 
+# Optional standalone demo — polls Open Library and publishes to the Gateway
+SERVICE_NAME=ingestion HTTP_PORT=8086 ADMIN_PORT=9096 \
+  GATEWAY_URL=http://localhost:8080 \
+  POLL_INTERVAL=5m \
+  SEARCH_QUERIES=programming,golang \
+  MAX_RESULTS_PER_QUERY=10 \
+  ./bin/ingestion
+
 # Open in browser
 open http://localhost:8080
 ```
@@ -268,7 +280,7 @@ make stop         # Stop and remove containers
 | Target | Description |
 |---|---|
 | `make build SERVICE=<name>` | Build a single service binary to `bin/<name>` |
-| `make build-all` | Build all 6 service binaries |
+| `make build-all` | Build all 7 service binaries |
 | `make test` | Run all tests |
 | `make test-cover` | Run tests with HTML coverage report |
 | `make test-race` | Run tests with the race detector |
@@ -277,7 +289,7 @@ make stop         # Stop and remove containers
 | `make vet` | Run go vet |
 | `make mod-tidy` | Tidy go module dependencies |
 | `make docker-build SERVICE=<name>` | Build Docker image for one service |
-| `make docker-build-all` | Build Docker images for all 6 services |
+| `make docker-build-all` | Build Docker images for all 7 services |
 | `make run` | Start all services via Docker Compose (PostgreSQL backend) |
 | `make stop` | Stop services and remove containers |
 | `make e2e` | Run E2E tests via docker-compose |
@@ -326,6 +338,7 @@ ghcr.io/kaio6fellipe/event-driven-bookinfo/reviews:<tag>
 ghcr.io/kaio6fellipe/event-driven-bookinfo/ratings:<tag>
 ghcr.io/kaio6fellipe/event-driven-bookinfo/notification:<tag>
 ghcr.io/kaio6fellipe/event-driven-bookinfo/dlqueue:<tag>
+ghcr.io/kaio6fellipe/event-driven-bookinfo/ingestion:<tag>
 ```
 
 ---
@@ -394,6 +407,7 @@ graph TD
 
         DLQR["dlqueue"]
         DLQW["dlqueue-write"]
+        ING["ingestion"]
 
         ES["EventSources"]
         EB["EventBus"]
@@ -430,13 +444,14 @@ graph TD
     S -->|"dlqTrigger<br/>(on failure)"| DLQW
 
     DR & DW & RR & RW & RTR & RTW & N & DLQR & DLQW --> PG
+    ING -.->|"outbound HTTPS"| GW
     PP --> Redis
 
     Alloy -.->|scrape :9090/metrics| PP
     Alloy -.->|OTLP traces| Tempo
     Alloy -.->|remote_write| Prom
     Alloy -.->|push logs| Loki
-    PP & DR & DW & RR & RW & RTR & RTW & N & DLQR & DLQW -.->|push profiles| Pyro
+    PP & DR & DW & RR & RW & RTR & RTW & N & DLQR & DLQW & ING -.->|push profiles| Pyro
     Prom & Tempo & Loki & Pyro --> Grafana
 
     style Browser fill:#6366f1,color:#fff,stroke:#818cf8
@@ -453,6 +468,7 @@ graph TD
     style Grafana fill:#e879f9,color:#000,stroke:#c026d3
     style PG fill:#3b82f6,color:#fff,stroke:#2563eb
     style Redis fill:#ef4444,color:#fff,stroke:#dc2626
+    style ING fill:#1a1d27,color:#e4e4e7,stroke:#10b981
 ```
 
 The cluster (`bookinfo-local`) runs four namespaces:
@@ -462,7 +478,7 @@ The cluster (`bookinfo-local`) runs four namespaces:
 | `platform` | Strimzi operator, Kafka (KRaft single-node), Argo Events controller, EventBus, Gateway `default-gw` |
 | `envoy-gateway-system` | Envoy Gateway controller, GatewayClass `eg`, stable `gateway` Service for CQRS routing |
 | `observability` | Prometheus, Grafana, Tempo, Loki, Pyroscope, Alloy (DaemonSet for logs + Deployment for metrics/traces) |
-| `bookinfo` | 10 app deployments (CQRS split incl. dlqueue read/write), PostgreSQL, 4 EventSources (incl. `dlq-event-received`), 4 Sensors (incl. DLQ), method-based HTTPRoutes |
+| `bookinfo` | 11 app deployments (CQRS split incl. dlqueue read/write, plus `ingestion` single deployment), PostgreSQL, 4 EventSources (incl. `dlq-event-received`), 4 Sensors (incl. DLQ), method-based HTTPRoutes |
 
 ### CQRS Deployment Split
 
@@ -476,6 +492,8 @@ Each backend service deploys as two separate Deployments sharing the same image 
 | `ratings` / `ratings-write` | Read / Write | reviews (read) / rating-submitted sensor |
 | `notification` | Write-only | All 3 sensors |
 | `dlqueue` / `dlqueue-write` | Read / Write | operator/service API (GET) / `dlq-event-received` sensor (POST) |
+
+> `ingestion` deploys as a single stateless deployment with no CQRS split — it is a pure event producer and is omitted from the table above.
 
 ### Usage
 
@@ -534,6 +552,16 @@ Replay is operator- or service-initiated via `POST /v1/events/{id}/replay`: dlqu
 
 ---
 
+## Data Ingestion
+
+The `ingestion` service is a demo-scale synthetic-data generator that exercises the full event-driven write pipeline end-to-end (Gateway → EventSource → Kafka → Sensor → `details-write`). It runs as a single stateless deployment with no storage adapters, no CQRS split, and no EventSource/Sensor of its own — it is purely outbound.
+
+A background poll loop ticks every `POLL_INTERVAL` (default 5m). For each query in `SEARCH_QUERIES`, the service calls `GET https://openlibrary.org/search.json`, validates each returned book (title, ISBN, authors, and publish year are required), and publishes accepted books via `POST {GATEWAY_URL}/v1/details`. Each publish carries a deterministic idempotency key `ingestion-isbn-<ISBN>` so the downstream `details-write` service deduplicates across cycles via `pkg/idempotency`. On-demand scrapes are also available via `POST /v1/ingestion/trigger` (optional body `{"queries": ["golang", "rust"]}`).
+
+Configuration via `GATEWAY_URL`, `POLL_INTERVAL`, `SEARCH_QUERIES`, and `MAX_RESULTS_PER_QUERY` environment variables. Because idempotency is enforced at the write service, replays and overlapping cycles are safe. For the full design, port contracts, and metric definitions, see [docs/superpowers/specs/2026-04-14-ingestion-service-design.md](docs/superpowers/specs/2026-04-14-ingestion-service-design.md).
+
+---
+
 ## E2E Tests
 
 E2E tests spin up all five services via docker-compose and exercise each service's HTTP API with shell scripts.
@@ -570,6 +598,7 @@ Prometheus-format metrics are available at `/metrics` on the admin port. Each se
   | details | `books_added_total` |
   | reviews | `reviews_submitted_total` |
   | notification | `notifications_dispatched_total`, `notifications_failed_total`, `notifications_by_status` |
+  | ingestion | `ingestion_scrapes_total`, `ingestion_books_published_total`, `ingestion_errors_total` |
 
 ### Tracing
 
@@ -623,15 +652,22 @@ event-driven-bookinfo/
 │   ├── reviews/                # User reviews (hex arch, calls ratings)
 │   ├── ratings/                # Star ratings (hex arch)
 │   ├── notification/           # Event consumer + audit log (hex arch)
-│   └── dlqueue/                # Dead letter queue (hex arch) — NEW
+│   ├── dlqueue/                # Dead letter queue (hex arch) — NEW
+│   │   ├── cmd/main.go
+│   │   ├── migrations/         # dlq_events + processed_events
+│   │   └── internal/
+│   │       ├── core/           # domain/, port/, service/
+│   │       ├── adapter/
+│   │       │   ├── inbound/http/
+│   │       │   └── outbound/   # memory/, postgres/, http/ (replay client)
+│   │       └── metrics/        # dlq_events_* counters
+│   └── ingestion/              # Producer (hex arch) — Open Library scraper, publishes to Gateway
 │       ├── cmd/main.go
-│       ├── migrations/         # dlq_events + processed_events
 │       └── internal/
 │           ├── core/           # domain/, port/, service/
-│           ├── adapter/
-│           │   ├── inbound/http/
-│           │   └── outbound/   # memory/, postgres/, http/ (replay client)
-│           └── metrics/        # dlq_events_* counters
+│           └── adapter/
+│               ├── inbound/http/
+│               └── outbound/   # openlibrary/ (BookFetcher), gateway/ (EventPublisher)
 ├── pkg/
 │   ├── config/                 # Env-based configuration
 │   ├── health/                 # /healthz and /readyz handlers
@@ -678,7 +714,7 @@ Each service is versioned and released independently. Releases are fully automat
 ### How It Works
 
 1. **PR merged to `main`** → `auto-tag.yml` runs
-2. **Detects changed services** — file paths under `services/<name>/`; changes to `pkg/`, `go.mod`, or `go.sum` trigger all 6 services
+2. **Detects changed services** — file paths under `services/<name>/`; changes to `pkg/`, `go.mod`, or `go.sum` trigger all 7 services
 3. **Determines version bump** — PR labels (`major`/`minor`) take priority, then conventional commit prefixes (`feat` → minor, `fix` → patch, `BREAKING CHANGE` → major), default is `patch`
 4. **Creates tag** — e.g., `details-v0.2.0`
 5. **Dispatches release** — `release.yml` builds binaries, Docker images (multi-arch), and creates a GitHub release

--- a/deploy/ingestion/values-local.yaml
+++ b/deploy/ingestion/values-local.yaml
@@ -7,7 +7,7 @@ image:
 
 config:
   LOG_LEVEL: "debug"
-  GATEWAY_URL: "http://default-gw-envoy.envoy-gateway-system.svc.cluster.local"
+  GATEWAY_URL: "http://gateway.envoy-gateway-system.svc.cluster.local"
   POLL_INTERVAL: "5m"
   SEARCH_QUERIES: "programming,golang,kubernetes,python,devops"
   MAX_RESULTS_PER_QUERY: "10"

--- a/docs/superpowers/plans/2026-04-14-ingestion-service.md
+++ b/docs/superpowers/plans/2026-04-14-ingestion-service.md
@@ -2161,7 +2161,7 @@ image:
 
 config:
   LOG_LEVEL: "debug"
-  GATEWAY_URL: "http://default-gw-envoy.envoy-gateway-system.svc.cluster.local"
+  GATEWAY_URL: "http://gateway.envoy-gateway-system.svc.cluster.local"
   POLL_INTERVAL: "5m"
   SEARCH_QUERIES: "programming,golang,kubernetes,python,devops"
   MAX_RESULTS_PER_QUERY: "10"

--- a/docs/superpowers/plans/2026-04-15-ingestion-docs-update.md
+++ b/docs/superpowers/plans/2026-04-15-ingestion-docs-update.md
@@ -1,0 +1,628 @@
+# Ingestion Documentation Update Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document the new `ingestion` service in `README.md` and `CLAUDE.md` so human readers and AI agents see the complete 7-service topology, updated diagrams, and ingestion-specific configuration.
+
+**Architecture:** Edit only two top-level doc files. All changes follow the pattern established by the dlqueue docs-update (`docs/superpowers/specs/2026-04-13-dlqueue-docs-update-design.md`). Ship atomically on branch `feat/ingestion-service` in a single commit. Historical specs and plans stay untouched.
+
+**Tech Stack:** Markdown, Mermaid diagrams (rendered by GitHub), GitHub-flavored tables. No code. No tests. Verification is `git diff` inspection plus Markdown/Mermaid preview.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-15-ingestion-docs-update-design.md`
+
+---
+
+## Task 1: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+All edits are small, independent, and stay inside CLAUDE.md. Do them in reading order so surrounding context is always visible.
+
+- [ ] **Step 1: Append ingestion mention to Project Overview paragraph**
+
+In `CLAUDE.md`, locate the paragraph ending at line 5:
+
+```
+...Failed events that exhaust sensor retries are captured by the `dlqueue` service for inspection and replay. Full observability: structured logging, distributed tracing, metrics, continuous profiling.
+```
+
+Replace with:
+
+```
+...Failed events that exhaust sensor retries are captured by the `dlqueue` service for inspection and replay. A standalone `ingestion` service polls the Open Library API and publishes `book-added` events through the Gateway, demonstrating the system as a self-hosted event broker. Full observability: structured logging, distributed tracing, metrics, continuous profiling.
+```
+
+- [ ] **Step 2: Add ingestion row to the Services table**
+
+In the Services table, immediately after the `dlqueue` row (around line 18), insert:
+
+```
+| **ingestion** | Producer (hex arch) | :8080 / :9090 admin | Open Library scraper; polls on interval, publishes book-added events to the Gateway |
+```
+
+- [ ] **Step 3: Insert new Ingestion architecture bullet**
+
+Immediately after the `Idempotency` bullet (line 31), insert a new bullet:
+
+```
+- **Ingestion**: `ingestion` service polls Open Library on `POLL_INTERVAL` → for each query in `SEARCH_QUERIES` → `POST {GATEWAY_URL}/v1/details` with `idempotency_key=ingestion-isbn-<ISBN>`. Stateless, single deployment, no CQRS split, no EventSource/Sensor of its own. Exercises the full write pipeline end-to-end.
+```
+
+- [ ] **Step 4: Update Build Commands counts**
+
+In the Build Commands code block (lines 35-41):
+
+Replace:
+```
+make build-all          # Build all 6 service binaries to bin/
+```
+with:
+```
+make build-all          # Build all 7 service binaries to bin/
+```
+
+Replace:
+```
+make docker-build-all   # Build all 6 Docker images
+```
+with:
+```
+make docker-build-all   # Build all 7 Docker images
+```
+
+- [ ] **Step 5: Update Deploy Structure "all 6 services" reference**
+
+In the Deploy Structure code block (line 73):
+
+Replace:
+```
+  bookinfo-service/          # Reusable Helm chart for all 6 services
+```
+with:
+```
+  bookinfo-service/          # Reusable Helm chart for all 7 services
+```
+
+- [ ] **Step 6: Insert ingestion block in Run Locally**
+
+Locate the `**dlqueue**` block (lines 109-112) and the `**productpage**` block that follows it. Between them, insert:
+
+````
+**ingestion** (publishes to Gateway; requires Gateway/productpage reachable):
+```bash
+SERVICE_NAME=ingestion HTTP_PORT=8086 ADMIN_PORT=9096 \
+  GATEWAY_URL=http://localhost:8080 \
+  POLL_INTERVAL=5m \
+  SEARCH_QUERIES=programming,golang \
+  MAX_RESULTS_PER_QUERY=10 \
+  go run ./services/ingestion/cmd/
+```
+````
+
+- [ ] **Step 7: Append ingestion env vars to the optional-vars paragraph**
+
+Locate the sentence at line 122:
+
+```
+Optional env vars (all services): `LOG_LEVEL` (debug/info/warn/error, default info), `OTEL_EXPORTER_OTLP_ENDPOINT`, `PYROSCOPE_SERVER_ADDRESS`, `STORAGE_BACKEND` (memory/postgres), `DATABASE_URL`. Productpage-specific: `REDIS_URL` (enables pending review cache; disabled when unset).
+```
+
+Replace with:
+
+```
+Optional env vars (all services): `LOG_LEVEL` (debug/info/warn/error, default info), `OTEL_EXPORTER_OTLP_ENDPOINT`, `PYROSCOPE_SERVER_ADDRESS`, `STORAGE_BACKEND` (memory/postgres), `DATABASE_URL`. Productpage-specific: `REDIS_URL` (enables pending review cache; disabled when unset). Ingestion-specific: `GATEWAY_URL`, `POLL_INTERVAL`, `SEARCH_QUERIES`, `MAX_RESULTS_PER_QUERY`.
+```
+
+- [ ] **Step 8: Verify CLAUDE.md diff**
+
+Run:
+```bash
+git diff CLAUDE.md
+```
+
+Expected: 7 change hunks covering overview paragraph, services table, architecture bullet, build commands, deploy structure, run locally, optional env vars. No lines removed from sections other than the replaced text.
+
+Do not commit yet — all changes ship in one commit at the end.
+
+---
+
+## Task 2: README.md — intro, services table, and top-of-file edits
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Append ingestion sentence to intro paragraph**
+
+In `README.md`, locate the paragraph ending at line 66:
+
+```
+...This demonstrates using Argo Events not only for workflow automation, but as a real-time event-driven architecture platform — a self-hosted alternative to Google Eventarc or AWS EventBridge.
+```
+
+Replace with:
+
+```
+...This demonstrates using Argo Events not only for workflow automation, but as a real-time event-driven architecture platform — a self-hosted alternative to Google Eventarc or AWS EventBridge. A standalone `ingestion` service demonstrates the pipeline as a self-hosted event broker — it polls the Open Library API and publishes synthetic book-added events through the same Gateway → EventSource → Kafka → Sensor path used by the UI.
+```
+
+- [ ] **Step 2: Append ingestion row to Services table**
+
+Locate the `dlqueue` row in the Services table (line 186). Immediately after it, insert this single-line row (no line breaks inside the row):
+
+```
+| **ingestion** | [![release](https://img.shields.io/github/v/release/kaio6fellipe/event-driven-bookinfo?filter=ingestion-v*&sort=semver&display_name=tag&label=release)](https://github.com/kaio6fellipe/event-driven-bookinfo/releases?q=ingestion-v&expanded=true) | [![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kaio6fellipe/event-driven-bookinfo/badges/coverage-ingestion.json)](https://github.com/kaio6fellipe/event-driven-bookinfo/actions/workflows/ci.yml?query=branch%3Amain) | Producer (hex arch) | 8086 | 9096 | Polls Open Library for books on a configurable interval and publishes `book-added` events to the Gateway. Stateless; no storage adapters. |
+```
+
+- [ ] **Step 3: Insert ingestion block in Quick Start**
+
+Locate the closing line of the `productpage` run block:
+
+```bash
+  ./bin/productpage
+
+# Open in browser
+open http://localhost:8080
+```
+
+Replace with:
+
+````bash
+  ./bin/productpage
+
+# Optional standalone demo — polls Open Library and publishes to the Gateway
+SERVICE_NAME=ingestion HTTP_PORT=8086 ADMIN_PORT=9096 \
+  GATEWAY_URL=http://localhost:8080 \
+  POLL_INTERVAL=5m \
+  SEARCH_QUERIES=programming,golang \
+  MAX_RESULTS_PER_QUERY=10 \
+  ./bin/ingestion
+
+# Open in browser
+open http://localhost:8080
+````
+
+- [ ] **Step 4: Update Makefile targets table descriptions**
+
+In the Makefile Targets table, replace:
+
+```
+| `make build-all` | Build all 6 service binaries |
+```
+with:
+```
+| `make build-all` | Build all 7 service binaries |
+```
+
+Replace:
+
+```
+| `make docker-build-all` | Build Docker images for all 6 services |
+```
+with:
+```
+| `make docker-build-all` | Build Docker images for all 7 services |
+```
+
+- [ ] **Step 5: Append ingestion to the Docker image list**
+
+Locate the GHCR image list block ending with:
+
+```
+ghcr.io/kaio6fellipe/event-driven-bookinfo/dlqueue:<tag>
+```
+
+Insert one line immediately after:
+
+```
+ghcr.io/kaio6fellipe/event-driven-bookinfo/ingestion:<tag>
+```
+
+- [ ] **Step 6: Verify intermediate diff**
+
+Run:
+```bash
+git diff README.md
+```
+
+Expected: 5 change hunks (intro, services table row, Quick Start addition, two Makefile-row replacements + a blank-line-free image-list append). Do not commit yet.
+
+---
+
+## Task 3: README.md — Event-Driven Write Flow diagram
+
+**Files:**
+- Modify: `README.md` (Event-Driven Write Flow mermaid block, lines 98-161)
+
+- [ ] **Step 1: Add ingestion node declaration**
+
+Inside the ```mermaid``` code block for "Event-Driven Write Flow", locate the existing declarations near the top:
+
+```
+    Browser["Browser POST /partials/rating"]
+    PP["productpage (BFF)"]
+    GW["Gateway (CQRS routing)"]
+    WH["External POST /v1/*"]
+```
+
+Immediately after the `WH` line, add:
+
+```
+    ING["ingestion<br/>Open Library poller"]
+```
+
+- [ ] **Step 2: Add ingestion arrow to Gateway**
+
+In the same mermaid block, locate the line:
+
+```
+    WH --> GW
+```
+
+Add a new line immediately after it:
+
+```
+    ING -->|"POST /v1/details"| GW
+```
+
+- [ ] **Step 3: Add ingestion style**
+
+In the same mermaid block, locate the `style` declarations (they follow the arrow definitions, at the bottom of the block). The last existing style in the group is:
+
+```
+    style DLQW fill:#1a1d27,color:#e4e4e7,stroke:#a855f7
+```
+
+Immediately after that line, add:
+
+```
+    style ING fill:#1a1d27,color:#e4e4e7,stroke:#10b981
+```
+
+- [ ] **Step 4: Verify diagram renders**
+
+In VS Code (or any Markdown/Mermaid preview), open `README.md` and scroll to the "Event-Driven Write Flow" diagram. Expected: the new `ING` node appears with a dark grey fill and a green border, connected to `GW` by an arrow labeled "POST /v1/details". All existing nodes, edges, and styles remain unchanged.
+
+Run `git diff README.md` and confirm the Event-Driven Write Flow block shows exactly 3 new lines added — no removals, no edits to existing lines.
+
+Do not commit yet.
+
+---
+
+## Task 4: README.md — Cluster Architecture diagram
+
+**Files:**
+- Modify: `README.md` (Cluster Architecture mermaid block, lines 368-456)
+
+- [ ] **Step 1: Declare ingestion node inside the bookinfo subgraph**
+
+Inside the ```mermaid``` code block for "Cluster Architecture", locate the `subgraph bookinfo` block. Near the existing `DLQW["dlqueue-write"]` line, keep scanning to the node declarations. Immediately after:
+
+```
+        DLQR["dlqueue"]
+        DLQW["dlqueue-write"]
+```
+
+add:
+
+```
+        ING["ingestion"]
+```
+
+- [ ] **Step 2: Add outbound arrow to Gateway**
+
+In the same mermaid block, locate the existing arrow section (after the subgraphs):
+
+```
+    GW -->|"POST /v1/*"| ES
+```
+
+Immediately after that line, add:
+
+```
+    ING --> GW
+```
+
+- [ ] **Step 3: Add ingestion to observability fan-out arrows**
+
+In the same mermaid block, locate the three observability fan-out lines. Two arrows list bookinfo workloads.
+
+Replace:
+
+```
+    DR & DW & RR & RW & RTR & RTW & N & DLQR & DLQW --> PG
+```
+with:
+```
+    DR & DW & RR & RW & RTR & RTW & N & DLQR & DLQW --> PG
+    ING -.->|"outbound HTTPS"| GW
+```
+
+(The `ING` line replaces an awkward `ING --> PG` since ingestion has no DB — it stays connected only to the Gateway, matching its stateless design. The existing `DR & DW & ... DLQW --> PG` line remains untouched above it.)
+
+Now locate:
+
+```
+    PP & DR & DW & RR & RW & RTR & RTW & N & DLQR & DLQW -.->|push profiles| Pyro
+```
+Replace with:
+```
+    PP & DR & DW & RR & RW & RTR & RTW & N & DLQR & DLQW & ING -.->|push profiles| Pyro
+```
+
+- [ ] **Step 4: Add ingestion style**
+
+In the same mermaid block, locate the `style` block at the bottom. The last existing style in that group is:
+
+```
+    style Redis fill:#ef4444,color:#fff,stroke:#dc2626
+```
+
+Immediately after that line, add:
+
+```
+    style ING fill:#1a1d27,color:#e4e4e7,stroke:#10b981
+```
+
+- [ ] **Step 5: Verify diagram renders**
+
+Open `README.md` in a Markdown/Mermaid preview and scroll to "Cluster Architecture". Expected: the new `ING` node appears inside the `bookinfo` subgraph with a green border. Arrows: `ING --> GW` (solid, outbound publish) and `ING -.-> Pyro` (dotted, via the combined push-profiles fan-out line). Existing arrows and styles unchanged.
+
+Run `git diff README.md` and confirm the Cluster Architecture block shows exactly 4 additions (node, outbound arrow, ING appended to Pyro fan-out, style), no removals.
+
+Do not commit yet.
+
+---
+
+## Task 5: README.md — CQRS note, observability metrics row, project tree, releasing
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add note below CQRS Deployment Split table**
+
+Locate the end of the CQRS Deployment Split table. The closing row is:
+
+```
+| `dlqueue` / `dlqueue-write` | Read / Write | operator/service API (GET) / `dlq-event-received` sensor (POST) |
+```
+
+Immediately after the table (before the next `###` heading), insert a blank line and a note paragraph:
+
+```
+
+> `ingestion` deploys as a single stateless deployment with no CQRS split — it is a pure event producer and is omitted from the table above.
+```
+
+- [ ] **Step 2: Append ingestion row to business metrics table**
+
+In the Observability section, locate the "Business metrics (per service)" table:
+
+```
+  | Service | Metric |
+  |---|---|
+  | ratings | `ratings_submitted_total` |
+  | details | `books_added_total` |
+  | reviews | `reviews_submitted_total` |
+  | notification | `notifications_dispatched_total`, `notifications_failed_total`, `notifications_by_status` |
+```
+
+Append one row:
+
+```
+  | ingestion | `ingestion_scrapes_total`, `ingestion_books_published_total`, `ingestion_errors_total` |
+```
+
+- [ ] **Step 3: Append ingestion block to Project Structure tree**
+
+In the Project Structure tree, locate the `dlqueue/` block:
+
+```
+│   └── dlqueue/                # Dead letter queue (hex arch) — NEW
+│       ├── cmd/main.go
+│       ├── migrations/         # dlq_events + processed_events
+│       └── internal/
+│           ├── core/           # domain/, port/, service/
+│           ├── adapter/
+│           │   ├── inbound/http/
+│           │   └── outbound/   # memory/, postgres/, http/ (replay client)
+│           └── metrics/        # dlq_events_* counters
+```
+
+Replace the leading `└──` of `dlqueue/` with `├──` (to allow another entry below), and append the ingestion entry:
+
+```
+│   ├── dlqueue/                # Dead letter queue (hex arch) — NEW
+│   │   ├── cmd/main.go
+│   │   ├── migrations/         # dlq_events + processed_events
+│   │   └── internal/
+│   │       ├── core/           # domain/, port/, service/
+│   │       ├── adapter/
+│   │       │   ├── inbound/http/
+│   │       │   └── outbound/   # memory/, postgres/, http/ (replay client)
+│   │       └── metrics/        # dlq_events_* counters
+│   └── ingestion/              # Producer (hex arch) — Open Library scraper, publishes to Gateway
+│       ├── cmd/main.go
+│       └── internal/
+│           ├── core/           # domain/, port/, service/
+│           └── adapter/
+│               ├── inbound/http/
+│               └── outbound/   # openlibrary/ (BookFetcher), gateway/ (EventPublisher)
+```
+
+- [ ] **Step 4: Update "all 6 services" in Releasing section**
+
+In the Releasing > How It Works numbered list, locate:
+
+```
+2. **Detects changed services** — file paths under `services/<name>/`; changes to `pkg/`, `go.mod`, or `go.sum` trigger all 6 services
+```
+
+Replace with:
+
+```
+2. **Detects changed services** — file paths under `services/<name>/`; changes to `pkg/`, `go.mod`, or `go.sum` trigger all 7 services
+```
+
+- [ ] **Step 5: Verify intermediate diff**
+
+Run:
+```bash
+git diff README.md
+```
+
+Expected: the prior task's hunks plus 4 new hunks (CQRS note, metrics row, project tree expansion, releasing count). No removals elsewhere. Do not commit yet.
+
+---
+
+## Task 6: README.md — new "Data Ingestion" subsection
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Insert new subsection after Dead Letter Queue**
+
+Locate the end of the "Dead Letter Queue" subsection. The closing line is:
+
+```
+Replay is operator- or service-initiated via `POST /v1/events/{id}/replay`: dlqueue re-POSTs the original payload and headers to the source EventSource URL stored on the DLQ record, re-entering the full CQRS pipeline. All write services are idempotent (see `pkg/idempotency`) so replays are safe. For the full domain model, API surface, and metric definitions, see [docs/superpowers/specs/2026-04-13-dlqueue-service-design.md](docs/superpowers/specs/2026-04-13-dlqueue-service-design.md).
+```
+
+This is followed by a horizontal-rule line (`---`) and then the `## E2E Tests` heading.
+
+Immediately after the horizontal-rule line (and before `## E2E Tests`), insert:
+
+````markdown
+## Data Ingestion
+
+The `ingestion` service is a demo-scale synthetic-data generator that exercises the full event-driven write pipeline end-to-end (Gateway → EventSource → Kafka → Sensor → `details-write`). It runs as a single stateless deployment with no storage adapters, no CQRS split, and no EventSource/Sensor of its own — it is purely outbound.
+
+A background poll loop ticks every `POLL_INTERVAL` (default 5m). For each query in `SEARCH_QUERIES`, the service calls `GET https://openlibrary.org/search.json`, validates each returned book (title, ISBN, authors, and publish year are required), and publishes accepted books via `POST {GATEWAY_URL}/v1/details`. Each publish carries a deterministic idempotency key `ingestion-isbn-<ISBN>` so the downstream `details-write` service deduplicates across cycles via `pkg/idempotency`. On-demand scrapes are also available via `POST /v1/ingestion/trigger` (optional body `{"queries": ["golang", "rust"]}`).
+
+Configuration via `GATEWAY_URL`, `POLL_INTERVAL`, `SEARCH_QUERIES`, and `MAX_RESULTS_PER_QUERY` environment variables. Because idempotency is enforced at the write service, replays and overlapping cycles are safe. For the full design, port contracts, and metric definitions, see [docs/superpowers/specs/2026-04-14-ingestion-service-design.md](docs/superpowers/specs/2026-04-14-ingestion-service-design.md).
+
+---
+
+````
+
+Note: the trailing `---` in the insert separates the new section from the next one, matching the section-separator style used elsewhere in README.md.
+
+- [ ] **Step 2: Verify the new subsection renders**
+
+Open `README.md` in a Markdown preview. Expected: a new `## Data Ingestion` heading appears between the DLQ "Replay" paragraph and the `## E2E Tests` heading. Three paragraphs. Both embedded paths (`docs/superpowers/specs/2026-04-14-ingestion-service-design.md`) render as clickable links.
+
+Run `git diff README.md` and confirm the new hunk is purely additive (no existing content removed).
+
+Do not commit yet.
+
+---
+
+## Task 7: Final verification and single commit
+
+**Files:**
+- Modify: `README.md` (review only)
+- Modify: `CLAUDE.md` (review only)
+- Commit: both files plus the two spec/plan docs
+
+- [ ] **Step 1: Check for missed service-count references**
+
+Run:
+```bash
+grep -n "6 services\|6 service \|all 6 " README.md CLAUDE.md
+```
+
+Expected: no matches. Any remaining hits must be fixed before committing.
+
+- [ ] **Step 2: Confirm ingestion appears in every place it should**
+
+Run:
+```bash
+grep -c "ingestion" README.md
+grep -c "ingestion" CLAUDE.md
+```
+
+Expected: README.md returns ≥ 9, CLAUDE.md returns ≥ 6. Lower counts mean an expected insertion was missed — re-run prior tasks.
+
+- [ ] **Step 3: Full diff inspection**
+
+Run:
+```bash
+git diff README.md CLAUDE.md
+```
+
+Walk the entire diff. Verify:
+- Only additions and one sentence-level replacement per section described in Task 1-6 appear
+- No stray trailing whitespace or CRLF changes
+- No accidental edits to lines outside the described hunks
+- Mermaid code blocks remain syntactically valid (fences balanced, styles referencing the correct node IDs)
+
+- [ ] **Step 4: Render both diagrams**
+
+Open `README.md` in VS Code with a Mermaid preview extension, or paste each mermaid block into https://mermaid.live. Verify the two updated diagrams (Event-Driven Write Flow, Cluster Architecture) render without errors and the new `ING` node and arrows are visible.
+
+- [ ] **Step 5: Stage and commit**
+
+Stage the two modified doc files plus the brainstorming spec and plan:
+
+```bash
+git add README.md CLAUDE.md \
+  docs/superpowers/specs/2026-04-15-ingestion-docs-update-design.md \
+  docs/superpowers/plans/2026-04-15-ingestion-docs-update.md
+```
+
+Commit with the pre-approved message:
+
+```bash
+git commit -m "$(cat <<'EOF'
+docs: update README and CLAUDE.md for ingestion service
+
+Add ingestion service row to services tables, project structure, Quick
+Start, Run Locally, business metrics, and Docker image list. Update
+Event-Driven Write Flow and Cluster Architecture diagrams with the new
+producer node. Add new "Data Ingestion" subsection after Dead Letter
+Queue describing purpose, flow, and config. Bump "6 services" references
+to "7". Note ingestion's omission from the CQRS Deployment Split table.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 6: Confirm commit landed cleanly**
+
+Run:
+```bash
+git log -1 --stat
+```
+
+Expected: single new commit on `feat/ingestion-service`, four files changed: `README.md`, `CLAUDE.md`, the new spec under `docs/superpowers/specs/`, and the plan under `docs/superpowers/plans/`. No untracked or modified files remain (`git status` should be clean).
+
+---
+
+## Self-review summary
+
+Spec coverage verified against every section of `docs/superpowers/specs/2026-04-15-ingestion-docs-update-design.md`:
+
+| Spec section | Plan task |
+|---|---|
+| Intro sentence (README) | Task 2 Step 1 |
+| Services table (README) | Task 2 Step 2 |
+| Event-Driven Write Flow diagram | Task 3 |
+| Cluster Architecture diagram | Task 4 |
+| Quick Start | Task 2 Step 3 |
+| Makefile + Docker image list | Task 2 Steps 4-5 |
+| CQRS Deployment Split note | Task 5 Step 1 |
+| Observability business metrics row | Task 5 Step 2 |
+| Data Ingestion subsection | Task 6 |
+| Project Structure tree | Task 5 Step 3 |
+| Releasing "6 services" bump | Task 5 Step 4 |
+| CLAUDE.md Project Overview | Task 1 Step 1 |
+| CLAUDE.md Services table | Task 1 Step 2 |
+| CLAUDE.md architecture bullet | Task 1 Step 3 |
+| CLAUDE.md Build Commands counts | Task 1 Step 4 |
+| CLAUDE.md Deploy Structure "6 services" | Task 1 Step 5 (bonus — caught during plan writing) |
+| CLAUDE.md Run Locally block | Task 1 Step 6 |
+| CLAUDE.md optional env-vars sentence | Task 1 Step 7 |
+| Single commit on feat/ingestion-service | Task 7 |
+
+No placeholders, no TODOs, every edit shows before/after text. File paths are absolute references inside the repo root. Step counts: Task 1 has 8 steps (7 edits + verify), Tasks 2-5 have 5-6 steps each, Task 6 has 2 steps, Task 7 has 6 steps. Total: ≈32 discrete steps, each 2-5 minutes.

--- a/docs/superpowers/specs/2026-04-14-ingestion-service-design.md
+++ b/docs/superpowers/specs/2026-04-14-ingestion-service-design.md
@@ -226,7 +226,7 @@ Standard `pkg/metrics` HTTP middleware on both ports, plus custom metrics:
 - `cqrs.enabled: false`
 - No EventSource, no Sensor, no write Deployment, no HTTPRoutes
 - Config values: `GATEWAY_URL`, `POLL_INTERVAL`, `SEARCH_QUERIES`, `MAX_RESULTS_PER_QUERY`
-- `GATEWAY_URL` in k8s: `http://default-gw-envoy.envoy-gateway-system.svc.cluster.local`
+- `GATEWAY_URL` in k8s: `http://gateway.envoy-gateway-system.svc.cluster.local` (stable alias service defined in `deploy/gateway/base/gateway-service.yaml` that selects the Envoy Gateway data-plane pods)
 
 ### Makefile
 - Add `ingestion` to `SERVICES` list

--- a/docs/superpowers/specs/2026-04-15-ingestion-docs-update-design.md
+++ b/docs/superpowers/specs/2026-04-15-ingestion-docs-update-design.md
@@ -1,0 +1,246 @@
+# Ingestion Documentation Update Design
+
+**Date:** 2026-04-15
+**Status:** Approved
+**Scope:** `README.md` and `CLAUDE.md` only — ships atomically with the ingestion feature PR on `feat/ingestion-service`.
+
+## Overview
+
+Update `README.md` and `CLAUDE.md` to reflect the new `ingestion` service — a stateless, outbound-only producer that polls the Open Library API and publishes `book-added` events through the Envoy Gateway. Matches the pattern established by the dlqueue docs update (`docs/superpowers/specs/2026-04-13-dlqueue-docs-update-design.md`): doc changes ship with the feature PR, historical specs and plans remain unchanged.
+
+## Problem
+
+The ingestion service is fully implemented (core + adapters + cmd + tests + Helm values + Makefile + CI auto-tag integration) on branch `feat/ingestion-service`, but neither `README.md` nor `CLAUDE.md` mentions it. Readers — human or AI agents consuming `CLAUDE.md` — will see a 6-service topology and miss:
+
+- A new service type (outbound producer, no inbound business traffic, no storage)
+- A new demo capability (self-hosted event broker driven by real external data)
+- Ingestion-specific env vars (`GATEWAY_URL`, `POLL_INTERVAL`, `SEARCH_QUERIES`, `MAX_RESULTS_PER_QUERY`)
+- Updated service counts ("6 services" → "7 services") in build/release commentary
+
+## Scope
+
+**In scope:**
+- `README.md` — services table, intro, 2 mermaid diagrams (Event-Driven Write Flow + Cluster Architecture), Quick Start, Makefile targets, Docker image list, Local Kubernetes CQRS note, Observability business metrics, new "Data Ingestion" subsection, Project Structure tree, service-count references
+- `CLAUDE.md` — project overview sentence, services table, architecture bullets, build-command counts, Run Locally block, optional env-var list
+
+**Out of scope:**
+- `docs/superpowers/specs/*.md` and `docs/superpowers/plans/*.md` — point-in-time historical artifacts (matches dlqueue precedent)
+- Per-service `services/ingestion/README.md` — no existing convention; deferred
+- Top CQRS diagram (README lines 12-62) — abstract, unchanged (ingestion is another POST source, no new flow)
+- Service Topology diagram (README lines 72-94) — shows sync service-to-service deps; ingestion has none
+- `.github/SECURITY.md` — not service-scoped, unaffected
+- Argo Events section — ingestion doesn't use Argo Events directly (publishes via Gateway)
+- Shared Packages table — ingestion adds no new package under `pkg/`
+- Service Structure (hex arch) section in CLAUDE.md — ingestion follows the same structure, just without memory/postgres outbound adapters
+
+## README.md Changes
+
+### Intro paragraph (append after line 66)
+
+Append one sentence to the existing overview paragraph:
+
+> "A standalone `ingestion` service demonstrates the pipeline as a self-hosted event broker — it polls the Open Library API and publishes synthetic book-added events through the same Gateway → EventSource → Kafka → Sensor path used by the UI."
+
+### Services table (append one row after the dlqueue row at line 186)
+
+```
+| **ingestion** | [![release](https://img.shields.io/github/v/release/kaio6fellipe/event-driven-bookinfo?filter=ingestion-v*&sort=semver&display_name=tag&label=release)](https://github.com/kaio6fellipe/event-driven-bookinfo/releases?q=ingestion-v&expanded=true) | [![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kaio6fellipe/event-driven-bookinfo/badges/coverage-ingestion.json)](https://github.com/kaio6fellipe/event-driven-bookinfo/actions/workflows/ci.yml?query=branch%3Amain) | Producer (hex arch) | 8086 | 9096 | Polls Open Library for books on a configurable interval and publishes `book-added` events to the Gateway. Stateless; no storage adapters. |
+```
+
+- Host ports `8086 / 9096` continue the sequential allocation pattern (productpage 8080 → dlqueue 8085 → ingestion 8086).
+- Type column value `Producer (hex arch)` is a new label. Rationale: ingestion's architectural role (outbound-only event producer) differs from "Backend (hex arch)" (bidirectional REST service). Documented in the services-table legend via the Description column.
+- Release and coverage badges follow the existing naming convention (`ingestion-v*` tag filter, `coverage-ingestion.json` file). The coverage JSON is produced by the existing CI workflow once ingestion is added to the services list (already done — see commit `bc49da6`).
+
+### Event-Driven Write Flow diagram (lines 98-161)
+
+Add one new node and one new arrow. All existing nodes, flows, and styles remain untouched.
+
+```
+ING["ingestion<br/>Open Library poller"]
+ING -->|"POST /v1/details"| GW
+style ING fill:#1a1d27,color:#e4e4e7,stroke:#10b981
+```
+
+Green stroke (`#10b981`) distinguishes ingestion from backend nodes (grey stroke), EventSources (green fill), and dlqueue nodes (purple stroke). The node sits upstream of `GW` (Gateway) alongside `Browser`, `PP`, and `WH` as one of the POST sources.
+
+### Cluster Architecture diagram (lines 368-456)
+
+Add `ING["ingestion"]` node inside the `bookinfo` subgraph. Add arrows:
+
+- `ING --> GW` (outbound publish to Gateway)
+- Add `ING` to the existing Alloy scrape line, OTLP traces line, and push-profiles line so the observability arrows enumerate all bookinfo workloads
+
+Same styling as the Write Flow diagram (`stroke:#10b981`).
+
+### Quick Start (after the productpage block at line 252)
+
+Add:
+
+````markdown
+# Optional standalone demo — polls Open Library and publishes to the Gateway
+SERVICE_NAME=ingestion HTTP_PORT=8086 ADMIN_PORT=9096 \
+  GATEWAY_URL=http://localhost:8080 \
+  POLL_INTERVAL=5m \
+  SEARCH_QUERIES=programming,golang \
+  MAX_RESULTS_PER_QUERY=10 \
+  ./bin/ingestion
+````
+
+Positioned after productpage because ingestion depends on the Gateway/productpage port being reachable at `GATEWAY_URL`.
+
+### Makefile targets table (lines 270-296)
+
+- `make build-all` description → "Build all 7 service binaries"
+- `make docker-build-all` description → "Build Docker images for all 7 services"
+
+### Docker image list (lines 323-329)
+
+Add one line:
+
+```
+ghcr.io/kaio6fellipe/event-driven-bookinfo/ingestion:<tag>
+```
+
+### Local Kubernetes — CQRS Deployment Split note (after the table at lines 471-479)
+
+Append a one-line note below the table:
+
+> "`ingestion` deploys as a single stateless deployment with no CQRS split — it is a pure event producer and is omitted from the table above."
+
+### Observability — business metrics table (after line 572)
+
+Append one row:
+
+```
+| ingestion | `ingestion_scrapes_total`, `ingestion_books_published_total`, `ingestion_errors_total` |
+```
+
+### NEW subsection `## Data Ingestion`
+
+Insert after the "Dead Letter Queue" subsection and before "E2E Tests". Three paragraphs:
+
+**Paragraph 1 — Purpose:**
+
+> "The `ingestion` service is a demo-scale synthetic-data generator that exercises the full event-driven write pipeline end-to-end (Gateway → EventSource → Kafka → Sensor → `details-write`). It runs as a single stateless deployment with no storage adapters, no CQRS split, and no EventSource/Sensor of its own — it is purely outbound."
+
+**Paragraph 2 — Flow:**
+
+> "A background poll loop ticks every `POLL_INTERVAL` (default 5m). For each query in `SEARCH_QUERIES`, the service calls `GET https://openlibrary.org/search.json`, validates each returned book (title, ISBN, authors, and publish year are required), and publishes accepted books via `POST {GATEWAY_URL}/v1/details`. Each publish carries a deterministic idempotency key `ingestion-isbn-<ISBN>` so the downstream `details-write` service deduplicates across cycles via `pkg/idempotency`. On-demand scrapes are also available via `POST /v1/ingestion/trigger` (optional body `{"queries": ["golang", "rust"]}`)."
+
+**Paragraph 3 — Config + link:**
+
+> "Configuration via `GATEWAY_URL`, `POLL_INTERVAL`, `SEARCH_QUERIES`, and `MAX_RESULTS_PER_QUERY` environment variables. Because idempotency is enforced at the write service, replays and overlapping cycles are safe. For the full design, port contracts, and metric definitions, see [docs/superpowers/specs/2026-04-14-ingestion-service-design.md](docs/superpowers/specs/2026-04-14-ingestion-service-design.md)."
+
+### Project Structure tree (services/ block at lines 608-634)
+
+Insert after the dlqueue entry:
+
+```
+│   └── ingestion/              # Producer (hex arch) — Open Library scraper, publishes to Gateway
+│       ├── cmd/main.go
+│       └── internal/
+│           ├── core/           # domain/, port/, service/
+│           └── adapter/
+│               ├── inbound/http/
+│               └── outbound/   # openlibrary/ (BookFetcher), gateway/ (EventPublisher)
+```
+
+### Releasing section (lines 676-711)
+
+Update any "6 services" references to "7 services" — specifically the bullet "changes to `pkg/`, `go.mod`, or `go.sum` trigger all 6 services" at line 682 becomes "trigger all 7 services".
+
+## CLAUDE.md Changes
+
+### Project Overview (line 5)
+
+Append one sentence to the existing overview paragraph:
+
+> "A standalone `ingestion` service polls the Open Library API and publishes `book-added` events through the Gateway, demonstrating the system as a self-hosted event broker."
+
+### Services table (append one row after the dlqueue row at line 18)
+
+```
+| **ingestion** | Producer (hex arch) | :8080 / :9090 admin | Open Library scraper; polls on interval, publishes book-added events to the Gateway |
+```
+
+Uses in-container port convention (`:8080 / :9090`) matching existing CLAUDE.md rows. Host-facing ports (`8086 / 9096`) are documented only in README.md — this matches the existing convention also followed in the dlqueue docs-update spec.
+
+### Architecture bullets (after the DLQ + Idempotency bullets)
+
+Insert one new bullet:
+
+> - **Ingestion**: `ingestion` service polls Open Library on `POLL_INTERVAL` → for each query in `SEARCH_QUERIES` → `POST {GATEWAY_URL}/v1/details` with `idempotency_key=ingestion-isbn-<ISBN>`. Stateless, single deployment, no CQRS split, no EventSource/Sensor of its own. Exercises the full write pipeline end-to-end.
+
+### Build Commands (lines 32-38)
+
+- `make build-all` description → "Build all 7 service binaries to bin/"
+- `make docker-build-all` description → "Build all 7 Docker images"
+
+### Run Locally (after the dlqueue block, before the productpage block)
+
+Add:
+
+````markdown
+**ingestion** (publishes to Gateway; requires Gateway/productpage reachable):
+
+```bash
+SERVICE_NAME=ingestion HTTP_PORT=8086 ADMIN_PORT=9096 \
+  GATEWAY_URL=http://localhost:8080 \
+  POLL_INTERVAL=5m \
+  SEARCH_QUERIES=programming,golang \
+  MAX_RESULTS_PER_QUERY=10 \
+  go run ./services/ingestion/cmd/
+```
+````
+
+### Optional env-var list (bottom of "Run Locally" section)
+
+Append one sentence to the paragraph listing optional env vars:
+
+> "Ingestion-specific: `GATEWAY_URL`, `POLL_INTERVAL`, `SEARCH_QUERIES`, `MAX_RESULTS_PER_QUERY`."
+
+### Shared Packages table
+
+**No change.** Ingestion adds no new package under `pkg/`.
+
+### Service Structure (hex arch) section
+
+**No change.** Ingestion follows the same structure, with the difference (no memory/postgres outbound adapters) captured in the new architecture bullet above.
+
+## Style Conventions
+
+- Preserve the `<h1 align="center">` header block at the top of README.md
+- Reuse existing mermaid node styling classes where possible; introduce one new stroke color (`#10b981` green) to visually distinguish ingestion from backend (grey), EventSource (green fill), and dlqueue (purple) nodes
+- Preserve existing table column order and formatting
+- Use backticks for file paths, code identifiers, and environment variables
+- Conventional commit style for the commit message
+
+## Deliverable
+
+One commit on the `feat/ingestion-service` branch (docs changes ship atomically with the implementation PR, mirroring the dlqueue-docs-update precedent):
+
+```
+docs: update README and CLAUDE.md for ingestion service
+
+Add ingestion service row to services tables, project structure, Quick
+Start, Run Locally, business metrics, and Docker image list. Update
+Event-Driven Write Flow and Cluster Architecture diagrams with the new
+producer node. Add new "Data Ingestion" subsection after Dead Letter
+Queue describing purpose, flow, and config. Bump "6 services" references
+to "7". Note ingestion's omission from the CQRS Deployment Split table.
+```
+
+## Validation
+
+- `git diff` review — verify no stray edits and that the 7-service count is consistent wherever it appears
+- Render both modified mermaid diagrams (Event-Driven Write Flow + Cluster Architecture) in a Markdown preview to confirm the new `ING` node and arrows render correctly
+- Spot-check every "N services" count reference in README.md and CLAUDE.md is consistent with 7
+- CI re-runs automatically on push; linters and link checks gate the merge
+
+## Out of Scope (v1)
+
+- Per-service `services/ingestion/README.md` — no existing convention in the repo
+- Updates to historical `docs/superpowers/specs/*` and `docs/superpowers/plans/*` — they are point-in-time artifacts
+- Admin UI documentation (no admin UI exists)
+- Runbook / troubleshooting guide (can be added later if operational issues surface)
+- Phase 2 synthetic review generation — already captured as a "Phase 2" section in the ingestion design spec itself


### PR DESCRIPTION
## Summary

Follow-up to #42 — commits that weren't pushed before the squash merge.

- **Documentation**: update README and CLAUDE.md with ingestion service (Quick Start, Services table, run-locally block, env vars, build/docker counts) plus design spec and plan for the docs update itself.
- **Gateway URL fix**: correct `GATEWAY_URL` in Helm values, design spec, and implementation plan to use `default-gateway` alias instead of the non-existent `default-gw-envoy` service.

## Test plan

- [x] Verified ingestion pod reaches the gateway after URL fix in local k3d cluster.
- [x] Reviewer: confirm `GATEWAY_URL` in `deploy/ingestion/values-local.yaml` resolves correctly in-cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)