### PR TITLE
fix(ci): add ingestion service to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
           - ratings
           - notification
           - dlqueue
+          - ingestion
       tag:
         description: "Full tag (e.g., details-v0.1.0)"
         required: true


### PR DESCRIPTION
## Summary
- Add `ingestion` to the `release.yml` `workflow_dispatch` service choice list
- Without this, `auto-tag.yml` dispatches for ingestion releases would fail since `ingestion` wasn't a valid option

## Test plan
- [ ] Verify `release.yml` accepts `ingestion` as a valid service input
- [ ] Trigger a manual release: `gh workflow run release.yml -f service=ingestion -f tag=ingestion-v0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)