### PR TITLE
feat: event-driven notifications via Kafka, replace parallel notify-* triggers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,18 @@ make e2e                # Docker Compose + shell smoke tests (memory backend)
 make docker-build-all   # Build all 7 Docker images
 ```
 
+## Compose vs k8s scope
+
+`make run` (docker-compose) is a lite development environment —
+postgres + redis + 5 backend services + productpage. Compose does
+NOT include Kafka, the ingestion service, Argo Events, or the
+observability stack. Producers fall back to a no-op publisher when
+`KAFKA_BROKERS` is unset; events are dropped. The full event-driven
+flow (ingestion + Kafka + Argo Events sensors driving notifications)
+and observability stack are exercised only via `make run-k8s`. Use
+`make e2e` for HTTP-level acceptance tests; the event chain is
+verified via Tempo traces after `make run-k8s`.
+
 ## Helm Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -274,6 +274,17 @@ make run-logs     # Tail logs
 make stop         # Stop and remove containers
 ```
 
+> **Lite mode.** Docker Compose runs the synchronous service mesh
+> only: postgres + redis + 5 backend services + productpage. Kafka,
+> the ingestion service, Argo Events, and the observability stack
+> are NOT included. Producers detect missing `KAFKA_BROKERS` and
+> fall back to a no-op publisher; events are dropped silently.
+>
+> The full event-driven path (ingestion polling Open Library →
+> Kafka → Argo Events EventSource → Sensor → notification HTTP
+> trigger) is exercised only via `make run-k8s` (k3d-based local
+> cluster).
+
 ---
 
 ## Makefile Targets
@@ -580,6 +591,12 @@ bash test/e2e/run-tests.sh
 ```
 
 Individual test scripts under `test/e2e/` cover health endpoints, CRUD operations, and cross-service integration (e.g., reviews fetching ratings).
+
+> **Scope.** `make e2e` covers HTTP-level acceptance tests
+> (idempotency, validation, CRUD round-trips) under the lite-mode
+> compose stack. The event chain (Kafka publish, Argo Events sensor,
+> notification HTTP trigger) is verified end-to-end via Tempo trace
+> inspection after `make run-k8s`.
 
 ---
 

--- a/charts/bookinfo-service/Chart.yaml
+++ b/charts/bookinfo-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bookinfo-service
 description: Reusable Helm chart for event-driven-bookinfo microservices
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "0.0.0"
 maintainers:
   - name: kaio6fellipe

--- a/charts/bookinfo-service/templates/consumer-sensor.yaml
+++ b/charts/bookinfo-service/templates/consumer-sensor.yaml
@@ -35,8 +35,11 @@ spec:
       {{- with $event.filter }}
       {{- with .ceType }}
       filters:
-        context:
-          type: {{ . | quote }}
+        data:
+          - path: headers.ce_type
+            type: string
+            value:
+              - {{ . | quote }}
       {{- end }}
       {{- end }}
     {{- end }}

--- a/charts/bookinfo-service/templates/consumer-sensor.yaml
+++ b/charts/bookinfo-service/templates/consumer-sensor.yaml
@@ -32,6 +32,13 @@ spec:
     - name: {{ $eventName }}-dep
       eventSourceName: {{ $event.eventSourceName }}
       eventName: {{ $event.eventName }}
+      {{- with $event.filter }}
+      {{- with .ceType }}
+      filters:
+        context:
+          type: {{ . | quote }}
+      {{- end }}
+      {{- end }}
     {{- end }}
   triggers:
     {{- range $eventName, $event := $.Values.events.consumed }}

--- a/charts/bookinfo-service/templates/kafka-eventsource.yaml
+++ b/charts/bookinfo-service/templates/kafka-eventsource.yaml
@@ -13,15 +13,16 @@ metadata:
   {{- end }}
 spec:
   eventBusName: {{ default "kafka" $event.eventBusName }}
-  {{- with $.Values.observability.otelEndpoint }}
   template:
+    serviceAccountName: {{ include "bookinfo-service.serviceAccountName" $ }}
+    {{- with $.Values.observability.otelEndpoint }}
     container:
       env:
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: {{ . | quote }}
         - name: OTEL_SERVICE_NAME
           value: {{ printf "%s-%s-eventsource" (include "bookinfo-service.fullname" $) $eventName | quote }}
-  {{- end }}
+    {{- end }}
   kafka:
     {{ $eventName }}:
       url: {{ required "events.kafka.broker must be set when events.exposed is defined" $.Values.events.kafka.broker }}

--- a/charts/bookinfo-service/templates/kafka-eventsource.yaml
+++ b/charts/bookinfo-service/templates/kafka-eventsource.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ include "bookinfo-service.fullname" $ }}-{{ $eventName }}
   labels:
     {{- include "bookinfo-service.labels" $ | nindent 4 }}
+  {{- with $event.eventTypes }}
+  annotations:
+    bookinfo.io/emitted-ce-types: {{ join "," . | quote }}
+  {{- end }}
 spec:
   eventBusName: {{ default "kafka" $event.eventBusName }}
   {{- with $.Values.observability.otelEndpoint }}

--- a/charts/bookinfo-service/values.yaml
+++ b/charts/bookinfo-service/values.yaml
@@ -157,14 +157,18 @@ events:
     #   topic: kafka_topic_name
     #   eventBusName: kafka
     #   contentType: application/json
+    #   eventTypes:                        # optional, rendered as bookinfo.io/emitted-ce-types annotation on the EventSource
+    #     - com.bookinfo.<service>.<event>
   consumed: {}
     # event-name:
     #   eventSourceName: producer-event-name
     #   eventName: event-name
+    #   filter:                             # optional
+    #     ceType: com.bookinfo.<service>.<event>   # matches Argo Events filters.context.type
     #   triggers:
     #     - name: trigger-name
     #       url: self
-    #       path: /v1/endpoint        # required when url is "self"
+    #       path: /v1/endpoint             # required when url is "self"
     #       method: POST
     #       payload:
     #         - passthrough

--- a/deploy/details/values-local.yaml
+++ b/deploy/details/values-local.yaml
@@ -12,6 +12,8 @@ postgresql:
 
 config:
   LOG_LEVEL: "debug"
+  KAFKA_BROKERS: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  KAFKA_TOPIC: "bookinfo_details_events"
 
 observability:
   otelEndpoint: "http://alloy-metrics-traces.observability.svc.cluster.local:4317"
@@ -41,23 +43,6 @@ cqrs:
           url: self
           payload:
             - passthrough
-        - name: notify-book-added
-          url: "http://notification.bookinfo.svc.cluster.local/v1/notifications"
-          method: POST
-          payload:
-            - src:
-                dependencyName: book-added-dep
-                dataKey: body.title
-              dest: subject
-            - src:
-                value: "New book added"
-              dest: body
-            - src:
-                value: "system@bookinfo"
-              dest: recipient
-            - src:
-                value: "email"
-              dest: channel
 
 sensor:
   dlq:
@@ -71,6 +56,13 @@ gateway:
 events:
   kafka:
     broker: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  exposed:
+    events:
+      topic: bookinfo_details_events
+      eventBusName: kafka
+      contentType: application/json
+      eventTypes:
+        - com.bookinfo.details.book-added
   consumed:
     raw-books-details:
       eventSourceName: ingestion-raw-books-details

--- a/deploy/notification/values-local.yaml
+++ b/deploy/notification/values-local.yaml
@@ -16,3 +16,35 @@ config:
 observability:
   otelEndpoint: "http://alloy-metrics-traces.observability.svc.cluster.local:4317"
   pyroscopeAddress: "http://pyroscope.observability.svc.cluster.local:4040"
+
+events:
+  kafka:
+    broker: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  consumed:
+    book-added:
+      eventSourceName: details-events
+      eventName: events
+      filter:
+        ceType: com.bookinfo.details.book-added
+      triggers:
+        - name: notify-book-added
+          url: self
+          path: /v1/notifications
+          method: POST
+          payload:
+            - src:
+                dependencyName: book-added-dep
+                dataKey: body.title
+              dest: subject
+            - src:
+                value: "New book added"
+              dest: body
+            - src:
+                value: "system@bookinfo"
+              dest: recipient
+            - src:
+                value: "email"
+              dest: channel
+      dlq:
+        enabled: true
+        url: "http://dlq-event-received-eventsource-svc.bookinfo.svc.cluster.local:12004/v1/events"

--- a/deploy/notification/values-local.yaml
+++ b/deploy/notification/values-local.yaml
@@ -48,3 +48,57 @@ events:
       dlq:
         enabled: true
         url: "http://dlq-event-received-eventsource-svc.bookinfo.svc.cluster.local:12004/v1/events"
+    review-submitted:
+      eventSourceName: reviews-events
+      eventName: events
+      filter:
+        ceType: com.bookinfo.reviews.review-submitted
+      triggers:
+        - name: notify-review-submitted
+          url: self
+          path: /v1/notifications
+          method: POST
+          payload:
+            - src:
+                dependencyName: review-submitted-dep
+                dataKey: body.product_id
+              dest: subject
+            - src:
+                value: "New review submitted"
+              dest: body
+            - src:
+                value: "system@bookinfo"
+              dest: recipient
+            - src:
+                value: "email"
+              dest: channel
+      dlq:
+        enabled: true
+        url: "http://dlq-event-received-eventsource-svc.bookinfo.svc.cluster.local:12004/v1/events"
+    review-deleted:
+      eventSourceName: reviews-events
+      eventName: events
+      filter:
+        ceType: com.bookinfo.reviews.review-deleted
+      triggers:
+        - name: notify-review-deleted
+          url: self
+          path: /v1/notifications
+          method: POST
+          payload:
+            - src:
+                dependencyName: review-deleted-dep
+                dataKey: body.product_id
+              dest: subject
+            - src:
+                value: "Review deleted"
+              dest: body
+            - src:
+                value: "system@bookinfo"
+              dest: recipient
+            - src:
+                value: "email"
+              dest: channel
+      dlq:
+        enabled: true
+        url: "http://dlq-event-received-eventsource-svc.bookinfo.svc.cluster.local:12004/v1/events"

--- a/deploy/notification/values-local.yaml
+++ b/deploy/notification/values-local.yaml
@@ -102,3 +102,30 @@ events:
       dlq:
         enabled: true
         url: "http://dlq-event-received-eventsource-svc.bookinfo.svc.cluster.local:12004/v1/events"
+    rating-submitted:
+      eventSourceName: ratings-events
+      eventName: events
+      filter:
+        ceType: com.bookinfo.ratings.rating-submitted
+      triggers:
+        - name: notify-rating-submitted
+          url: self
+          path: /v1/notifications
+          method: POST
+          payload:
+            - src:
+                dependencyName: rating-submitted-dep
+                dataKey: body.product_id
+              dest: subject
+            - src:
+                value: "New rating submitted"
+              dest: body
+            - src:
+                value: "system@bookinfo"
+              dest: recipient
+            - src:
+                value: "email"
+              dest: channel
+      dlq:
+        enabled: true
+        url: "http://dlq-event-received-eventsource-svc.bookinfo.svc.cluster.local:12004/v1/events"

--- a/deploy/notification/values-local.yaml
+++ b/deploy/notification/values-local.yaml
@@ -88,7 +88,7 @@ events:
           payload:
             - src:
                 dependencyName: review-deleted-dep
-                dataKey: body.product_id
+                dataKey: body.review_id
               dest: subject
             - src:
                 value: "Review deleted"

--- a/deploy/observability/local/kube-prometheus-stack-values.yaml
+++ b/deploy/observability/local/kube-prometheus-stack-values.yaml
@@ -110,7 +110,7 @@ grafana:
       memory: 128Mi
     limits:
       cpu: 300m
-      memory: 256Mi
+      memory: 512Mi
 
 alertmanager:
   enabled: false

--- a/deploy/ratings/values-local.yaml
+++ b/deploy/ratings/values-local.yaml
@@ -12,10 +12,23 @@ postgresql:
 
 config:
   LOG_LEVEL: "debug"
+  KAFKA_BROKERS: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  KAFKA_TOPIC: "bookinfo_ratings_events"
 
 observability:
   otelEndpoint: "http://alloy-metrics-traces.observability.svc.cluster.local:4317"
   pyroscopeAddress: "http://pyroscope.observability.svc.cluster.local:4040"
+
+events:
+  kafka:
+    broker: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  exposed:
+    events:
+      topic: bookinfo_ratings_events
+      eventBusName: kafka
+      contentType: application/json
+      eventTypes:
+        - com.bookinfo.ratings.rating-submitted
 
 cqrs:
   enabled: true
@@ -41,23 +54,6 @@ cqrs:
           url: self
           payload:
             - passthrough
-        - name: notify-rating-submitted
-          url: "http://notification.bookinfo.svc.cluster.local/v1/notifications"
-          method: POST
-          payload:
-            - src:
-                dependencyName: rating-submitted-dep
-                dataKey: body.product_id
-              dest: subject
-            - src:
-                value: "New rating submitted"
-              dest: body
-            - src:
-                value: "system@bookinfo"
-              dest: recipient
-            - src:
-                value: "email"
-              dest: channel
 
 sensor:
   dlq:

--- a/deploy/reviews/values-local.yaml
+++ b/deploy/reviews/values-local.yaml
@@ -13,6 +13,8 @@ postgresql:
 config:
   LOG_LEVEL: "debug"
   RATINGS_SERVICE_URL: "http://ratings.bookinfo.svc.cluster.local"
+  KAFKA_BROKERS: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  KAFKA_TOPIC: "bookinfo_reviews_events"
 
 observability:
   otelEndpoint: "http://alloy-metrics-traces.observability.svc.cluster.local:4317"
@@ -42,23 +44,6 @@ cqrs:
           url: self
           payload:
             - passthrough
-        - name: notify-review-submitted
-          url: "http://notification.bookinfo.svc.cluster.local/v1/notifications"
-          method: POST
-          payload:
-            - src:
-                dependencyName: review-submitted-dep
-                dataKey: body.product_id
-              dest: subject
-            - src:
-                value: "New review submitted"
-              dest: body
-            - src:
-                value: "system@bookinfo"
-              dest: recipient
-            - src:
-                value: "email"
-              dest: channel
     review-deleted:
       port: 12003
       method: POST
@@ -71,23 +56,6 @@ cqrs:
                 dependencyName: review-deleted-dep
                 dataKey: body.review_id
               dest: review_id
-        - name: notify-review-deleted
-          url: "http://notification.bookinfo.svc.cluster.local/v1/notifications"
-          method: POST
-          payload:
-            - src:
-                dependencyName: review-deleted-dep
-                dataKey: body.product_id
-              dest: subject
-            - src:
-                value: "Review deleted"
-              dest: body
-            - src:
-                value: "system@bookinfo"
-              dest: recipient
-            - src:
-                value: "email"
-              dest: channel
 
 sensor:
   dlq:
@@ -97,3 +65,15 @@ gateway:
   name: default-gw
   namespace: platform
   sectionName: web
+
+events:
+  kafka:
+    broker: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  exposed:
+    events:
+      topic: bookinfo_reviews_events
+      eventBusName: kafka
+      contentType: application/json
+      eventTypes:
+        - com.bookinfo.reviews.review-submitted
+        - com.bookinfo.reviews.review-deleted

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,13 @@
-# Local development compose file.
+# Local development compose file — lite mode.
+#
+# Scope: postgres + redis + 5 backend services + productpage.
+# NOT included: Kafka, ingestion service, Argo Events, observability.
+# Producers detect missing KAFKA_BROKERS and fall back to a no-op
+# publisher; events are dropped silently.
+#
+# The full event-driven path (ingestion → Kafka → Argo Events sensor
+# → notification HTTP trigger) requires `make run-k8s` (k3d cluster).
+#
 # Usage: make run | make run-logs | make stop | make seed
 #   or:  docker compose up --build
 services:

--- a/docs/superpowers/plans/2026-04-24-event-driven-notifications.md
+++ b/docs/superpowers/plans/2026-04-24-event-driven-notifications.md
@@ -1,0 +1,3118 @@
+# Event-Driven Notifications Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace parallel `notify-*` sensor triggers with CloudEvents emitted by write services after successful persistence; notification consumes via Argo Events with `ce_type` filtering. Notifications fire iff the corresponding write succeeded.
+
+**Architecture:** Each write service (details, reviews, ratings) gains a `franz-go` Kafka producer wired through a new `EventPublisher` outbound port, called unconditionally after the idempotency branch. Returning 500 on publish failure triggers Argo Events sensor retries — idempotency dedupes the second Save while the publish retries. Notification stays HTTP-only; its Consumer Sensor filters events by `ce_type` and maps payload fields to the notification API.
+
+**Tech Stack:** Go 1.22, `github.com/twmb/franz-go`, Argo Events 1.9+, Helm 3, CloudEvents v1.0 over Kafka headers.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-24-event-driven-notifications-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+```
+charts/bookinfo-service/templates/
+  (no new files — existing templates extended)
+
+services/details/internal/
+  core/domain/event.go                          # BookAddedEvent type
+  core/port/publisher.go                        # EventPublisher port
+  adapter/outbound/kafka/producer.go            # franz-go adapter
+  adapter/outbound/kafka/producer_test.go       # adapter unit test
+  adapter/outbound/kafka/noop.go                # no-op publisher
+
+services/reviews/internal/
+  core/domain/event.go                          # ReviewSubmittedEvent, ReviewDeletedEvent
+  core/port/publisher.go
+  adapter/outbound/kafka/producer.go
+  adapter/outbound/kafka/producer_test.go
+  adapter/outbound/kafka/noop.go
+
+services/ratings/internal/
+  core/domain/event.go                          # RatingSubmittedEvent
+  core/port/publisher.go
+  adapter/outbound/kafka/producer.go
+  adapter/outbound/kafka/producer_test.go
+  adapter/outbound/kafka/noop.go
+```
+
+### Modified files
+
+```
+charts/bookinfo-service/templates/kafka-eventsource.yaml   # add eventTypes annotation
+charts/bookinfo-service/templates/consumer-sensor.yaml     # add filter.ceType
+charts/bookinfo-service/values.yaml                        # document new fields
+
+deploy/details/values-local.yaml         # add events.exposed, KAFKA_*, drop notify-book-added
+deploy/reviews/values-local.yaml         # add events.exposed, KAFKA_*, drop notify-review-*
+deploy/ratings/values-local.yaml         # add events.exposed, KAFKA_*, drop notify-rating-submitted
+deploy/notification/values-local.yaml    # add events.consumed × 4
+
+services/details/cmd/main.go                                  # wire publisher
+services/details/internal/core/service/detail_service.go      # always-publish semantics
+services/details/internal/core/service/detail_service_test.go # fake publisher assertions
+
+services/reviews/cmd/main.go
+services/reviews/internal/core/service/review_service.go      # + idempotent DeleteReview
+services/reviews/internal/core/service/review_service_test.go # (if exists) or handler test
+services/reviews/internal/adapter/inbound/http/handler.go     # (if needed) return 204 on delete dedup
+
+services/ratings/cmd/main.go
+services/ratings/internal/core/service/rating_service.go
+services/ratings/internal/core/service/rating_service_test.go
+```
+
+Each service's `kafka` adapter package follows ingestion's layout (`services/ingestion/internal/adapter/outbound/kafka/`) exactly — fake `Client` interface for testability, CloudEvents headers, `ensureTopic` on startup.
+
+---
+
+## Phase 1 — Chart extensions
+
+Low risk, low coupling. Done first so Helm values written later can rely on the new fields.
+
+### Task 1: Render `eventTypes` list as EventSource annotation
+
+**Files:**
+- Modify: `charts/bookinfo-service/templates/kafka-eventsource.yaml`
+
+- [ ] **Step 1: Read current template to confirm structure**
+
+Run: `cat charts/bookinfo-service/templates/kafka-eventsource.yaml`
+
+Confirms current metadata block:
+```yaml
+metadata:
+  name: {{ include "bookinfo-service.fullname" $ }}-{{ $eventName }}
+  labels:
+    {{- include "bookinfo-service.labels" $ | nindent 4 }}
+```
+
+- [ ] **Step 2: Add annotations block under metadata**
+
+Replace the metadata block with:
+```yaml
+metadata:
+  name: {{ include "bookinfo-service.fullname" $ }}-{{ $eventName }}
+  labels:
+    {{- include "bookinfo-service.labels" $ | nindent 4 }}
+  {{- with $event.eventTypes }}
+  annotations:
+    bookinfo.io/emitted-ce-types: {{ join "," . | quote }}
+  {{- end }}
+```
+
+- [ ] **Step 3: Verify chart still renders for ingestion (which has no eventTypes yet)**
+
+Run: `helm template test charts/bookinfo-service -f deploy/ingestion/values-local.yaml | grep -A3 "kind: EventSource"`
+
+Expected: EventSource `ingestion-raw-books-details` renders without an `annotations:` block (since `eventTypes` not defined).
+
+- [ ] **Step 4: Verify with a temporary values snippet that annotation renders when eventTypes present**
+
+Run:
+```bash
+helm template test charts/bookinfo-service -f deploy/ingestion/values-local.yaml \
+  --set 'events.exposed.raw-books-details.eventTypes[0]=com.bookinfo.ingestion.book-added' \
+  | grep -A5 "kind: EventSource"
+```
+
+Expected: rendered EventSource contains:
+```yaml
+annotations:
+  bookinfo.io/emitted-ce-types: "com.bookinfo.ingestion.book-added"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charts/bookinfo-service/templates/kafka-eventsource.yaml
+git commit -m "feat(chart): render eventTypes list as EventSource annotation"
+```
+
+---
+
+### Task 2: Add `filter.ceType` support to consumer-sensor dependencies
+
+**Files:**
+- Modify: `charts/bookinfo-service/templates/consumer-sensor.yaml`
+
+- [ ] **Step 1: Locate the dependencies block**
+
+Open `charts/bookinfo-service/templates/consumer-sensor.yaml` — dependencies render around lines 30-36:
+```yaml
+dependencies:
+  {{- range $eventName, $event := $.Values.events.consumed }}
+  - name: {{ $eventName }}-dep
+    eventSourceName: {{ $event.eventSourceName }}
+    eventName: {{ $event.eventName }}
+  {{- end }}
+```
+
+- [ ] **Step 2: Add optional `filters.context.type` clause**
+
+Replace the dependencies block with:
+```yaml
+dependencies:
+  {{- range $eventName, $event := $.Values.events.consumed }}
+  - name: {{ $eventName }}-dep
+    eventSourceName: {{ $event.eventSourceName }}
+    eventName: {{ $event.eventName }}
+    {{- with $event.filter }}
+    {{- with .ceType }}
+    filters:
+      context:
+        type: {{ . | quote }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
+```
+
+- [ ] **Step 3: Verify no regression in details service (consumes ingestion without a filter)**
+
+Run: `helm template test charts/bookinfo-service -f deploy/details/values-local.yaml | grep -A3 "raw-books-details-dep"`
+
+Expected: `raw-books-details-dep` renders with `eventSourceName` and `eventName`, no `filters:` block.
+
+- [ ] **Step 4: Verify filter renders when set**
+
+Run:
+```bash
+helm template test charts/bookinfo-service -f deploy/details/values-local.yaml \
+  --set 'events.consumed.raw-books-details.filter.ceType=com.example.test' \
+  | grep -A5 "raw-books-details-dep"
+```
+
+Expected: dependency includes:
+```yaml
+filters:
+  context:
+    type: "com.example.test"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add charts/bookinfo-service/templates/consumer-sensor.yaml
+git commit -m "feat(chart): optional ce_type filter on consumer sensor dependencies"
+```
+
+---
+
+### Task 3: Document new fields in chart `values.yaml`
+
+**Files:**
+- Modify: `charts/bookinfo-service/values.yaml`
+
+- [ ] **Step 1: Locate events schema (around line 151)**
+
+Current block:
+```yaml
+# -- Kafka event pipeline (independent of CQRS)
+events:
+  kafka:
+    broker: ""
+  exposed: {}
+    # event-name:
+    #   topic: kafka_topic_name
+    #   eventBusName: kafka
+    #   contentType: application/json
+  consumed: {}
+    # event-name:
+    #   eventSourceName: producer-event-name
+    #   ...
+```
+
+- [ ] **Step 2: Update commented schema with the new optional fields**
+
+Replace the `events:` block with:
+```yaml
+# -- Kafka event pipeline (independent of CQRS)
+events:
+  kafka:
+    broker: ""
+  exposed: {}
+    # event-name:
+    #   topic: kafka_topic_name
+    #   eventBusName: kafka
+    #   contentType: application/json
+    #   eventTypes:                        # optional, rendered as bookinfo.io/emitted-ce-types annotation on the EventSource
+    #     - com.bookinfo.<service>.<event>
+  consumed: {}
+    # event-name:
+    #   eventSourceName: producer-event-name
+    #   eventName: event-name
+    #   filter:                             # optional
+    #     ceType: com.bookinfo.<service>.<event>   # matches Argo Events filters.context.type
+    #   triggers:
+    #     - name: trigger-name
+    #       url: self
+    #       path: /v1/endpoint             # required when url is "self"
+    #       method: POST
+    #       payload:
+    #         - passthrough
+    #   retryStrategy: {}
+    #   dlq:
+    #     enabled: true
+    #     url: ""
+```
+
+- [ ] **Step 3: Run chart lint**
+
+Run: `make helm-lint`
+
+Expected: `==> Linting charts/bookinfo-service` followed by `1 chart(s) linted, 0 chart(s) failed`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add charts/bookinfo-service/values.yaml
+git commit -m "docs(chart): document events.exposed.eventTypes and events.consumed.filter.ceType"
+```
+
+---
+
+## Phase 2 — Details service producer
+
+Implements the pattern end-to-end for one service. Reviews and ratings mirror this phase.
+
+### Task 4: Add domain event type and outbound port
+
+**Files:**
+- Create: `services/details/internal/core/domain/event.go`
+- Create: `services/details/internal/core/port/publisher.go`
+
+- [ ] **Step 1: Create `event.go`**
+
+Write this file exactly:
+```go
+// Package domain contains pure domain types for the details service.
+package domain
+
+// BookAddedEvent is the domain event emitted after a successful AddDetail.
+// Carries the business payload shape consumed by downstream services (e.g. notification).
+type BookAddedEvent struct {
+	ID             string
+	Title          string
+	Author         string
+	Year           int
+	Type           string
+	Pages          int
+	Publisher      string
+	Language       string
+	ISBN10         string
+	ISBN13         string
+	IdempotencyKey string
+}
+```
+
+- [ ] **Step 2: Create `publisher.go`**
+
+Write this file exactly:
+```go
+// file: services/details/internal/core/port/publisher.go
+package port
+
+import (
+	"context"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/domain"
+)
+
+// EventPublisher is the outbound port for emitting domain events to a message broker.
+type EventPublisher interface {
+	PublishBookAdded(ctx context.Context, evt domain.BookAddedEvent) error
+}
+```
+
+- [ ] **Step 3: Run go build to verify compile**
+
+Run: `go build ./services/details/...`
+
+Expected: no output, exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/details/internal/core/domain/event.go services/details/internal/core/port/publisher.go
+git commit -m "feat(details): add BookAddedEvent domain type and EventPublisher port"
+```
+
+---
+
+### Task 5: Kafka producer adapter — write failing test first
+
+**Files:**
+- Create: `services/details/internal/adapter/outbound/kafka/producer_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create the test file:
+```go
+// file: services/details/internal/adapter/outbound/kafka/producer_test.go
+package kafka_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/kafka"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/domain"
+)
+
+type fakeClient struct {
+	mu      sync.Mutex
+	records []*kgo.Record
+}
+
+func (f *fakeClient) ProduceSync(_ context.Context, rs ...*kgo.Record) kgo.ProduceResults {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var results kgo.ProduceResults
+	for _, r := range rs {
+		f.records = append(f.records, r)
+		results = append(results, kgo.ProduceResult{Record: r})
+	}
+	return results
+}
+
+func (f *fakeClient) Close() {}
+
+type errorClient struct{}
+
+func (e *errorClient) ProduceSync(_ context.Context, rs ...*kgo.Record) kgo.ProduceResults {
+	var results kgo.ProduceResults
+	for _, r := range rs {
+		results = append(results, kgo.ProduceResult{Record: r, Err: context.DeadlineExceeded})
+	}
+	return results
+}
+
+func (e *errorClient) Close() {}
+
+func TestPublishBookAdded(t *testing.T) {
+	t.Parallel()
+
+	evt := domain.BookAddedEvent{
+		ID:             "det_123",
+		Title:          "The Go Programming Language",
+		Author:         "Alan Donovan, Brian Kernighan",
+		Year:           2015,
+		Type:           "paperback",
+		Pages:          380,
+		Publisher:      "Addison-Wesley",
+		Language:       "en",
+		ISBN10:         "",
+		ISBN13:         "9780134190440",
+		IdempotencyKey: "det-idem-123",
+	}
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_details_events")
+
+	if err := p.PublishBookAdded(context.Background(), evt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	if len(fc.records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(fc.records))
+	}
+	r := fc.records[0]
+
+	if r.Topic != "bookinfo_details_events" {
+		t.Errorf("topic = %q, want %q", r.Topic, "bookinfo_details_events")
+	}
+	if string(r.Key) != evt.IdempotencyKey {
+		t.Errorf("key = %q, want %q", string(r.Key), evt.IdempotencyKey)
+	}
+
+	headers := map[string]string{}
+	for _, h := range r.Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["ce_type"] != "com.bookinfo.details.book-added" {
+		t.Errorf("ce_type = %q, want %q", headers["ce_type"], "com.bookinfo.details.book-added")
+	}
+	if headers["ce_source"] != "details" {
+		t.Errorf("ce_source = %q, want %q", headers["ce_source"], "details")
+	}
+	if headers["ce_specversion"] != "1.0" {
+		t.Errorf("ce_specversion = %q, want %q", headers["ce_specversion"], "1.0")
+	}
+	if headers["ce_subject"] != evt.IdempotencyKey {
+		t.Errorf("ce_subject = %q, want %q", headers["ce_subject"], evt.IdempotencyKey)
+	}
+	if headers["content-type"] != "application/json" {
+		t.Errorf("content-type = %q, want %q", headers["content-type"], "application/json")
+	}
+	if headers["ce_id"] == "" {
+		t.Error("ce_id header is empty, expected a UUID")
+	}
+	if headers["ce_time"] == "" {
+		t.Error("ce_time header is empty, expected RFC3339 timestamp")
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(r.Value, &body); err != nil {
+		t.Fatalf("failed to unmarshal record value: %v", err)
+	}
+	if body["title"] != evt.Title {
+		t.Errorf("body title = %q, want %q", body["title"], evt.Title)
+	}
+	if body["author"] != evt.Author {
+		t.Errorf("body author = %q, want %q", body["author"], evt.Author)
+	}
+	if body["year"].(float64) != float64(evt.Year) {
+		t.Errorf("body year = %v, want %v", body["year"], evt.Year)
+	}
+	if body["isbn_13"] != evt.ISBN13 {
+		t.Errorf("body isbn_13 = %q, want %q", body["isbn_13"], evt.ISBN13)
+	}
+	if body["idempotency_key"] != evt.IdempotencyKey {
+		t.Errorf("body idempotency_key = %q, want %q", body["idempotency_key"], evt.IdempotencyKey)
+	}
+}
+
+func TestPublishBookAdded_ProduceError(t *testing.T) {
+	t.Parallel()
+
+	p := kafkaadapter.NewProducerWithClient(&errorClient{}, "bookinfo_details_events")
+
+	err := p.PublishBookAdded(context.Background(), domain.BookAddedEvent{
+		Title: "t", Author: "a", Year: 2024, Type: "paperback",
+		IdempotencyKey: "idem-x",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (producer not defined yet)**
+
+Run: `go test ./services/details/internal/adapter/outbound/kafka/... -v`
+
+Expected: compile error `undefined: kafkaadapter.NewProducerWithClient` or similar.
+
+---
+
+### Task 6: Implement Kafka producer adapter
+
+**Files:**
+- Create: `services/details/internal/adapter/outbound/kafka/producer.go`
+
+- [ ] **Step 1: Create producer implementation**
+
+Write this file exactly:
+```go
+// Package kafka implements the EventPublisher port using a native Kafka producer.
+package kafka
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/domain"
+)
+
+const (
+	ceTypeBookAdded = "com.bookinfo.details.book-added"
+	ceSource        = "details"
+	ceVersion       = "1.0"
+
+	defaultPartitions        = 3
+	defaultReplicationFactor = 1
+)
+
+// bookAddedBody is the marshaled Kafka record value for a BookAddedEvent.
+type bookAddedBody struct {
+	ID             string `json:"id,omitempty"`
+	Title          string `json:"title"`
+	Author         string `json:"author"`
+	Year           int    `json:"year"`
+	Type           string `json:"type"`
+	Pages          int    `json:"pages,omitempty"`
+	Publisher      string `json:"publisher,omitempty"`
+	Language       string `json:"language,omitempty"`
+	ISBN10         string `json:"isbn_10,omitempty"`
+	ISBN13         string `json:"isbn_13,omitempty"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+// Client abstracts the franz-go client for testing.
+type Client interface {
+	ProduceSync(ctx context.Context, rs ...*kgo.Record) kgo.ProduceResults
+	Close()
+}
+
+// Producer implements port.EventPublisher by producing to Kafka.
+type Producer struct {
+	client Client
+	topic  string
+}
+
+// NewProducer creates a real Kafka producer connecting to the given brokers.
+// Auto-creates the topic if it does not exist.
+func NewProducer(ctx context.Context, brokers, topic string) (*Producer, error) {
+	seeds := strings.Split(brokers, ",")
+
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(seeds...),
+		kgo.DefaultProduceTopic(topic),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating Kafka client: %w", err)
+	}
+
+	if err := ensureTopic(ctx, client, topic); err != nil {
+		client.Close()
+		return nil, fmt.Errorf("ensuring topic %q: %w", topic, err)
+	}
+
+	return &Producer{client: client, topic: topic}, nil
+}
+
+// NewProducerWithClient creates a Producer with an injected client (for testing).
+func NewProducerWithClient(client Client, topic string) *Producer {
+	return &Producer{client: client, topic: topic}
+}
+
+// PublishBookAdded sends a book-added CloudEvent to Kafka.
+func (p *Producer) PublishBookAdded(ctx context.Context, evt domain.BookAddedEvent) error {
+	logger := logging.FromContext(ctx)
+
+	body := bookAddedBody{
+		ID:             evt.ID,
+		Title:          evt.Title,
+		Author:         evt.Author,
+		Year:           evt.Year,
+		Type:           evt.Type,
+		Pages:          evt.Pages,
+		Publisher:      evt.Publisher,
+		Language:       evt.Language,
+		ISBN10:         evt.ISBN10,
+		ISBN13:         evt.ISBN13,
+		IdempotencyKey: evt.IdempotencyKey,
+	}
+
+	value, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshaling book-added event: %w", err)
+	}
+
+	now := time.Now().UTC()
+	record := &kgo.Record{
+		Topic: p.topic,
+		Key:   []byte(evt.IdempotencyKey),
+		Value: value,
+		Headers: []kgo.RecordHeader{
+			{Key: "ce_specversion", Value: []byte(ceVersion)},
+			{Key: "ce_type", Value: []byte(ceTypeBookAdded)},
+			{Key: "ce_source", Value: []byte(ceSource)},
+			{Key: "ce_id", Value: []byte(uuid.New().String())},
+			{Key: "ce_time", Value: []byte(now.Format(time.RFC3339))},
+			{Key: "ce_subject", Value: []byte(evt.IdempotencyKey)},
+			{Key: "content-type", Value: []byte("application/json")},
+		},
+	}
+
+	results := p.client.ProduceSync(ctx, record)
+	if err := results.FirstErr(); err != nil {
+		return fmt.Errorf("producing to Kafka: %w", err)
+	}
+
+	logger.Debug("published book-added event to Kafka", "topic", p.topic, "idempotency_key", evt.IdempotencyKey)
+	return nil
+}
+
+// Close flushes pending messages and closes the Kafka client.
+func (p *Producer) Close() {
+	p.client.Close()
+}
+
+func ensureTopic(ctx context.Context, client *kgo.Client, topic string) error {
+	admin := kadm.NewClient(client)
+
+	resp, err := admin.CreateTopics(ctx, int32(defaultPartitions), int16(defaultReplicationFactor), nil, topic)
+	if err != nil {
+		return fmt.Errorf("creating topic: %w", err)
+	}
+
+	for _, t := range resp.Sorted() {
+		if t.Err != nil && t.ErrMessage != "" && !isTopicExistsError(t.ErrMessage) {
+			return fmt.Errorf("topic %q: %s", t.Topic, t.ErrMessage)
+		}
+	}
+
+	return nil
+}
+
+func isTopicExistsError(msg string) bool {
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "TOPIC_ALREADY_EXISTS")
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `go test ./services/details/internal/adapter/outbound/kafka/... -v`
+
+Expected: both tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/details/internal/adapter/outbound/kafka/producer.go \
+        services/details/internal/adapter/outbound/kafka/producer_test.go
+git commit -m "feat(details): add franz-go Kafka producer for BookAddedEvent"
+```
+
+---
+
+### Task 7: Add no-op publisher for docker-compose / unit tests
+
+**Files:**
+- Create: `services/details/internal/adapter/outbound/kafka/noop.go`
+
+- [ ] **Step 1: Create no-op adapter**
+
+Write this file exactly:
+```go
+// file: services/details/internal/adapter/outbound/kafka/noop.go
+package kafka
+
+import (
+	"context"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/domain"
+)
+
+// NoopPublisher implements port.EventPublisher but performs no work.
+// Used when KAFKA_BROKERS is not set (e.g. docker-compose, unit tests).
+type NoopPublisher struct{}
+
+// NewNoopPublisher returns a publisher that silently succeeds.
+func NewNoopPublisher() *NoopPublisher { return &NoopPublisher{} }
+
+// PublishBookAdded logs at debug and returns nil.
+func (n *NoopPublisher) PublishBookAdded(ctx context.Context, evt domain.BookAddedEvent) error {
+	logging.FromContext(ctx).Debug("noop publisher: book-added event discarded", "idempotency_key", evt.IdempotencyKey)
+	return nil
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run: `go build ./services/details/...`
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/details/internal/adapter/outbound/kafka/noop.go
+git commit -m "feat(details): add no-op publisher for broker-less environments"
+```
+
+---
+
+### Task 8: Wire publisher into `DetailService` with always-publish semantics
+
+**Files:**
+- Modify: `services/details/internal/core/service/detail_service.go`
+- Modify: `services/details/internal/core/service/detail_service_test.go`
+
+- [ ] **Step 1: Write the new service test (TDD)**
+
+Open `services/details/internal/core/service/detail_service_test.go`. Add these imports and helpers at the top:
+
+```go
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/idempotency"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/memory"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/domain"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/service"
+)
+
+type fakePublisher struct {
+	mu       sync.Mutex
+	calls    []domain.BookAddedEvent
+	forceErr error
+}
+
+func (f *fakePublisher) PublishBookAdded(_ context.Context, evt domain.BookAddedEvent) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, evt)
+	return f.forceErr
+}
+```
+
+Replace the existing `TestAddDetail_Success` with one that also constructs a `fakePublisher` and asserts publish was called exactly once:
+
+```go
+func TestAddDetail_Success(t *testing.T) {
+	repo := memory.NewDetailRepository()
+	pub := &fakePublisher{}
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), pub)
+
+	detail, err := svc.AddDetail(context.Background(),
+		"The Art of Go", "Jane Doe", 2024, "paperback",
+		350, "Go Press", "English", "1234567890", "1234567890123", "",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if detail.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if len(pub.calls) != 1 {
+		t.Fatalf("expected 1 publish call, got %d", len(pub.calls))
+	}
+	if pub.calls[0].Title != "The Art of Go" {
+		t.Errorf("event Title = %q, want %q", pub.calls[0].Title, "The Art of Go")
+	}
+}
+```
+
+Replace `TestAddDetail_ValidationError`, `TestGetDetail_Found`, `TestGetDetail_NotFound` to pass the publisher:
+```go
+func TestAddDetail_ValidationError(t *testing.T) {
+	repo := memory.NewDetailRepository()
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), &fakePublisher{})
+
+	_, err := svc.AddDetail(context.Background(),
+		"", "Jane Doe", 2024, "paperback",
+		350, "Go Press", "English", "1234567890", "1234567890123", "",
+	)
+	if err == nil {
+		t.Fatal("expected validation error for empty title")
+	}
+}
+
+func TestGetDetail_Found(t *testing.T) {
+	repo := memory.NewDetailRepository()
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), &fakePublisher{})
+
+	created, err := svc.AddDetail(context.Background(),
+		"The Art of Go", "Jane Doe", 2024, "paperback",
+		350, "Go Press", "English", "1234567890", "1234567890123", "",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error creating: %v", err)
+	}
+	found, err := svc.GetDetail(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("unexpected error getting: %v", err)
+	}
+	if found.ID != created.ID {
+		t.Errorf("ID = %q, want %q", found.ID, created.ID)
+	}
+}
+
+func TestGetDetail_NotFound(t *testing.T) {
+	repo := memory.NewDetailRepository()
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), &fakePublisher{})
+
+	_, err := svc.GetDetail(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent detail")
+	}
+}
+```
+
+Add a new test asserting publish runs on idempotency dedup (Option A semantics):
+
+```go
+func TestAddDetail_PublishesOnIdempotencyDedup(t *testing.T) {
+	repo := memory.NewDetailRepository()
+	pub := &fakePublisher{}
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), pub)
+
+	args := []interface{}{
+		"The Art of Go", "Jane Doe", 2024, "paperback",
+		350, "Go Press", "English", "1234567890", "1234567890123", "fixed-key",
+	}
+
+	_, err := svc.AddDetail(context.Background(),
+		args[0].(string), args[1].(string), args[2].(int), args[3].(string),
+		args[4].(int), args[5].(string), args[6].(string), args[7].(string), args[8].(string), args[9].(string),
+	)
+	if err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+
+	// Second call with same idempotency key
+	_, err = svc.AddDetail(context.Background(),
+		args[0].(string), args[1].(string), args[2].(int), args[3].(string),
+		args[4].(int), args[5].(string), args[6].(string), args[7].(string), args[8].(string), args[9].(string),
+	)
+	if !errors.Is(err, service.ErrAlreadyProcessed) {
+		t.Fatalf("second call: expected ErrAlreadyProcessed, got %v", err)
+	}
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if len(pub.calls) != 2 {
+		t.Fatalf("expected 2 publish calls (one per attempt), got %d", len(pub.calls))
+	}
+}
+
+func TestAddDetail_PublishErrorPropagates(t *testing.T) {
+	repo := memory.NewDetailRepository()
+	pub := &fakePublisher{forceErr: errors.New("kafka down")}
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), pub)
+
+	_, err := svc.AddDetail(context.Background(),
+		"Test", "Author", 2024, "paperback", 10, "Pub", "en", "", "9780000000002", "",
+	)
+	if err == nil {
+		t.Fatal("expected publish error to propagate, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — expect compile fail (constructor signature mismatch)**
+
+Run: `go test ./services/details/internal/core/service/... -v`
+
+Expected: compile error `too many arguments in call to service.NewDetailService`.
+
+- [ ] **Step 3: Update `DetailService` to accept and use publisher**
+
+Replace `services/details/internal/core/service/detail_service.go` with:
+```go
+// Package service implements the business logic for the details service.
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/idempotency"
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/domain"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/port"
+)
+
+// ErrAlreadyProcessed signals that an idempotent request was previously processed.
+var ErrAlreadyProcessed = errors.New("request already processed")
+
+// DetailService implements the port.DetailService interface.
+type DetailService struct {
+	repo        port.DetailRepository
+	idempotency idempotency.Store
+	publisher   port.EventPublisher
+}
+
+// NewDetailService creates a new DetailService with the given repository, idempotency store, and event publisher.
+func NewDetailService(repo port.DetailRepository, idem idempotency.Store, publisher port.EventPublisher) *DetailService {
+	return &DetailService{repo: repo, idempotency: idem, publisher: publisher}
+}
+
+// GetDetail returns a book detail by ID.
+func (s *DetailService) GetDetail(ctx context.Context, id string) (*domain.Detail, error) {
+	detail, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("finding detail %s: %w", id, err)
+	}
+	return detail, nil
+}
+
+// AddDetail creates and persists a new book detail, then publishes a BookAddedEvent.
+// Always publishes (even on idempotency dedup) so that a retry after a Kafka blip still delivers the event.
+func (s *DetailService) AddDetail(ctx context.Context, title, author string, year int, bookType string, pages int, publisher, language, isbn10, isbn13, idempotencyKey string) (*domain.Detail, error) {
+	key := idempotency.Resolve(idempotencyKey, title, author, strconv.Itoa(year), bookType, strconv.Itoa(pages), publisher, language, isbn10, isbn13)
+
+	detail, err := domain.NewDetail(title, author, year, bookType, pages, publisher, language, isbn10, isbn13)
+	if err != nil {
+		return nil, fmt.Errorf("creating detail: %w", err)
+	}
+
+	alreadyProcessed, err := s.idempotency.CheckAndRecord(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("checking idempotency: %w", err)
+	}
+
+	if !alreadyProcessed {
+		if err := s.repo.Save(ctx, detail); err != nil {
+			return nil, fmt.Errorf("saving detail: %w", err)
+		}
+	} else {
+		logger := logging.FromContext(ctx)
+		logger.Info("detail save skipped: already processed", slog.String("idempotency_key", key))
+	}
+
+	evt := domain.BookAddedEvent{
+		ID:             detail.ID,
+		Title:          detail.Title,
+		Author:         detail.Author,
+		Year:           detail.Year,
+		Type:           detail.Type,
+		Pages:          detail.Pages,
+		Publisher:      detail.Publisher,
+		Language:       detail.Language,
+		ISBN10:         detail.ISBN10,
+		ISBN13:         detail.ISBN13,
+		IdempotencyKey: key,
+	}
+	if err := s.publisher.PublishBookAdded(ctx, evt); err != nil {
+		return nil, fmt.Errorf("publishing book-added event: %w", err)
+	}
+
+	if alreadyProcessed {
+		return nil, ErrAlreadyProcessed
+	}
+	return detail, nil
+}
+
+// ListDetails returns all stored book details.
+func (s *DetailService) ListDetails(ctx context.Context) ([]*domain.Detail, error) {
+	return s.repo.FindAll(ctx)
+}
+```
+
+- [ ] **Step 4: Check existing idempotency test file compiles**
+
+Open `services/details/internal/core/service/detail_service_idempotency_test.go` and update any `NewDetailService` call to pass a `&fakePublisher{}` as the third argument. If the fake is in the main test file in the same package, it is reachable without changes. Check for `NewDetailService(...)` occurrences:
+
+Run: `grep -n "NewDetailService(" services/details/internal/core/service/detail_service_idempotency_test.go`
+
+If hits found, update each call site. Example:
+```go
+svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), &fakePublisher{})
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./services/details/internal/core/service/... -race -v`
+
+Expected: all tests PASS. Expect `TestAddDetail_PublishesOnIdempotencyDedup` reports `2 publish calls`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/details/internal/core/service/detail_service.go \
+        services/details/internal/core/service/detail_service_test.go \
+        services/details/internal/core/service/detail_service_idempotency_test.go
+git commit -m "feat(details): always-publish BookAddedEvent from AddDetail"
+```
+
+---
+
+### Task 9: Wire publisher in `cmd/main.go`
+
+**Files:**
+- Modify: `services/details/cmd/main.go`
+
+- [ ] **Step 1: Add kafka adapter import and publisher wiring**
+
+Open `services/details/cmd/main.go`. Add import:
+```go
+kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/kafka"
+```
+And `"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/port"` is already imported.
+
+Before `svc := service.NewDetailService(repo, idemStore)`, add:
+```go
+var publisher port.EventPublisher
+if cfg.KafkaBrokers != "" {
+	kafkaTopic := cfg.KafkaTopic
+	if kafkaTopic == "" {
+		kafkaTopic = "bookinfo_details_events"
+	}
+	kProd, err := kafkaadapter.NewProducer(ctx, cfg.KafkaBrokers, kafkaTopic)
+	if err != nil {
+		logger.Error("failed to create Kafka producer", "error", err)
+		os.Exit(1)
+	}
+	defer kProd.Close()
+	publisher = kProd
+	logger.Info("kafka publisher enabled", "topic", kafkaTopic)
+} else {
+	publisher = kafkaadapter.NewNoopPublisher()
+	logger.Info("kafka publisher disabled — using no-op")
+}
+```
+
+Change the service constructor call:
+```go
+svc := service.NewDetailService(repo, idemStore, publisher)
+```
+
+- [ ] **Step 2: Run go build**
+
+Run: `go build ./services/details/cmd/`
+
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Run full tests for details**
+
+Run: `go test ./services/details/... -race -count=1`
+
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/details/cmd/main.go
+git commit -m "feat(details): wire Kafka publisher in composition root"
+```
+
+---
+
+### Task 10: Update `deploy/details/values-local.yaml`
+
+**Files:**
+- Modify: `deploy/details/values-local.yaml`
+
+- [ ] **Step 1: Add `KAFKA_*` to config block**
+
+Update the `config:` block:
+```yaml
+config:
+  LOG_LEVEL: "debug"
+  KAFKA_BROKERS: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  KAFKA_TOPIC: "bookinfo_details_events"
+```
+
+- [ ] **Step 2: Add `events.exposed.events` block**
+
+Below the existing `events.kafka` and `events.consumed.raw-books-details` blocks, add `events.exposed.events`. The full `events:` block should be:
+```yaml
+events:
+  kafka:
+    broker: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  exposed:
+    events:
+      topic: bookinfo_details_events
+      eventBusName: kafka
+      contentType: application/json
+      eventTypes:
+        - com.bookinfo.details.book-added
+  consumed:
+    raw-books-details:
+      eventSourceName: ingestion-raw-books-details
+      eventName: raw-books-details
+      triggers:
+        - name: ingest-book-detail
+          url: self
+          path: /v1/details
+          method: POST
+          payload:
+            - passthrough
+      dlq:
+        enabled: true
+        url: "http://dlq-event-received-eventsource-svc.bookinfo.svc.cluster.local:12004/v1/events"
+```
+
+- [ ] **Step 3: Remove `notify-book-added` trigger from CQRS endpoint**
+
+Update `cqrs.endpoints.book-added.triggers` to contain only `create-detail`:
+```yaml
+cqrs:
+  enabled: true
+  read:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+  write:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+  endpoints:
+    book-added:
+      port: 12000
+      method: POST
+      endpoint: /v1/details
+      triggers:
+        - name: create-detail
+          url: self
+          payload:
+            - passthrough
+```
+
+- [ ] **Step 4: Lint + template check**
+
+Run: `make helm-lint && make helm-template SERVICE=details | grep -A5 "details-events"`
+
+Expected: lint passes; rendered `EventSource/details-events` contains:
+```yaml
+annotations:
+  bookinfo.io/emitted-ce-types: "com.bookinfo.details.book-added"
+```
+
+- [ ] **Step 5: Verify no `notify-book-added` remains**
+
+Run: `make helm-template SERVICE=details | grep notify-book-added`
+
+Expected: zero matches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add deploy/details/values-local.yaml
+git commit -m "feat(details): emit book-added event, drop notify trigger from CQRS sensor"
+```
+
+---
+
+### Task 11: Add book-added consumer in notification values
+
+**Files:**
+- Modify: `deploy/notification/values-local.yaml`
+
+- [ ] **Step 1: Add events block with book-added consumer**
+
+Append to `deploy/notification/values-local.yaml`:
+```yaml
+
+events:
+  kafka:
+    broker: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  consumed:
+    book-added:
+      eventSourceName: details-events
+      eventName: events
+      filter:
+        ceType: com.bookinfo.details.book-added
+      triggers:
+        - name: notify-book-added
+          url: self
+          path: /v1/notifications
+          method: POST
+          payload:
+            - src:
+                dependencyName: book-added-dep
+                dataKey: body.title
+              dest: subject
+            - src:
+                value: "New book added"
+              dest: body
+            - src:
+                value: "system@bookinfo"
+              dest: recipient
+            - src:
+                value: "email"
+              dest: channel
+      dlq:
+        enabled: true
+        url: "http://dlq-event-received-eventsource-svc.bookinfo.svc.cluster.local:12004/v1/events"
+```
+
+- [ ] **Step 2: Template check for dependency + filter rendering**
+
+Run: `make helm-template SERVICE=notification | grep -A4 "book-added-dep"`
+
+Expected output contains:
+```yaml
+- name: book-added-dep
+  eventSourceName: details-events
+  eventName: events
+  filters:
+    context:
+      type: "com.bookinfo.details.book-added"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/notification/values-local.yaml
+git commit -m "feat(notification): consume book-added events via details-events EventSource"
+```
+
+---
+
+## Phase 3 — Reviews service producer
+
+### Task 12: Add domain events and port for reviews
+
+**Files:**
+- Create: `services/reviews/internal/core/domain/event.go`
+- Create: `services/reviews/internal/core/port/publisher.go`
+
+- [ ] **Step 1: Create `event.go`**
+
+```go
+// file: services/reviews/internal/core/domain/event.go
+package domain
+
+// ReviewSubmittedEvent is emitted after a successful SubmitReview.
+type ReviewSubmittedEvent struct {
+	ID             string
+	ProductID      string
+	Reviewer       string
+	Text           string
+	IdempotencyKey string
+}
+
+// ReviewDeletedEvent is emitted after a successful DeleteReview.
+type ReviewDeletedEvent struct {
+	ReviewID       string
+	ProductID      string
+	IdempotencyKey string
+}
+```
+
+- [ ] **Step 2: Create `publisher.go`**
+
+```go
+// file: services/reviews/internal/core/port/publisher.go
+package port
+
+import (
+	"context"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+)
+
+// EventPublisher is the outbound port for emitting review domain events.
+type EventPublisher interface {
+	PublishReviewSubmitted(ctx context.Context, evt domain.ReviewSubmittedEvent) error
+	PublishReviewDeleted(ctx context.Context, evt domain.ReviewDeletedEvent) error
+}
+```
+
+- [ ] **Step 3: Compile check + commit**
+
+Run: `go build ./services/reviews/...`
+
+```bash
+git add services/reviews/internal/core/domain/event.go services/reviews/internal/core/port/publisher.go
+git commit -m "feat(reviews): add ReviewSubmitted/Deleted domain events and EventPublisher port"
+```
+
+---
+
+### Task 13: Reviews Kafka producer — TDD
+
+**Files:**
+- Create: `services/reviews/internal/adapter/outbound/kafka/producer_test.go`
+- Create: `services/reviews/internal/adapter/outbound/kafka/producer.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// file: services/reviews/internal/adapter/outbound/kafka/producer_test.go
+package kafka_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/internal/adapter/outbound/kafka"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+)
+
+type fakeClient struct {
+	mu      sync.Mutex
+	records []*kgo.Record
+}
+
+func (f *fakeClient) ProduceSync(_ context.Context, rs ...*kgo.Record) kgo.ProduceResults {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var results kgo.ProduceResults
+	for _, r := range rs {
+		f.records = append(f.records, r)
+		results = append(results, kgo.ProduceResult{Record: r})
+	}
+	return results
+}
+
+func (f *fakeClient) Close() {}
+
+func TestPublishReviewSubmitted(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_reviews_events")
+
+	evt := domain.ReviewSubmittedEvent{
+		ID: "rev_1", ProductID: "prod-42", Reviewer: "alice", Text: "Great",
+		IdempotencyKey: "rev-idem-1",
+	}
+	if err := p.PublishReviewSubmitted(context.Background(), evt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if len(fc.records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(fc.records))
+	}
+	r := fc.records[0]
+	headers := map[string]string{}
+	for _, h := range r.Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["ce_type"] != "com.bookinfo.reviews.review-submitted" {
+		t.Errorf("ce_type = %q", headers["ce_type"])
+	}
+	if headers["ce_source"] != "reviews" {
+		t.Errorf("ce_source = %q", headers["ce_source"])
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(r.Value, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["product_id"] != "prod-42" {
+		t.Errorf("body product_id = %v, want %q", body["product_id"], "prod-42")
+	}
+	if body["reviewer"] != "alice" {
+		t.Errorf("body reviewer = %v", body["reviewer"])
+	}
+}
+
+func TestPublishReviewDeleted(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_reviews_events")
+
+	evt := domain.ReviewDeletedEvent{ReviewID: "rev_99", ProductID: "prod-42", IdempotencyKey: "del-idem-1"}
+	if err := p.PublishReviewDeleted(context.Background(), evt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	r := fc.records[0]
+	headers := map[string]string{}
+	for _, h := range r.Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["ce_type"] != "com.bookinfo.reviews.review-deleted" {
+		t.Errorf("ce_type = %q", headers["ce_type"])
+	}
+	var body map[string]interface{}
+	_ = json.Unmarshal(r.Value, &body)
+	if body["review_id"] != "rev_99" {
+		t.Errorf("body review_id = %v", body["review_id"])
+	}
+}
+```
+
+> Note: the test imports `github.com/kaio6fellipe/event-driven-bookinfo/internal/adapter/outbound/kafka` in the snippet above but the actual path is `github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/outbound/kafka`. Use the actual path.
+
+Correct the import line:
+```go
+kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/outbound/kafka"
+```
+
+- [ ] **Step 2: Run test — expect compile fail**
+
+Run: `go test ./services/reviews/internal/adapter/outbound/kafka/... -v`
+
+Expected: `no Go files` or `undefined: kafkaadapter.NewProducerWithClient`.
+
+- [ ] **Step 3: Implement producer**
+
+```go
+// file: services/reviews/internal/adapter/outbound/kafka/producer.go
+package kafka
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+)
+
+const (
+	ceTypeReviewSubmitted = "com.bookinfo.reviews.review-submitted"
+	ceTypeReviewDeleted   = "com.bookinfo.reviews.review-deleted"
+	ceSource              = "reviews"
+	ceVersion             = "1.0"
+
+	defaultPartitions        = 3
+	defaultReplicationFactor = 1
+)
+
+type submittedBody struct {
+	ID             string `json:"id,omitempty"`
+	ProductID      string `json:"product_id"`
+	Reviewer       string `json:"reviewer"`
+	Text           string `json:"text"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+type deletedBody struct {
+	ReviewID       string `json:"review_id"`
+	ProductID      string `json:"product_id,omitempty"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+// Client abstracts the franz-go client for testing.
+type Client interface {
+	ProduceSync(ctx context.Context, rs ...*kgo.Record) kgo.ProduceResults
+	Close()
+}
+
+// Producer emits reviews domain events to Kafka.
+type Producer struct {
+	client Client
+	topic  string
+}
+
+// NewProducer creates a real producer connecting to the brokers. Creates topic if missing.
+func NewProducer(ctx context.Context, brokers, topic string) (*Producer, error) {
+	seeds := strings.Split(brokers, ",")
+	client, err := kgo.NewClient(kgo.SeedBrokers(seeds...), kgo.DefaultProduceTopic(topic))
+	if err != nil {
+		return nil, fmt.Errorf("creating Kafka client: %w", err)
+	}
+	if err := ensureTopic(ctx, client, topic); err != nil {
+		client.Close()
+		return nil, fmt.Errorf("ensuring topic %q: %w", topic, err)
+	}
+	return &Producer{client: client, topic: topic}, nil
+}
+
+// NewProducerWithClient creates a Producer with an injected client (for tests).
+func NewProducerWithClient(client Client, topic string) *Producer {
+	return &Producer{client: client, topic: topic}
+}
+
+// PublishReviewSubmitted sends a review-submitted CloudEvent to Kafka.
+func (p *Producer) PublishReviewSubmitted(ctx context.Context, evt domain.ReviewSubmittedEvent) error {
+	body := submittedBody{
+		ID:             evt.ID,
+		ProductID:      evt.ProductID,
+		Reviewer:       evt.Reviewer,
+		Text:           evt.Text,
+		IdempotencyKey: evt.IdempotencyKey,
+	}
+	return p.produce(ctx, ceTypeReviewSubmitted, evt.IdempotencyKey, evt.ProductID, body)
+}
+
+// PublishReviewDeleted sends a review-deleted CloudEvent to Kafka.
+func (p *Producer) PublishReviewDeleted(ctx context.Context, evt domain.ReviewDeletedEvent) error {
+	body := deletedBody{
+		ReviewID:       evt.ReviewID,
+		ProductID:      evt.ProductID,
+		IdempotencyKey: evt.IdempotencyKey,
+	}
+	return p.produce(ctx, ceTypeReviewDeleted, evt.IdempotencyKey, evt.ProductID, body)
+}
+
+func (p *Producer) produce(ctx context.Context, ceType, key, partitionHint string, body any) error {
+	logger := logging.FromContext(ctx)
+
+	value, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshaling event: %w", err)
+	}
+
+	recordKey := []byte(partitionHint)
+	if len(recordKey) == 0 {
+		recordKey = []byte(key)
+	}
+
+	now := time.Now().UTC()
+	record := &kgo.Record{
+		Topic: p.topic,
+		Key:   recordKey,
+		Value: value,
+		Headers: []kgo.RecordHeader{
+			{Key: "ce_specversion", Value: []byte(ceVersion)},
+			{Key: "ce_type", Value: []byte(ceType)},
+			{Key: "ce_source", Value: []byte(ceSource)},
+			{Key: "ce_id", Value: []byte(uuid.New().String())},
+			{Key: "ce_time", Value: []byte(now.Format(time.RFC3339))},
+			{Key: "ce_subject", Value: []byte(key)},
+			{Key: "content-type", Value: []byte("application/json")},
+		},
+	}
+
+	results := p.client.ProduceSync(ctx, record)
+	if err := results.FirstErr(); err != nil {
+		return fmt.Errorf("producing to Kafka: %w", err)
+	}
+
+	logger.Debug("published reviews event", "topic", p.topic, "ce_type", ceType, "idempotency_key", key)
+	return nil
+}
+
+// Close flushes and closes the underlying client.
+func (p *Producer) Close() { p.client.Close() }
+
+func ensureTopic(ctx context.Context, client *kgo.Client, topic string) error {
+	admin := kadm.NewClient(client)
+	resp, err := admin.CreateTopics(ctx, int32(defaultPartitions), int16(defaultReplicationFactor), nil, topic)
+	if err != nil {
+		return fmt.Errorf("creating topic: %w", err)
+	}
+	for _, t := range resp.Sorted() {
+		if t.Err != nil && t.ErrMessage != "" && !isTopicExistsError(t.ErrMessage) {
+			return fmt.Errorf("topic %q: %s", t.Topic, t.ErrMessage)
+		}
+	}
+	return nil
+}
+
+func isTopicExistsError(msg string) bool {
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "TOPIC_ALREADY_EXISTS")
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./services/reviews/internal/adapter/outbound/kafka/... -race -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/reviews/internal/adapter/outbound/kafka/
+git commit -m "feat(reviews): add Kafka producer for review-submitted and review-deleted events"
+```
+
+---
+
+### Task 14: No-op publisher for reviews
+
+**Files:**
+- Create: `services/reviews/internal/adapter/outbound/kafka/noop.go`
+
+- [ ] **Step 1: Create no-op adapter**
+
+```go
+// file: services/reviews/internal/adapter/outbound/kafka/noop.go
+package kafka
+
+import (
+	"context"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+)
+
+// NoopPublisher implements port.EventPublisher without side effects.
+type NoopPublisher struct{}
+
+// NewNoopPublisher returns a no-op publisher.
+func NewNoopPublisher() *NoopPublisher { return &NoopPublisher{} }
+
+// PublishReviewSubmitted logs at debug and returns nil.
+func (n *NoopPublisher) PublishReviewSubmitted(ctx context.Context, evt domain.ReviewSubmittedEvent) error {
+	logging.FromContext(ctx).Debug("noop publisher: review-submitted discarded", "idempotency_key", evt.IdempotencyKey)
+	return nil
+}
+
+// PublishReviewDeleted logs at debug and returns nil.
+func (n *NoopPublisher) PublishReviewDeleted(ctx context.Context, evt domain.ReviewDeletedEvent) error {
+	logging.FromContext(ctx).Debug("noop publisher: review-deleted discarded", "idempotency_key", evt.IdempotencyKey)
+	return nil
+}
+```
+
+- [ ] **Step 2: Build + commit**
+
+Run: `go build ./services/reviews/...`
+
+```bash
+git add services/reviews/internal/adapter/outbound/kafka/noop.go
+git commit -m "feat(reviews): add no-op publisher"
+```
+
+---
+
+### Task 15: Wire publisher into `ReviewService` + make `DeleteReview` idempotent
+
+**Files:**
+- Modify: `services/reviews/internal/core/service/review_service.go`
+- Find / modify / create tests to match new constructor
+
+- [ ] **Step 1: Inspect current review tests**
+
+Run: `ls services/reviews/internal/core/service/`
+
+Note each `_test.go` file that calls `service.NewReviewService(...)` — all call sites need a 4th arg (the publisher).
+
+- [ ] **Step 2: Update `review_service.go`**
+
+Replace with:
+```go
+// Package service implements the business logic for the reviews service.
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/idempotency"
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/port"
+)
+
+// ErrAlreadyProcessed signals that an idempotent request was previously processed.
+var ErrAlreadyProcessed = errors.New("request already processed")
+
+// ReviewService implements the port.ReviewService interface.
+type ReviewService struct {
+	repo          port.ReviewRepository
+	ratingsClient port.RatingsClient
+	idempotency   idempotency.Store
+	publisher     port.EventPublisher
+}
+
+// NewReviewService creates a new ReviewService.
+func NewReviewService(repo port.ReviewRepository, ratingsClient port.RatingsClient, idem idempotency.Store, publisher port.EventPublisher) *ReviewService {
+	return &ReviewService{
+		repo:          repo,
+		ratingsClient: ratingsClient,
+		idempotency:   idem,
+		publisher:     publisher,
+	}
+}
+
+// GetProductReviews returns paginated reviews for a product, enriched with ratings data.
+func (s *ReviewService) GetProductReviews(ctx context.Context, productID string, page, pageSize int) ([]domain.Review, int, error) {
+	offset := (page - 1) * pageSize
+
+	reviews, total, err := s.repo.FindByProductID(ctx, productID, offset, pageSize)
+	if err != nil {
+		return nil, 0, fmt.Errorf("finding reviews for product %s: %w", productID, err)
+	}
+
+	ratingData, err := s.ratingsClient.GetProductRatings(ctx, productID)
+	if err != nil {
+		logger := logging.FromContext(ctx)
+		logger.Warn("failed to fetch ratings, returning reviews without ratings",
+			slog.String("product_id", productID),
+			slog.String("error", err.Error()),
+		)
+		return reviews, total, nil
+	}
+
+	for i := range reviews {
+		reviews[i].Rating = &domain.ReviewRating{
+			Stars:   ratingData.IndividualRatings[reviews[i].Reviewer],
+			Average: ratingData.Average,
+			Count:   ratingData.Count,
+		}
+	}
+
+	return reviews, total, nil
+}
+
+// SubmitReview creates and persists a new review, then publishes a ReviewSubmittedEvent.
+// Always publishes (even on idempotency dedup) for retry safety.
+func (s *ReviewService) SubmitReview(ctx context.Context, productID, reviewer, text, idempotencyKey string) (*domain.Review, error) {
+	key := idempotency.Resolve(idempotencyKey, productID, reviewer, text)
+
+	review, err := domain.NewReview(productID, reviewer, text)
+	if err != nil {
+		return nil, fmt.Errorf("creating review: %w", err)
+	}
+
+	alreadyProcessed, err := s.idempotency.CheckAndRecord(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("checking idempotency: %w", err)
+	}
+
+	if !alreadyProcessed {
+		if err := s.repo.Save(ctx, review); err != nil {
+			return nil, fmt.Errorf("saving review: %w", err)
+		}
+	} else {
+		logging.FromContext(ctx).Info("review submit skipped: already processed", slog.String("idempotency_key", key))
+	}
+
+	evt := domain.ReviewSubmittedEvent{
+		ID:             review.ID,
+		ProductID:      review.ProductID,
+		Reviewer:       review.Reviewer,
+		Text:           review.Text,
+		IdempotencyKey: key,
+	}
+	if err := s.publisher.PublishReviewSubmitted(ctx, evt); err != nil {
+		return nil, fmt.Errorf("publishing review-submitted event: %w", err)
+	}
+
+	if alreadyProcessed {
+		return nil, ErrAlreadyProcessed
+	}
+	return review, nil
+}
+
+// DeleteReview removes a review by its ID and publishes a ReviewDeletedEvent.
+// Idempotent: if the review does not exist (already deleted), returns nil and still publishes.
+// This is required for Option B retry semantics — a retry after a Kafka blip must succeed + re-publish.
+func (s *ReviewService) DeleteReview(ctx context.Context, id string) error {
+	productID := ""
+	existing, err := s.repo.FindByID(ctx, id)
+	switch {
+	case err == nil:
+		productID = existing.ProductID
+	case errors.Is(err, domain.ErrNotFound):
+		logging.FromContext(ctx).Info("delete review: already absent, treating as idempotent success", slog.String("review_id", id))
+	default:
+		return fmt.Errorf("looking up review %s before delete: %w", id, err)
+	}
+
+	if err := s.repo.DeleteByID(ctx, id); err != nil && !errors.Is(err, domain.ErrNotFound) {
+		return fmt.Errorf("deleting review %s: %w", id, err)
+	}
+
+	evt := domain.ReviewDeletedEvent{
+		ReviewID:       id,
+		ProductID:      productID,
+		IdempotencyKey: "review-deleted-" + id,
+	}
+	if err := s.publisher.PublishReviewDeleted(ctx, evt); err != nil {
+		return fmt.Errorf("publishing review-deleted event: %w", err)
+	}
+
+	return nil
+}
+```
+
+> NOTE: this change assumes `ReviewRepository` has a `FindByID` method. If it doesn't, fall back to directly calling `repo.DeleteByID` and setting `productID = ""` — the notification consumer sensor maps `subject: body.product_id`, so an empty product_id on a retry-delete is acceptable for the notification content.
+
+- [ ] **Step 3: Check repo interface**
+
+Run: `grep -n "FindByID" services/reviews/internal/core/port/outbound.go`
+
+If no match, either:
+- Drop the `FindByID` call and rely solely on `DeleteByID` returning success/ErrNotFound.
+- Or add the method to the interface + memory + postgres implementations.
+
+For simplicity, if FindByID is absent, use this minimal variant for `DeleteReview`:
+```go
+func (s *ReviewService) DeleteReview(ctx context.Context, id string) error {
+	if err := s.repo.DeleteByID(ctx, id); err != nil && !errors.Is(err, domain.ErrNotFound) {
+		return fmt.Errorf("deleting review %s: %w", id, err)
+	}
+
+	evt := domain.ReviewDeletedEvent{
+		ReviewID:       id,
+		IdempotencyKey: "review-deleted-" + id,
+	}
+	if err := s.publisher.PublishReviewDeleted(ctx, evt); err != nil {
+		return fmt.Errorf("publishing review-deleted event: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Update handler if it treats ErrNotFound as 404**
+
+Open `services/reviews/internal/adapter/inbound/http/handler.go` and change `deleteReview` so that ErrNotFound is no longer returned as 404 (it can't happen now). Leave the handler unchanged if only `fmt.Errorf` errors flow through — keep only the `http.StatusInternalServerError` branch plus the 204 success:
+```go
+func (h *Handler) deleteReview(w http.ResponseWriter, r *http.Request) {
+	logger := logging.FromContext(r.Context())
+
+	var req struct {
+		ReviewID string `json:"review_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.ReviewID == "" {
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{Error: "review_id is required"})
+		return
+	}
+
+	if err := h.svc.DeleteReview(r.Context(), req.ReviewID); err != nil {
+		logger.Error("failed to delete review", "error", err, "review_id", req.ReviewID)
+		writeJSON(w, http.StatusInternalServerError, ErrorResponse{Error: "internal error"})
+		return
+	}
+
+	logger.Info("review deleted", "review_id", req.ReviewID)
+	w.WriteHeader(http.StatusNoContent)
+}
+```
+
+Remove the unused `domain` import if no longer referenced.
+
+- [ ] **Step 5: Update all `NewReviewService` call sites in tests**
+
+Find them:
+```bash
+grep -rn "NewReviewService(" services/reviews/
+```
+
+For each test file, add `&fakeReviewPublisher{}` (define a local fake matching `port.EventPublisher`) as the fourth argument. Example fake to add in each test file (or a shared helpers file at `services/reviews/internal/core/service/helpers_test.go`):
+
+```go
+// helpers_test.go in services/reviews/internal/core/service/
+package service_test
+
+import (
+	"context"
+	"sync"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+)
+
+type fakeReviewPublisher struct {
+	mu        sync.Mutex
+	submitted []domain.ReviewSubmittedEvent
+	deleted   []domain.ReviewDeletedEvent
+	forceErr  error
+}
+
+func (f *fakeReviewPublisher) PublishReviewSubmitted(_ context.Context, evt domain.ReviewSubmittedEvent) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.submitted = append(f.submitted, evt)
+	return f.forceErr
+}
+
+func (f *fakeReviewPublisher) PublishReviewDeleted(_ context.Context, evt domain.ReviewDeletedEvent) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleted = append(f.deleted, evt)
+	return f.forceErr
+}
+```
+
+Then update constructors, e.g. `svc := service.NewReviewService(repo, ratingsClient, idempotency.NewMemoryStore(), &fakeReviewPublisher{})`.
+
+- [ ] **Step 6: Add a test for DeleteReview publishing**
+
+In the existing review_service_test.go (or a new one), add:
+```go
+func TestDeleteReview_PublishesEvent(t *testing.T) {
+	repo := memory.NewReviewRepository()
+	pub := &fakeReviewPublisher{}
+	svc := service.NewReviewService(repo, nil, idempotency.NewMemoryStore(), pub)
+
+	// Even deleting a non-existent review succeeds + publishes.
+	if err := svc.DeleteReview(context.Background(), "rev_missing"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if len(pub.deleted) != 1 {
+		t.Fatalf("expected 1 deleted publish, got %d", len(pub.deleted))
+	}
+	if pub.deleted[0].ReviewID != "rev_missing" {
+		t.Errorf("ReviewID = %q", pub.deleted[0].ReviewID)
+	}
+}
+```
+
+> If `memory.NewReviewRepository()` doesn't exist in the current codebase, use whatever fake the other tests use.
+
+- [ ] **Step 7: Run tests**
+
+Run: `go test ./services/reviews/... -race -count=1`
+
+Expected: all PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add services/reviews/internal/core/service/ services/reviews/internal/adapter/inbound/http/handler.go
+git commit -m "feat(reviews): always-publish review-submitted/deleted, idempotent DeleteReview"
+```
+
+---
+
+### Task 16: Wire publisher in reviews `cmd/main.go`
+
+**Files:**
+- Modify: `services/reviews/cmd/main.go`
+
+- [ ] **Step 1: Add imports**
+
+```go
+kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/outbound/kafka"
+```
+
+Ensure `port` is imported — it already is.
+
+- [ ] **Step 2: Add publisher wiring before `svc := service.NewReviewService(...)`**
+
+```go
+var publisher port.EventPublisher
+if cfg.KafkaBrokers != "" {
+	topic := cfg.KafkaTopic
+	if topic == "" {
+		topic = "bookinfo_reviews_events"
+	}
+	kProd, err := kafkaadapter.NewProducer(ctx, cfg.KafkaBrokers, topic)
+	if err != nil {
+		logger.Error("failed to create Kafka producer", "error", err)
+		os.Exit(1)
+	}
+	defer kProd.Close()
+	publisher = kProd
+	logger.Info("kafka publisher enabled", "topic", topic)
+} else {
+	publisher = kafkaadapter.NewNoopPublisher()
+	logger.Info("kafka publisher disabled — using no-op")
+}
+
+svc := service.NewReviewService(repo, ratingsClient, idemStore, publisher)
+```
+
+- [ ] **Step 3: Build + test**
+
+Run: `go build ./services/reviews/cmd/ && go test ./services/reviews/... -race -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/reviews/cmd/main.go
+git commit -m "feat(reviews): wire Kafka publisher in composition root"
+```
+
+---
+
+### Task 17: Reviews Helm values — emit events, drop notify triggers
+
+**Files:**
+- Modify: `deploy/reviews/values-local.yaml`
+
+- [ ] **Step 1: Update `config:` with Kafka env vars**
+
+```yaml
+config:
+  LOG_LEVEL: "debug"
+  RATINGS_SERVICE_URL: "http://ratings.bookinfo.svc.cluster.local"
+  KAFKA_BROKERS: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  KAFKA_TOPIC: "bookinfo_reviews_events"
+```
+
+- [ ] **Step 2: Add `events.exposed` block**
+
+Add (alongside existing `cqrs:` and `sensor:` blocks):
+```yaml
+events:
+  kafka:
+    broker: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  exposed:
+    events:
+      topic: bookinfo_reviews_events
+      eventBusName: kafka
+      contentType: application/json
+      eventTypes:
+        - com.bookinfo.reviews.review-submitted
+        - com.bookinfo.reviews.review-deleted
+```
+
+- [ ] **Step 3: Remove `notify-review-submitted` and `notify-review-deleted` from CQRS endpoints**
+
+Replace the entire `cqrs.endpoints:` block with:
+```yaml
+  endpoints:
+    review-submitted:
+      port: 12001
+      method: POST
+      endpoint: /v1/reviews
+      triggers:
+        - name: create-review
+          url: self
+          payload:
+            - passthrough
+    review-deleted:
+      port: 12003
+      method: POST
+      endpoint: /v1/reviews/delete
+      triggers:
+        - name: delete-review-write
+          url: self
+          payload:
+            - src:
+                dependencyName: review-deleted-dep
+                dataKey: body.review_id
+              dest: review_id
+```
+
+- [ ] **Step 4: Verify rendering**
+
+```bash
+make helm-lint
+make helm-template SERVICE=reviews | grep notify-review
+```
+
+Expected: lint passes. Second command returns **zero** matches.
+
+Run: `make helm-template SERVICE=reviews | grep -A3 "reviews-events"`
+
+Expected: `reviews-events` EventSource annotation lists both review-submitted and review-deleted types.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deploy/reviews/values-local.yaml
+git commit -m "feat(reviews): emit review events, drop notify-* from CQRS sensor"
+```
+
+---
+
+### Task 18: Notification consumer — add reviews subscriptions
+
+**Files:**
+- Modify: `deploy/notification/values-local.yaml`
+
+- [ ] **Step 1: Append review-submitted and review-deleted consumers**
+
+Append to the `events.consumed:` block (created in Task 11):
+```yaml
+    review-submitted:
+      eventSourceName: reviews-events
+      eventName: events
+      filter:
+        ceType: com.bookinfo.reviews.review-submitted
+      triggers:
+        - name: notify-review-submitted
+          url: self
+          path: /v1/notifications
+          method: POST
+          payload:
+            - src:
+                dependencyName: review-submitted-dep
+                dataKey: body.product_id
+              dest: subject
+            - src:
+                value: "New review submitted"
+              dest: body
+            - src:
+                value: "system@bookinfo"
+              dest: recipient
+            - src:
+                value: "email"
+              dest: channel
+      dlq:
+        enabled: true
+        url: "http://dlq-event-received-eventsource-svc.bookinfo.svc.cluster.local:12004/v1/events"
+    review-deleted:
+      eventSourceName: reviews-events
+      eventName: events
+      filter:
+        ceType: com.bookinfo.reviews.review-deleted
+      triggers:
+        - name: notify-review-deleted
+          url: self
+          path: /v1/notifications
+          method: POST
+          payload:
+            - src:
+                dependencyName: review-deleted-dep
+                dataKey: body.product_id
+              dest: subject
+            - src:
+                value: "Review deleted"
+              dest: body
+            - src:
+                value: "system@bookinfo"
+              dest: recipient
+            - src:
+                value: "email"
+              dest: channel
+      dlq:
+        enabled: true
+        url: "http://dlq-event-received-eventsource-svc.bookinfo.svc.cluster.local:12004/v1/events"
+```
+
+- [ ] **Step 2: Template check**
+
+```bash
+make helm-template SERVICE=notification | grep -E "review-submitted-dep|review-deleted-dep" | head -10
+```
+
+Expected: each appears twice (once as dep, once in trigger). Filters include `com.bookinfo.reviews.review-submitted` / `.review-deleted`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/notification/values-local.yaml
+git commit -m "feat(notification): consume review-submitted and review-deleted events"
+```
+
+---
+
+## Phase 4 — Ratings service producer
+
+Mirrors details; single event.
+
+### Task 19: Ratings domain event + publisher port
+
+**Files:**
+- Create: `services/ratings/internal/core/domain/event.go`
+- Create: `services/ratings/internal/core/port/publisher.go`
+
+- [ ] **Step 1: Create `event.go`**
+
+```go
+// file: services/ratings/internal/core/domain/event.go
+package domain
+
+// RatingSubmittedEvent is emitted after a successful SubmitRating.
+type RatingSubmittedEvent struct {
+	ID             string
+	ProductID      string
+	Reviewer       string
+	Stars          int
+	IdempotencyKey string
+}
+```
+
+- [ ] **Step 2: Create `publisher.go`**
+
+```go
+// file: services/ratings/internal/core/port/publisher.go
+package port
+
+import (
+	"context"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/domain"
+)
+
+// EventPublisher is the outbound port for emitting rating domain events.
+type EventPublisher interface {
+	PublishRatingSubmitted(ctx context.Context, evt domain.RatingSubmittedEvent) error
+}
+```
+
+- [ ] **Step 3: Build + commit**
+
+Run: `go build ./services/ratings/...`
+
+```bash
+git add services/ratings/internal/core/domain/event.go services/ratings/internal/core/port/publisher.go
+git commit -m "feat(ratings): add RatingSubmittedEvent domain type and EventPublisher port"
+```
+
+---
+
+### Task 20: Ratings Kafka producer — TDD
+
+**Files:**
+- Create: `services/ratings/internal/adapter/outbound/kafka/producer_test.go`
+- Create: `services/ratings/internal/adapter/outbound/kafka/producer.go`
+
+- [ ] **Step 1: Write test**
+
+```go
+// file: services/ratings/internal/adapter/outbound/kafka/producer_test.go
+package kafka_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/adapter/outbound/kafka"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/domain"
+)
+
+type fakeClient struct {
+	mu      sync.Mutex
+	records []*kgo.Record
+}
+
+func (f *fakeClient) ProduceSync(_ context.Context, rs ...*kgo.Record) kgo.ProduceResults {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var results kgo.ProduceResults
+	for _, r := range rs {
+		f.records = append(f.records, r)
+		results = append(results, kgo.ProduceResult{Record: r})
+	}
+	return results
+}
+
+func (f *fakeClient) Close() {}
+
+func TestPublishRatingSubmitted(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_ratings_events")
+
+	evt := domain.RatingSubmittedEvent{
+		ID: "rat_1", ProductID: "prod-42", Reviewer: "alice", Stars: 5,
+		IdempotencyKey: "rat-idem-1",
+	}
+	if err := p.PublishRatingSubmitted(context.Background(), evt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if len(fc.records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(fc.records))
+	}
+	r := fc.records[0]
+
+	headers := map[string]string{}
+	for _, h := range r.Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["ce_type"] != "com.bookinfo.ratings.rating-submitted" {
+		t.Errorf("ce_type = %q", headers["ce_type"])
+	}
+	if headers["ce_source"] != "ratings" {
+		t.Errorf("ce_source = %q", headers["ce_source"])
+	}
+
+	var body map[string]interface{}
+	_ = json.Unmarshal(r.Value, &body)
+	if body["product_id"] != "prod-42" {
+		t.Errorf("product_id = %v", body["product_id"])
+	}
+	if body["stars"].(float64) != 5 {
+		t.Errorf("stars = %v", body["stars"])
+	}
+}
+```
+
+- [ ] **Step 2: Implement producer**
+
+```go
+// file: services/ratings/internal/adapter/outbound/kafka/producer.go
+package kafka
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/domain"
+)
+
+const (
+	ceTypeRatingSubmitted = "com.bookinfo.ratings.rating-submitted"
+	ceSource              = "ratings"
+	ceVersion             = "1.0"
+
+	defaultPartitions        = 3
+	defaultReplicationFactor = 1
+)
+
+type submittedBody struct {
+	ID             string `json:"id,omitempty"`
+	ProductID      string `json:"product_id"`
+	Reviewer       string `json:"reviewer"`
+	Stars          int    `json:"stars"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+// Client abstracts the franz-go client for testing.
+type Client interface {
+	ProduceSync(ctx context.Context, rs ...*kgo.Record) kgo.ProduceResults
+	Close()
+}
+
+// Producer emits ratings domain events to Kafka.
+type Producer struct {
+	client Client
+	topic  string
+}
+
+// NewProducer creates a real producer connecting to the brokers. Creates topic if missing.
+func NewProducer(ctx context.Context, brokers, topic string) (*Producer, error) {
+	seeds := strings.Split(brokers, ",")
+	client, err := kgo.NewClient(kgo.SeedBrokers(seeds...), kgo.DefaultProduceTopic(topic))
+	if err != nil {
+		return nil, fmt.Errorf("creating Kafka client: %w", err)
+	}
+	if err := ensureTopic(ctx, client, topic); err != nil {
+		client.Close()
+		return nil, fmt.Errorf("ensuring topic %q: %w", topic, err)
+	}
+	return &Producer{client: client, topic: topic}, nil
+}
+
+// NewProducerWithClient creates a Producer with an injected client (for tests).
+func NewProducerWithClient(client Client, topic string) *Producer {
+	return &Producer{client: client, topic: topic}
+}
+
+// PublishRatingSubmitted sends a rating-submitted CloudEvent to Kafka.
+func (p *Producer) PublishRatingSubmitted(ctx context.Context, evt domain.RatingSubmittedEvent) error {
+	logger := logging.FromContext(ctx)
+
+	body := submittedBody{
+		ID:             evt.ID,
+		ProductID:      evt.ProductID,
+		Reviewer:       evt.Reviewer,
+		Stars:          evt.Stars,
+		IdempotencyKey: evt.IdempotencyKey,
+	}
+	value, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshaling rating-submitted event: %w", err)
+	}
+
+	recordKey := []byte(evt.ProductID)
+	if len(recordKey) == 0 {
+		recordKey = []byte(evt.IdempotencyKey)
+	}
+
+	now := time.Now().UTC()
+	record := &kgo.Record{
+		Topic: p.topic,
+		Key:   recordKey,
+		Value: value,
+		Headers: []kgo.RecordHeader{
+			{Key: "ce_specversion", Value: []byte(ceVersion)},
+			{Key: "ce_type", Value: []byte(ceTypeRatingSubmitted)},
+			{Key: "ce_source", Value: []byte(ceSource)},
+			{Key: "ce_id", Value: []byte(uuid.New().String())},
+			{Key: "ce_time", Value: []byte(now.Format(time.RFC3339))},
+			{Key: "ce_subject", Value: []byte(evt.IdempotencyKey)},
+			{Key: "content-type", Value: []byte("application/json")},
+		},
+	}
+
+	results := p.client.ProduceSync(ctx, record)
+	if err := results.FirstErr(); err != nil {
+		return fmt.Errorf("producing to Kafka: %w", err)
+	}
+
+	logger.Debug("published rating-submitted event", "topic", p.topic, "idempotency_key", evt.IdempotencyKey)
+	return nil
+}
+
+// Close flushes pending messages and closes the Kafka client.
+func (p *Producer) Close() { p.client.Close() }
+
+func ensureTopic(ctx context.Context, client *kgo.Client, topic string) error {
+	admin := kadm.NewClient(client)
+	resp, err := admin.CreateTopics(ctx, int32(defaultPartitions), int16(defaultReplicationFactor), nil, topic)
+	if err != nil {
+		return fmt.Errorf("creating topic: %w", err)
+	}
+	for _, t := range resp.Sorted() {
+		if t.Err != nil && t.ErrMessage != "" && !isTopicExistsError(t.ErrMessage) {
+			return fmt.Errorf("topic %q: %s", t.Topic, t.ErrMessage)
+		}
+	}
+	return nil
+}
+
+func isTopicExistsError(msg string) bool {
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "TOPIC_ALREADY_EXISTS")
+}
+```
+
+- [ ] **Step 3: Tests pass + commit**
+
+Run: `go test ./services/ratings/internal/adapter/outbound/kafka/... -race -v`
+
+Expected: PASS.
+
+```bash
+git add services/ratings/internal/adapter/outbound/kafka/
+git commit -m "feat(ratings): add Kafka producer for rating-submitted event"
+```
+
+---
+
+### Task 21: Ratings no-op publisher + service wiring
+
+**Files:**
+- Create: `services/ratings/internal/adapter/outbound/kafka/noop.go`
+- Modify: `services/ratings/internal/core/service/rating_service.go`
+- Modify: `services/ratings/internal/core/service/rating_service_test.go` (and any sibling test files)
+- Modify: `services/ratings/cmd/main.go`
+
+- [ ] **Step 1: Create noop**
+
+```go
+// file: services/ratings/internal/adapter/outbound/kafka/noop.go
+package kafka
+
+import (
+	"context"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/domain"
+)
+
+// NoopPublisher implements port.EventPublisher without side effects.
+type NoopPublisher struct{}
+
+// NewNoopPublisher returns a no-op publisher.
+func NewNoopPublisher() *NoopPublisher { return &NoopPublisher{} }
+
+// PublishRatingSubmitted logs at debug and returns nil.
+func (n *NoopPublisher) PublishRatingSubmitted(ctx context.Context, evt domain.RatingSubmittedEvent) error {
+	logging.FromContext(ctx).Debug("noop publisher: rating-submitted discarded", "idempotency_key", evt.IdempotencyKey)
+	return nil
+}
+```
+
+- [ ] **Step 2: Update `rating_service.go` with always-publish semantics**
+
+Replace body with:
+```go
+// Package service implements the business logic for the ratings service.
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/idempotency"
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/domain"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/port"
+)
+
+// ErrAlreadyProcessed signals that an idempotent request was previously processed.
+var ErrAlreadyProcessed = errors.New("request already processed")
+
+// RatingService implements the port.RatingService interface.
+type RatingService struct {
+	repo        port.RatingRepository
+	idempotency idempotency.Store
+	publisher   port.EventPublisher
+}
+
+// NewRatingService creates a new RatingService with the given repository, idempotency store, and event publisher.
+func NewRatingService(repo port.RatingRepository, idem idempotency.Store, publisher port.EventPublisher) *RatingService {
+	return &RatingService{repo: repo, idempotency: idem, publisher: publisher}
+}
+
+// GetProductRatings returns all ratings aggregated for a product.
+func (s *RatingService) GetProductRatings(ctx context.Context, productID string) (*domain.ProductRatings, error) {
+	ratings, err := s.repo.FindByProductID(ctx, productID)
+	if err != nil {
+		return nil, fmt.Errorf("finding ratings for product %s: %w", productID, err)
+	}
+	return &domain.ProductRatings{ProductID: productID, Ratings: ratings}, nil
+}
+
+// SubmitRating creates and persists a new rating, then publishes a RatingSubmittedEvent.
+// Always publishes (even on idempotency dedup) for retry safety.
+func (s *RatingService) SubmitRating(ctx context.Context, productID, reviewer string, stars int, idempotencyKey string) (*domain.Rating, error) {
+	key := idempotency.Resolve(idempotencyKey, productID, reviewer, strconv.Itoa(stars))
+
+	rating, err := domain.NewRating(productID, reviewer, stars)
+	if err != nil {
+		return nil, fmt.Errorf("creating rating: %w", err)
+	}
+
+	alreadyProcessed, err := s.idempotency.CheckAndRecord(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("checking idempotency: %w", err)
+	}
+
+	if !alreadyProcessed {
+		if err := s.repo.Save(ctx, rating); err != nil {
+			return nil, fmt.Errorf("saving rating: %w", err)
+		}
+	} else {
+		logging.FromContext(ctx).Info("rating submit skipped: already processed", slog.String("idempotency_key", key))
+	}
+
+	evt := domain.RatingSubmittedEvent{
+		ID:             rating.ID,
+		ProductID:      rating.ProductID,
+		Reviewer:       rating.Reviewer,
+		Stars:          rating.Stars,
+		IdempotencyKey: key,
+	}
+	if err := s.publisher.PublishRatingSubmitted(ctx, evt); err != nil {
+		return nil, fmt.Errorf("publishing rating-submitted event: %w", err)
+	}
+
+	if alreadyProcessed {
+		return nil, ErrAlreadyProcessed
+	}
+	return rating, nil
+}
+```
+
+- [ ] **Step 3: Update ratings tests**
+
+Find `NewRatingService(` usages:
+```bash
+grep -rn "NewRatingService(" services/ratings/
+```
+
+In each `_test.go` file, add a fake publisher:
+```go
+type fakeRatingPublisher struct {
+	mu    sync.Mutex
+	calls []domain.RatingSubmittedEvent
+}
+
+func (f *fakeRatingPublisher) PublishRatingSubmitted(_ context.Context, evt domain.RatingSubmittedEvent) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, evt)
+	return nil
+}
+```
+
+And update constructor calls to `service.NewRatingService(repo, idempotency.NewMemoryStore(), &fakeRatingPublisher{})`.
+
+- [ ] **Step 4: Update `ratings/cmd/main.go`**
+
+Add imports:
+```go
+kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/adapter/outbound/kafka"
+```
+
+Before `svc := service.NewRatingService(repo, idemStore)`:
+```go
+var publisher port.EventPublisher
+if cfg.KafkaBrokers != "" {
+	topic := cfg.KafkaTopic
+	if topic == "" {
+		topic = "bookinfo_ratings_events"
+	}
+	kProd, err := kafkaadapter.NewProducer(ctx, cfg.KafkaBrokers, topic)
+	if err != nil {
+		logger.Error("failed to create Kafka producer", "error", err)
+		os.Exit(1)
+	}
+	defer kProd.Close()
+	publisher = kProd
+	logger.Info("kafka publisher enabled", "topic", topic)
+} else {
+	publisher = kafkaadapter.NewNoopPublisher()
+	logger.Info("kafka publisher disabled — using no-op")
+}
+
+svc := service.NewRatingService(repo, idemStore, publisher)
+```
+
+- [ ] **Step 5: Build + tests**
+
+Run: `go build ./services/ratings/cmd/ && go test ./services/ratings/... -race -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/ratings/
+git commit -m "feat(ratings): always-publish rating-submitted event + no-op publisher + composition root wiring"
+```
+
+---
+
+### Task 22: Ratings Helm values — emit events, drop notify trigger
+
+**Files:**
+- Modify: `deploy/ratings/values-local.yaml`
+
+- [ ] **Step 1: Update config + add events.exposed + drop notify-rating-submitted**
+
+Full file after edit:
+```yaml
+# deploy/ratings/values-local.yaml
+serviceName: ratings
+fullnameOverride: ratings
+image:
+  repository: event-driven-bookinfo/ratings
+  tag: local
+
+postgresql:
+  enabled: true
+  auth:
+    database: "bookinfo_ratings"
+
+config:
+  LOG_LEVEL: "debug"
+  KAFKA_BROKERS: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  KAFKA_TOPIC: "bookinfo_ratings_events"
+
+observability:
+  otelEndpoint: "http://alloy-metrics-traces.observability.svc.cluster.local:4317"
+  pyroscopeAddress: "http://pyroscope.observability.svc.cluster.local:4040"
+
+events:
+  kafka:
+    broker: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  exposed:
+    events:
+      topic: bookinfo_ratings_events
+      eventBusName: kafka
+      contentType: application/json
+      eventTypes:
+        - com.bookinfo.ratings.rating-submitted
+
+cqrs:
+  enabled: true
+  read:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+  write:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+  endpoints:
+    rating-submitted:
+      port: 12002
+      method: POST
+      endpoint: /v1/ratings
+      triggers:
+        - name: create-rating
+          url: self
+          payload:
+            - passthrough
+
+sensor:
+  dlq:
+    url: "http://dlq-event-received-eventsource-svc.bookinfo.svc.cluster.local:12004/v1/events"
+
+gateway:
+  name: default-gw
+  namespace: platform
+  sectionName: web
+```
+
+- [ ] **Step 2: Verify lint + rendering**
+
+```bash
+make helm-lint
+make helm-template SERVICE=ratings | grep -E "notify-rating|ratings-events" | head
+```
+
+Expected: no `notify-rating` match; `ratings-events` EventSource present with `com.bookinfo.ratings.rating-submitted` annotation.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/ratings/values-local.yaml
+git commit -m "feat(ratings): emit rating-submitted event, drop notify trigger from CQRS sensor"
+```
+
+---
+
+### Task 23: Notification consumer — add rating-submitted
+
+**Files:**
+- Modify: `deploy/notification/values-local.yaml`
+
+- [ ] **Step 1: Append rating-submitted entry**
+
+Append under `events.consumed:` (same block that now contains book-added + review-submitted + review-deleted):
+```yaml
+    rating-submitted:
+      eventSourceName: ratings-events
+      eventName: events
+      filter:
+        ceType: com.bookinfo.ratings.rating-submitted
+      triggers:
+        - name: notify-rating-submitted
+          url: self
+          path: /v1/notifications
+          method: POST
+          payload:
+            - src:
+                dependencyName: rating-submitted-dep
+                dataKey: body.product_id
+              dest: subject
+            - src:
+                value: "New rating submitted"
+              dest: body
+            - src:
+                value: "system@bookinfo"
+              dest: recipient
+            - src:
+                value: "email"
+              dest: channel
+      dlq:
+        enabled: true
+        url: "http://dlq-event-received-eventsource-svc.bookinfo.svc.cluster.local:12004/v1/events"
+```
+
+- [ ] **Step 2: Final rendering check — all four dependencies exist with filters**
+
+Run:
+```bash
+make helm-template SERVICE=notification | grep -E "^\s+- name: .+-dep" | sort -u
+```
+
+Expected (exactly these four):
+```
+    - name: book-added-dep
+    - name: rating-submitted-dep
+    - name: review-deleted-dep
+    - name: review-submitted-dep
+```
+
+Run:
+```bash
+make helm-template SERVICE=notification | grep "context:" -A1 | grep "type:"
+```
+
+Expected: four `type:` lines, one per ce_type.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/notification/values-local.yaml
+git commit -m "feat(notification): consume rating-submitted events via ratings-events EventSource"
+```
+
+---
+
+## Phase 5 — End-to-end validation
+
+### Task 24: Deploy to local k8s and verify rollout
+
+- [ ] **Step 1: Tear down any previous cluster**
+
+Run: `make stop-k8s`
+
+Expected: `k3d` cluster `bookinfo-local` deleted (or "not found" if already gone).
+
+- [ ] **Step 2: Full deploy**
+
+Run: `make run-k8s`
+
+Expected: `k3d` cluster created, platform (Kafka, Argo Events) installed, observability stack installed, app namespace `bookinfo` deployed. Takes ~5-10 min.
+
+- [ ] **Step 3: Status check**
+
+Run: `make k8s-status`
+
+Expected: all Deployments `Ready`, no CrashLoopBackOff, access URLs printed.
+
+- [ ] **Step 4: EventSource rollout**
+
+Run:
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo get eventsource
+```
+
+Expected: `ingestion-raw-books-details`, `details-events`, `reviews-events`, `ratings-events` all present, age > 0s.
+
+- [ ] **Step 5: Verify emitted-ce-types annotations**
+
+Run:
+```bash
+for svc in details-events reviews-events ratings-events; do
+  echo "-- $svc --"
+  kubectl --context=k3d-bookinfo-local -n bookinfo get eventsource $svc -o jsonpath='{.metadata.annotations.bookinfo\.io/emitted-ce-types}'
+  echo
+done
+```
+
+Expected:
+- `details-events`: `com.bookinfo.details.book-added`
+- `reviews-events`: `com.bookinfo.reviews.review-submitted,com.bookinfo.reviews.review-deleted`
+- `ratings-events`: `com.bookinfo.ratings.rating-submitted`
+
+- [ ] **Step 6: Sensor dependencies + filters**
+
+Run:
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo get sensor notification-consumer-sensor -o yaml | grep -A2 "type:"
+```
+
+Expected: four `type:` lines matching the four ce_types.
+
+- [ ] **Step 7: Commit deployment verification evidence (optional)**
+
+No commit needed — this is observation only.
+
+---
+
+### Task 25: Smoke tests for all four event paths
+
+For each event, POST to the gateway and verify: entity persisted, Kafka event emitted, notification stored with matching subject.
+
+- [ ] **Step 1: book-added**
+
+```bash
+BOOK_PAYLOAD='{"title":"Smoke Book","author":"Test Author","year":2026,"type":"paperback","pages":100,"publisher":"SP","language":"en","isbn_13":"9780000000001"}'
+curl -sS -X POST http://localhost:8080/v1/details -H 'Content-Type: application/json' -d "$BOOK_PAYLOAD"
+```
+
+Verify detail:
+```bash
+curl -sS http://localhost:8080/v1/details | jq '.[] | select(.title=="Smoke Book")'
+```
+Expected: JSON record present.
+
+Verify Kafka event:
+```bash
+kubectl --context=k3d-bookinfo-local -n platform exec bookinfo-kafka-cluster-kafka-0 -- \
+  bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 \
+  --topic bookinfo_details_events --from-beginning --max-messages 1 --timeout-ms 10000 --property print.headers=true
+```
+Expected: one record with header `ce_type:com.bookinfo.details.book-added` and JSON body containing `"title":"Smoke Book"`.
+
+Verify notification:
+```bash
+curl -sS 'http://localhost:8080/v1/notifications?recipient=system@bookinfo' | jq '.[] | select(.subject=="Smoke Book")'
+```
+Expected: non-empty notification record with `body: "New book added"`.
+
+- [ ] **Step 2: review-submitted**
+
+```bash
+REV_PAYLOAD='{"product_id":"smoke-prod-1","reviewer":"smoke-user","text":"Great"}'
+curl -sS -X POST http://localhost:8080/v1/reviews -H 'Content-Type: application/json' -d "$REV_PAYLOAD"
+```
+
+Verify notification:
+```bash
+curl -sS 'http://localhost:8080/v1/notifications?recipient=system@bookinfo' | jq '.[] | select(.subject=="smoke-prod-1" and .body=="New review submitted")'
+```
+Expected: non-empty.
+
+- [ ] **Step 3: review-deleted**
+
+Capture review_id from step 2 (or list reviews):
+```bash
+REVIEW_ID=$(curl -sS http://localhost:8080/v1/reviews/smoke-prod-1 | jq -r '.reviews[0].id')
+curl -sS -X POST http://localhost:8080/v1/reviews/delete -H 'Content-Type: application/json' -d "{\"review_id\":\"$REVIEW_ID\"}"
+```
+
+Verify:
+```bash
+curl -sS 'http://localhost:8080/v1/notifications?recipient=system@bookinfo' | jq '.[] | select(.body=="Review deleted")'
+```
+Expected: non-empty.
+
+- [ ] **Step 4: rating-submitted**
+
+```bash
+RAT_PAYLOAD='{"product_id":"smoke-prod-1","reviewer":"smoke-user","stars":5}'
+curl -sS -X POST http://localhost:8080/v1/ratings -H 'Content-Type: application/json' -d "$RAT_PAYLOAD"
+```
+
+Verify:
+```bash
+curl -sS 'http://localhost:8080/v1/notifications?recipient=system@bookinfo' | jq '.[] | select(.body=="New rating submitted")'
+```
+Expected: non-empty.
+
+- [ ] **Step 5: Record success, no commit needed**
+
+If any step fails, tail logs for the corresponding `-write` service:
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo logs deploy/details-write --tail=50
+```
+
+---
+
+### Task 26: Failure-recovery smoke test (Kafka blip)
+
+- [ ] **Step 1: Scale Kafka down**
+
+```bash
+kubectl --context=k3d-bookinfo-local -n platform scale strimzipodset bookinfo-kafka-cluster-kafka --replicas=0
+kubectl --context=k3d-bookinfo-local -n platform wait --for=delete pod -l strimzi.io/name=bookinfo-kafka-cluster-kafka --timeout=60s || true
+```
+
+- [ ] **Step 2: POST a book — expect 500**
+
+```bash
+curl -i -sS -X POST http://localhost:8080/v1/details -H 'Content-Type: application/json' \
+  -d '{"title":"Blip Test","author":"X","year":2026,"type":"paperback","isbn_13":"9780000000099"}'
+```
+
+Expected: HTTP 5xx from `details-write` (visible in the curl output) AND sensor retrying (`kubectl -n bookinfo describe sensor details-sensor`).
+
+- [ ] **Step 3: Scale Kafka back up**
+
+```bash
+kubectl --context=k3d-bookinfo-local -n platform scale strimzipodset bookinfo-kafka-cluster-kafka --replicas=1
+kubectl --context=k3d-bookinfo-local -n platform wait --for=condition=ready pod -l strimzi.io/name=bookinfo-kafka-cluster-kafka --timeout=120s
+```
+
+- [ ] **Step 4: Within retry window — verify exactly-once delivery**
+
+Wait ~30s for sensor retries to reach the now-healthy service, then:
+```bash
+curl -sS http://localhost:8080/v1/details | jq '[.[] | select(.title=="Blip Test")] | length'
+```
+Expected: `1` (idempotency dedupe prevents duplicates).
+
+```bash
+curl -sS 'http://localhost:8080/v1/notifications?recipient=system@bookinfo' | jq '[.[] | select(.subject=="Blip Test")] | length'
+```
+Expected: `1` (notification natural-key dedupe prevents duplicates).
+
+---
+
+### Task 27: k6 load run + Tempo trace verification
+
+- [ ] **Step 1: Run k6 load for 2 minutes**
+
+```bash
+DURATION=2m BASE_RATE=5 make k8s-load
+```
+
+Expected: docker-based k6 container drives traffic through the gateway. Prints a summary at the end with checks passed / failed.
+
+- [ ] **Step 2: Inspect Grafana traces**
+
+Open in a browser: `http://localhost:3000` → sign in (default admin/admin) → Explore → select the `Tempo` data source → query:
+
+```
+{ service.name = "details-write" && resource.service.name = "details-write" }
+```
+(or using `resource.service.name="details-write"` per Tempo TraceQL support)
+
+Pick any recent span from a POST request.
+
+- [ ] **Step 3: Verify full trace chain**
+
+In the trace timeline, confirm spans from these services appear in order:
+1. `envoy-gateway`
+2. `details-eventsource` (CQRS EventSource)
+3. `details-cqrs-sensor`
+4. `details-write` (HTTP handler + DB save + **kafka producer span**)
+5. `details-events` (Kafka EventSource consumer side)
+6. `notification-consumer-sensor`
+7. `notification-write` (HTTP handler + DB save)
+
+Also confirm Kafka span attributes:
+- `messaging.system = kafka`
+- `messaging.destination.name = bookinfo_details_events`
+- `messaging.kafka.message.key = <idempotency key>`
+
+- [ ] **Step 4: Repeat spot-check for a review and a rating trace**
+
+Filter Tempo by `resource.service.name = "reviews-write"` and `"ratings-events"` — confirm similar chains end at `notification-write`.
+
+- [ ] **Step 5: No commit — validation only**
+
+If trace chain is broken at any hop, check:
+- Alloy / OpenTelemetry Collector logs in `observability` namespace
+- Verify `OTEL_EXPORTER_OTLP_ENDPOINT` env var set on each service
+- Compare to ingestion's producer trace (known-working baseline)
+
+---
+
+### Task 28: Final full sweep — lint, test, helm-lint
+
+- [ ] **Step 1: Go lint + test**
+
+```bash
+make lint
+make test
+```
+
+Expected: both pass with no errors.
+
+- [ ] **Step 2: Helm lint**
+
+```bash
+make helm-lint
+```
+
+Expected: `1 chart(s) linted, 0 chart(s) failed`.
+
+- [ ] **Step 3: Grep sweep for any remaining notify-* triggers**
+
+```bash
+grep -rn "notify-" deploy/details/values-local.yaml deploy/reviews/values-local.yaml deploy/ratings/values-local.yaml
+```
+
+Expected: zero matches.
+
+- [ ] **Step 4: Acceptance criteria review**
+
+Re-read `docs/superpowers/specs/2026-04-24-event-driven-notifications-design.md` § Acceptance criteria. For each numbered criterion, verify it holds. If all 7 pass, feature complete.
+
+- [ ] **Step 5: Commit any final polish**
+
+If lint or test adjustments were needed in this phase, commit them:
+```bash
+git add -A
+git commit -m "chore: final polish for event-driven notifications"
+```
+
+---
+
+## Self-Review
+
+1. **Spec coverage:**
+   - Decision 1 (all four events) → Tasks 9, 15, 21 publish-wiring + Tasks 10, 17, 22 values ✔
+   - Decision 2 (return 500, sensor retries) → Task 8/15/21 service layer returns publish error ✔
+   - Decision 3 (full entity + CE headers) → Tasks 6, 13, 20 ✔
+   - Decision 4 (one topic per service, ce_type carried) → Task 17 (reviews carries 2), Tasks 10, 22 (1 each) ✔
+   - Decision 5 (always-publish) → Service-level tests (Task 8) assert publish on idem dedup ✔
+   - Decision 6 (chart unchanged naming) → No template prefix changes ✔
+   - Decision 7 (ce_type contract annotation) → Task 1 chart template + eventTypes in each values file ✔
+   - Component: notification consumer sensor filter → Task 2 template, Tasks 11/18/23 values ✔
+   - Removed notify-* triggers → Tasks 10, 17, 22 ✔
+   - Error handling cases (DB error, Kafka unset, topic missing, DLQ, dedupe) → Covered by Tasks 6-8, 13-15, 20-21 code + Phase 5 validation ✔
+   - Testing (unit, helm, e2e, k6, Tempo) → Phases 4 (helm template checks per Helm task) + Phase 5 tasks ✔
+   - Acceptance criteria 1-7 → Task 28 sweep ✔
+
+2. **Placeholder scan:** No "TBD", "TODO", "similar to", or "implement later" remain. The repo method uncertainty in Task 15 step 3 is handled with a concrete alternative implementation.
+
+3. **Type consistency:**
+   - `port.EventPublisher` defined with `PublishBookAdded` (details), `PublishReviewSubmitted/Deleted` (reviews), `PublishRatingSubmitted` (ratings) — matches adapter method names and test assertions throughout.
+   - Domain event types match JSON body field names (`product_id`, `isbn_13`, `idempotency_key`, etc).
+   - Chart `events.consumed.<name>.filter.ceType` matches template path `filters.context.type`.

--- a/docs/superpowers/plans/2026-04-25-compose-lite-mode-docs.md
+++ b/docs/superpowers/plans/2026-04-25-compose-lite-mode-docs.md
@@ -1,0 +1,461 @@
+# Compose Lite-Mode Documentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a consistent "lite mode" disclaimer to `docker-compose.yml`, `README.md`, and `CLAUDE.md` making explicit that compose covers postgres + redis + 5 services only — Kafka, ingestion, Argo Events, and observability are k8s-only via `make run-k8s`.
+
+**Architecture:** Three coordinated text edits in existing docs. No code, helm, or compose-service changes. Each edit reuses the same canonical wording so the message is consistent.
+
+**Tech Stack:** Markdown + YAML comment text only.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-25-compose-lite-mode-docs-design.md`
+
+**Repo:** `/Users/kaio.fellipe/Documents/git/others/go-http-server`
+**Branch:** `feat/event-driven-notifications` (continuation of PR #54)
+
+---
+
+## File Structure
+
+Three existing files modified, no new files.
+
+```text
+docker-compose.yml    # header comment block (lines 1-3) replaced with ~12-line lite-mode notice
+README.md             # ~10-line callout under "Or use Docker Compose" (line 269) + ~5-line note in E2E section (line 568+)
+CLAUDE.md             # ~9-line "Compose vs k8s scope" paragraph inserted between Build Commands and Helm Commands
+```
+
+Total diff: ~36 lines added, ~3 lines removed.
+
+---
+
+## Task 1: Update `docker-compose.yml` header comment
+
+**Files:**
+
+- Modify: `docker-compose.yml` (lines 1-3)
+
+- [ ] **Step 1: Read current header**
+
+```bash
+head -10 /Users/kaio.fellipe/Documents/git/others/go-http-server/docker-compose.yml
+```
+
+Expected current first 3 lines:
+
+```yaml
+# Local development compose file.
+# Usage: make run | make run-logs | make stop | make seed
+#   or:  docker compose up --build
+```
+
+- [ ] **Step 2: Replace the header**
+
+Replace the first 3 lines of `docker-compose.yml` with:
+
+```yaml
+# Local development compose file — lite mode.
+#
+# Scope: postgres + redis + 5 backend services + productpage.
+# NOT included: Kafka, ingestion service, Argo Events, observability.
+# Producers detect missing KAFKA_BROKERS and fall back to a no-op
+# publisher; events are dropped silently.
+#
+# The full event-driven path (ingestion → Kafka → Argo Events sensor
+# → notification HTTP trigger) requires `make run-k8s` (k3d cluster).
+#
+# Usage: make run | make run-logs | make stop | make seed
+#   or:  docker compose up --build
+```
+
+The rest of the file is unchanged.
+
+- [ ] **Step 3: Verify the file is still valid YAML**
+
+Run:
+
+```bash
+docker compose -f /Users/kaio.fellipe/Documents/git/others/go-http-server/docker-compose.yml config >/dev/null
+echo "compose config: $?"
+```
+
+Expected: `compose config: 0`. If non-zero, the YAML body was disturbed — revert and only edit the comment block.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/go-http-server
+git add docker-compose.yml
+git commit -m "$(cat <<'EOF'
+docs(compose): annotate docker-compose.yml as lite-mode dev environment
+
+Postgres + redis + 5 backend services + productpage only. Kafka,
+ingestion, Argo Events, and observability live in k8s (make run-k8s).
+Producers detect missing KAFKA_BROKERS and fall back to a no-op
+publisher; events are dropped silently.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Update `README.md` — `make run` section
+
+**Files:**
+
+- Modify: `README.md` (around line 269 — "Or use Docker Compose" section)
+
+- [ ] **Step 1: Read the section**
+
+```bash
+sed -n '264,278p' /Users/kaio.fellipe/Documents/git/others/go-http-server/README.md
+```
+
+Expected output (lines 269-275 visible):
+
+```markdown
+**Or use Docker Compose** (PostgreSQL backend, all services with one command):
+
+```bash
+make run          # Start all services + PostgreSQL, seed databases
+make run-logs     # Tail logs
+make stop         # Stop and remove containers
+```
+```
+
+- [ ] **Step 2: Insert the lite-mode callout block**
+
+Find the line `make stop         # Stop and remove containers` followed by the closing fence ` ``` `. Immediately AFTER the closing fence, insert a blank line, then the callout, then another blank line:
+
+```markdown
+> **Lite mode.** Docker Compose runs the synchronous service mesh
+> only: postgres + redis + 5 backend services + productpage. Kafka,
+> the ingestion service, Argo Events, and the observability stack
+> are NOT included. Producers detect missing `KAFKA_BROKERS` and
+> fall back to a no-op publisher; events are dropped silently.
+>
+> The full event-driven path (ingestion polling Open Library →
+> Kafka → Argo Events EventSource → Sensor → notification HTTP
+> trigger) is exercised only via `make run-k8s` (k3d-based local
+> cluster).
+```
+
+The result around lines 269-285 should read:
+
+```markdown
+**Or use Docker Compose** (PostgreSQL backend, all services with one command):
+
+```bash
+make run          # Start all services + PostgreSQL, seed databases
+make run-logs     # Tail logs
+make stop         # Stop and remove containers
+```
+
+> **Lite mode.** Docker Compose runs the synchronous service mesh
+> only: postgres + redis + 5 backend services + productpage. Kafka,
+> the ingestion service, Argo Events, and the observability stack
+> are NOT included. Producers detect missing `KAFKA_BROKERS` and
+> fall back to a no-op publisher; events are dropped silently.
+>
+> The full event-driven path (ingestion polling Open Library →
+> Kafka → Argo Events EventSource → Sensor → notification HTTP
+> trigger) is exercised only via `make run-k8s` (k3d-based local
+> cluster).
+
+---
+```
+
+(The trailing `---` is the existing horizontal rule that was already on line 277.)
+
+- [ ] **Step 3: Verify markdown structure not broken**
+
+Run a sanity check that the file still parses as expected by counting backtick-fenced blocks (should be unchanged from before the edit since we only added a blockquote, not a fenced block):
+
+```bash
+grep -c "^\`\`\`" /Users/kaio.fellipe/Documents/git/others/go-http-server/README.md
+```
+
+Expected: an even number (each fence has an open and close). Note the count before AND after; it must match.
+
+> NOTE: do NOT commit yet. Task 3 also edits `README.md` — single commit covers both.
+
+---
+
+## Task 3: Update `README.md` — E2E Tests section
+
+**Files:**
+
+- Modify: `README.md` (around line 568 — "## E2E Tests" section)
+
+- [ ] **Step 1: Read the section**
+
+```bash
+sed -n '566,584p' /Users/kaio.fellipe/Documents/git/others/go-http-server/README.md
+```
+
+Expected output (around lines 568-583):
+
+```markdown
+## E2E Tests
+
+E2E tests spin up all five services via docker-compose and exercise each service's HTTP API with shell scripts.
+
+```bash
+# Run E2E tests (memory backend)
+make e2e
+
+# Run E2E tests with PostgreSQL backend
+docker compose -f test/e2e/docker-compose.yml \
+               -f test/e2e/docker-compose.postgres.yml up -d
+bash test/e2e/run-tests.sh
+```
+
+Individual test scripts under `test/e2e/` cover health endpoints, CRUD operations, and cross-service integration (e.g., reviews fetching ratings).
+```
+
+- [ ] **Step 2: Append a lite-mode scope note after the "Individual test scripts ..." paragraph**
+
+Find the line:
+
+```markdown
+Individual test scripts under `test/e2e/` cover health endpoints, CRUD operations, and cross-service integration (e.g., reviews fetching ratings).
+```
+
+Add an immediately-following blockquote, separated by one blank line:
+
+```markdown
+> **Scope.** `make e2e` covers HTTP-level acceptance tests
+> (idempotency, validation, CRUD round-trips) under the lite-mode
+> compose stack. The event chain (Kafka publish, Argo Events sensor,
+> notification HTTP trigger) is verified end-to-end via Tempo trace
+> inspection after `make run-k8s`.
+```
+
+The result around lines 582-590 should read:
+
+```markdown
+Individual test scripts under `test/e2e/` cover health endpoints, CRUD operations, and cross-service integration (e.g., reviews fetching ratings).
+
+> **Scope.** `make e2e` covers HTTP-level acceptance tests
+> (idempotency, validation, CRUD round-trips) under the lite-mode
+> compose stack. The event chain (Kafka publish, Argo Events sensor,
+> notification HTTP trigger) is verified end-to-end via Tempo trace
+> inspection after `make run-k8s`.
+
+---
+```
+
+(The trailing `---` is the existing horizontal rule that was already on line 584.)
+
+- [ ] **Step 3: Verify the markdown still has even backtick-fenced count**
+
+```bash
+grep -c "^\`\`\`" /Users/kaio.fellipe/Documents/git/others/go-http-server/README.md
+```
+
+Expected: same even number as after Task 2 Step 3 (we added blockquotes only, no fenced blocks).
+
+- [ ] **Step 4: Commit (covers Task 2 and Task 3 together)**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/go-http-server
+git add README.md
+git commit -m "$(cat <<'EOF'
+docs(readme): annotate compose + e2e as lite-mode
+
+Adds two blockquote callouts: one under the docker-compose run section
+explaining the lite-mode scope (no Kafka/ingestion/Argo Events/
+observability) and pointing at make run-k8s for the full event-driven
+path; one under the E2E Tests section noting that make e2e covers
+HTTP-level tests only and the event chain is verified via Tempo
+traces after make run-k8s.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Update `CLAUDE.md` — Compose vs k8s scope paragraph
+
+**Files:**
+
+- Modify: `CLAUDE.md` (insert between line 45 — end of `## Build Commands` block — and line 47 — `## Helm Commands` heading)
+
+- [ ] **Step 1: Read the section**
+
+```bash
+sed -n '37,55p' /Users/kaio.fellipe/Documents/git/others/go-http-server/CLAUDE.md
+```
+
+Expected output (lines 37-54):
+
+```markdown
+## Build Commands
+
+```bash
+make build-all          # Build all 7 service binaries to bin/
+make test               # go test -race -count=1 ./...
+make lint               # golangci-lint run
+make e2e                # Docker Compose + shell smoke tests (memory backend)
+make docker-build-all   # Build all 7 Docker images
+```
+
+## Helm Commands
+
+```bash
+helm dependency build charts/bookinfo-service  # Fetch subchart dependencies (run once after clone)
+make helm-lint            # Lint chart with all per-service values files
+make helm-template SERVICE=ratings  # Dry-run render for a specific service
+helm upgrade --install ratings charts/bookinfo-service -f deploy/ratings/values-local.yaml -n bookinfo
+```
+```
+
+- [ ] **Step 2: Insert the scope paragraph between Build Commands and Helm Commands**
+
+Find the closing fence ` ``` ` of the Build Commands block (line 45). After that fence and the existing blank line at line 46, BEFORE the `## Helm Commands` heading at line 47, insert a new section:
+
+```markdown
+## Compose vs k8s scope
+
+`make run` (docker-compose) is a lite development environment —
+postgres + redis + 5 backend services + productpage. Compose does
+NOT include Kafka, the ingestion service, Argo Events, or the
+observability stack. Producers fall back to a no-op publisher when
+`KAFKA_BROKERS` is unset; events are dropped. The full event-driven
+flow (ingestion + Kafka + Argo Events sensors driving notifications)
+and observability stack are exercised only via `make run-k8s`. Use
+`make e2e` for HTTP-level acceptance tests; the event chain is
+verified via Tempo traces after `make run-k8s`.
+
+```
+
+The result around lines 37-58 (after edit) should read:
+
+```markdown
+## Build Commands
+
+```bash
+make build-all          # Build all 7 service binaries to bin/
+make test               # go test -race -count=1 ./...
+make lint               # golangci-lint run
+make e2e                # Docker Compose + shell smoke tests (memory backend)
+make docker-build-all   # Build all 7 Docker images
+```
+
+## Compose vs k8s scope
+
+`make run` (docker-compose) is a lite development environment —
+postgres + redis + 5 backend services + productpage. Compose does
+NOT include Kafka, the ingestion service, Argo Events, or the
+observability stack. Producers fall back to a no-op publisher when
+`KAFKA_BROKERS` is unset; events are dropped. The full event-driven
+flow (ingestion + Kafka + Argo Events sensors driving notifications)
+and observability stack are exercised only via `make run-k8s`. Use
+`make e2e` for HTTP-level acceptance tests; the event chain is
+verified via Tempo traces after `make run-k8s`.
+
+## Helm Commands
+
+```bash
+...
+```
+```
+
+- [ ] **Step 3: Verify markdown structure**
+
+```bash
+grep -c "^\`\`\`" /Users/kaio.fellipe/Documents/git/others/go-http-server/CLAUDE.md
+```
+
+Expected: same even number as before the edit (no fenced blocks added/removed).
+
+```bash
+grep -c "^## " /Users/kaio.fellipe/Documents/git/others/go-http-server/CLAUDE.md
+```
+
+Expected: incremented by exactly 1 vs before the edit (we added one new `##` heading).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/go-http-server
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs(claude): document compose vs k8s scope boundary
+
+Inserts a Compose vs k8s scope section between Build Commands and
+Helm Commands explaining that make run (docker-compose) is the lite
+dev path (postgres + redis + 5 services) and the full event-driven
+flow (Kafka, ingestion, Argo Events, observability) is exercised
+only via make run-k8s. Producers fall back to a no-op publisher
+when KAFKA_BROKERS is unset.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Push to PR #54
+
+- [ ] **Step 1: Verify branch + clean state**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/go-http-server
+git branch --show-current
+git status
+```
+
+Expected: on `feat/event-driven-notifications`, clean working tree.
+
+- [ ] **Step 2: Inspect the three new commits**
+
+```bash
+git log --oneline -3
+```
+
+Expected (top to bottom):
+
+1. `docs(claude): document compose vs k8s scope boundary`
+2. `docs(readme): annotate compose + e2e as lite-mode`
+3. `docs(compose): annotate docker-compose.yml as lite-mode dev environment`
+
+- [ ] **Step 3: Push**
+
+```bash
+git push
+```
+
+Expected: branch updated; PR #54 picks up the three new docs commits.
+
+- [ ] **Step 4: Watch CI**
+
+```bash
+gh pr checks 54 --watch --interval 30 --fail-fast
+```
+
+Expected: all checks green. Docs-only changes shouldn't trip any lint or test failures, but the chart-version-bump CI job from earlier may run on any PR push — should pass since chart files are untouched.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Decision 1 (document, do not extend compose) → all four tasks are docs-only ✔
+- Decision 2 (same wording across all three files) → Tasks 1, 2/3, 4 reuse the canonical phrasing about scope, NoopPublisher fallback, and pointer to `make run-k8s` ✔
+- Decision 3 (mention NoopPublisher behavior explicitly) → Tasks 1, 2, 4 all include "fall back to a no-op publisher; events are dropped" ✔
+- Decision 4 (reference `make run-k8s` as the full-chain path) → Tasks 1, 2, 4 all point at `make run-k8s` ✔
+- Component: `docker-compose.yml` header → Task 1 ✔
+- Component: README.md run + e2e callouts → Tasks 2 + 3 ✔
+- Component: CLAUDE.md scope paragraph → Task 4 ✔
+- Acceptance criteria 1-5 → Tasks 1 (criterion 1), 2-3 (criterion 2), 4 (criterion 3), wording-consistency check is implicit in reuse (criterion 4), no code/helm/service edits (criterion 5) ✔
+
+**Placeholder scan:** no "TBD", "TODO", "implement later", "similar to". The "verify the markdown still has even backtick-fenced count" instruction is a concrete sanity check, not a placeholder.
+
+**Type consistency:** N/A — no types or method signatures involved. Wording consistency is the analogous concern: the phrases "Kafka, the ingestion service, Argo Events, and the observability stack", "no-op publisher", "events are dropped", and "make run-k8s" appear identically across Tasks 1, 2, and 4. Verified.

--- a/docs/superpowers/plans/2026-04-25-e2e-tracing-kafka.md
+++ b/docs/superpowers/plans/2026-04-25-e2e-tracing-kafka.md
@@ -1,0 +1,1307 @@
+# End-to-End Tracing Across Kafka Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Producer (Go) injects W3C `traceparent` into Kafka record headers; argo-events fork's Kafka source extracts those headers into CloudEvent extensions so the existing `tracing.SpanFromCloudEvent` chain joins the upstream trace. Result: one connected Tempo trace from gateway through to notification.
+
+**Architecture:** Two-repo change. (1) `event-driven-bookinfo`: shared `pkg/telemetry/kafka.go` helper called once per producer. (2) `argo-events` fork: new `WithKafkaHeaders` Option (mirrors existing `WithHTTPHeaders`) plus a one-line call from each kafka source dispatch site. Cherry-pick the fork commit from `feat/cloudevents-compliance-otel-tracing` (PR 3961) onto the consumed branch `feat/combined-prs-3961-3983` so the image rebuild picks it up.
+
+**Tech Stack:** Go 1.22, `github.com/twmb/franz-go`, OpenTelemetry SDK (W3C TraceContext propagator), Argo Events 1.9+, `github.com/cloudevents/sdk-go/v2`.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-25-e2e-tracing-kafka-design.md`
+
+---
+
+## File Structure
+
+### Repo 1 — `event-driven-bookinfo` (this repo)
+
+**Created:**
+
+```
+pkg/telemetry/kafka.go               # kafkaHeaderCarrier + InjectTraceContext
+pkg/telemetry/kafka_test.go          # unit test for the helper
+```
+
+**Modified (one line each):**
+
+```
+services/details/internal/adapter/outbound/kafka/producer.go
+services/details/internal/adapter/outbound/kafka/producer_test.go
+services/reviews/internal/adapter/outbound/kafka/producer.go
+services/reviews/internal/adapter/outbound/kafka/producer_test.go
+services/ratings/internal/adapter/outbound/kafka/producer.go
+services/ratings/internal/adapter/outbound/kafka/producer_test.go
+services/ingestion/internal/adapter/outbound/kafka/producer.go
+services/ingestion/internal/adapter/outbound/kafka/producer_test.go
+```
+
+### Repo 2 — `argo-events` fork (`/Users/kaio.fellipe/Documents/git/others/argo-events`)
+
+**Modified on `feat/cloudevents-compliance-otel-tracing`:**
+
+```
+pkg/eventsources/common/common.go            # add WithKafkaHeaders Option
+pkg/eventsources/common/common_test.go       # extend existing test file
+pkg/eventsources/sources/kafka/start.go      # call dispatch with WithKafkaHeaders
+```
+
+Then cherry-picked verbatim onto `feat/combined-prs-3961-3983`.
+
+---
+
+## Phase 1 — Producer side (event-driven-bookinfo)
+
+### Task 1: Shared Kafka trace-injection helper
+
+**Files:**
+
+- Create: `pkg/telemetry/kafka.go`
+- Create: `pkg/telemetry/kafka_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `pkg/telemetry/kafka_test.go`:
+
+```go
+package telemetry_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
+)
+
+func TestInjectTraceContext_WithActiveSpan_AddsTraceparent(t *testing.T) {
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "parent")
+	defer span.End()
+
+	rec := &kgo.Record{Topic: "t"}
+	telemetry.InjectTraceContext(ctx, rec)
+
+	headers := map[string]string{}
+	for _, h := range rec.Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["traceparent"] == "" {
+		t.Fatal("expected traceparent header, got none")
+	}
+
+	want := span.SpanContext().TraceID().String()
+	got := headers["traceparent"]
+	if len(got) < 35 || got[3:35] != want {
+		t.Errorf("traceparent trace_id = %q, want trace_id %q embedded", got, want)
+	}
+}
+
+func TestInjectTraceContext_NoActiveSpan_NoTraceparent(t *testing.T) {
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	rec := &kgo.Record{Topic: "t"}
+	telemetry.InjectTraceContext(context.Background(), rec)
+
+	for _, h := range rec.Headers {
+		if h.Key == "traceparent" {
+			t.Fatalf("expected no traceparent header, got %q", string(h.Value))
+		}
+	}
+}
+
+func TestInjectTraceContext_PreservesExistingHeaders(t *testing.T) {
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "p")
+	defer span.End()
+
+	rec := &kgo.Record{
+		Topic: "t",
+		Headers: []kgo.RecordHeader{
+			{Key: "ce_type", Value: []byte("com.example.x")},
+		},
+	}
+	telemetry.InjectTraceContext(ctx, rec)
+
+	var hasCE, hasTP bool
+	for _, h := range rec.Headers {
+		if h.Key == "ce_type" {
+			hasCE = true
+		}
+		if h.Key == "traceparent" {
+			hasTP = true
+		}
+	}
+	if !hasCE {
+		t.Error("ce_type header was lost")
+	}
+	if !hasTP {
+		t.Error("traceparent was not added")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/telemetry/... -v`
+
+Expected: compile failure `undefined: telemetry.InjectTraceContext` (since the source file doesn't exist yet).
+
+- [ ] **Step 3: Implement the helper**
+
+Create `pkg/telemetry/kafka.go`:
+
+```go
+package telemetry
+
+import (
+	"context"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// kafkaHeaderCarrier adapts a *kgo.Record's Headers slice to TextMapCarrier
+// for W3C trace context propagation.
+type kafkaHeaderCarrier struct {
+	record *kgo.Record
+}
+
+func (c *kafkaHeaderCarrier) Get(key string) string {
+	for _, h := range c.record.Headers {
+		if h.Key == key {
+			return string(h.Value)
+		}
+	}
+	return ""
+}
+
+func (c *kafkaHeaderCarrier) Set(key, value string) {
+	for i := range c.record.Headers {
+		if c.record.Headers[i].Key == key {
+			c.record.Headers[i].Value = []byte(value)
+			return
+		}
+	}
+	c.record.Headers = append(c.record.Headers, kgo.RecordHeader{Key: key, Value: []byte(value)})
+}
+
+func (c *kafkaHeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(c.record.Headers))
+	for _, h := range c.record.Headers {
+		keys = append(keys, h.Key)
+	}
+	return keys
+}
+
+// InjectTraceContext writes W3C traceparent (and tracestate, when set) from
+// ctx into the Kafka record headers via the registered TextMapPropagator.
+// No-op when ctx carries no active span.
+func InjectTraceContext(ctx context.Context, record *kgo.Record) {
+	otel.GetTextMapPropagator().Inject(ctx, &kafkaHeaderCarrier{record: record})
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./pkg/telemetry/... -race -count=1 -v`
+
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/telemetry/kafka.go pkg/telemetry/kafka_test.go
+git commit -m "feat(pkg/telemetry): add Kafka record traceparent injector
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Wire injector into details producer
+
+**Files:**
+
+- Modify: `services/details/internal/adapter/outbound/kafka/producer.go`
+- Modify: `services/details/internal/adapter/outbound/kafka/producer_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `services/details/internal/adapter/outbound/kafka/producer_test.go`. Add at the bottom (preserve existing tests):
+
+```go
+func TestPublishBookAdded_InjectsTraceparent(t *testing.T) {
+	t.Parallel()
+
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	ctx, span := otel.Tracer("test").Start(context.Background(), "parent")
+	defer span.End()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_details_events")
+
+	if err := p.PublishBookAdded(ctx, domain.BookAddedEvent{
+		Title: "T", Author: "A", Year: 2024, Type: "paperback",
+		IdempotencyKey: "k1",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	headers := map[string]string{}
+	for _, h := range fc.records[0].Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["traceparent"] == "" {
+		t.Fatal("expected traceparent header, got none")
+	}
+	want := span.SpanContext().TraceID().String()
+	if got := headers["traceparent"]; len(got) < 35 || got[3:35] != want {
+		t.Errorf("traceparent = %q, want embedded trace_id %q", got, want)
+	}
+}
+```
+
+Add the imports needed at the top of the test file (alongside existing imports):
+
+```go
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `go test ./services/details/internal/adapter/outbound/kafka/... -run TestPublishBookAdded_InjectsTraceparent -v`
+
+Expected: FAIL with `expected traceparent header, got none` (producer doesn't inject yet).
+
+- [ ] **Step 3: Add the inject call to the producer**
+
+Open `services/details/internal/adapter/outbound/kafka/producer.go`. Add the import (alongside existing imports):
+
+```go
+"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
+```
+
+Locate the section in `PublishBookAdded` that builds `record` then calls `p.client.ProduceSync`. Insert one line between record construction and the `ProduceSync` call:
+
+```go
+record := &kgo.Record{
+	Topic: p.topic,
+	Key:   []byte(evt.IdempotencyKey),
+	Value: value,
+	Headers: []kgo.RecordHeader{
+		{Key: "ce_specversion", Value: []byte(ceVersion)},
+		{Key: "ce_type", Value: []byte(ceTypeBookAdded)},
+		{Key: "ce_source", Value: []byte(ceSource)},
+		{Key: "ce_id", Value: []byte(uuid.New().String())},
+		{Key: "ce_time", Value: []byte(now.Format(time.RFC3339))},
+		{Key: "ce_subject", Value: []byte(evt.IdempotencyKey)},
+		{Key: "content-type", Value: []byte("application/json")},
+	},
+}
+
+telemetry.InjectTraceContext(ctx, record)
+
+results := p.client.ProduceSync(ctx, record)
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `go test ./services/details/internal/adapter/outbound/kafka/... -race -count=1 -v`
+
+Expected: all tests PASS, including `TestPublishBookAdded_InjectsTraceparent`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/details/internal/adapter/outbound/kafka/
+git commit -m "feat(details): inject W3C traceparent into Kafka record headers
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Wire injector into reviews producer
+
+**Files:**
+
+- Modify: `services/reviews/internal/adapter/outbound/kafka/producer.go`
+- Modify: `services/reviews/internal/adapter/outbound/kafka/producer_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `services/reviews/internal/adapter/outbound/kafka/producer_test.go`. Add at the bottom:
+
+```go
+func TestPublishReviewSubmitted_InjectsTraceparent(t *testing.T) {
+	t.Parallel()
+
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	ctx, span := otel.Tracer("test").Start(context.Background(), "parent")
+	defer span.End()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_reviews_events")
+
+	if err := p.PublishReviewSubmitted(ctx, domain.ReviewSubmittedEvent{
+		ID: "r1", ProductID: "p", Reviewer: "u", Text: "ok", IdempotencyKey: "k1",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	headers := map[string]string{}
+	for _, h := range fc.records[0].Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["traceparent"] == "" {
+		t.Fatal("expected traceparent header, got none")
+	}
+	want := span.SpanContext().TraceID().String()
+	if got := headers["traceparent"]; len(got) < 35 || got[3:35] != want {
+		t.Errorf("traceparent = %q, want embedded trace_id %q", got, want)
+	}
+}
+```
+
+Add imports if not already present:
+
+```go
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `go test ./services/reviews/internal/adapter/outbound/kafka/... -run TestPublishReviewSubmitted_InjectsTraceparent -v`
+
+Expected: FAIL with `expected traceparent header, got none`.
+
+- [ ] **Step 3: Add the inject call to the reviews producer**
+
+Open `services/reviews/internal/adapter/outbound/kafka/producer.go`. Add import:
+
+```go
+"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
+```
+
+In the private `produce(ctx, ceType, key, partitionHint, body)` helper, insert one line between record construction and the `ProduceSync` call:
+
+```go
+record := &kgo.Record{
+	Topic: p.topic,
+	Key:   recordKey,
+	Value: value,
+	Headers: []kgo.RecordHeader{
+		{Key: "ce_specversion", Value: []byte(ceVersion)},
+		{Key: "ce_type", Value: []byte(ceType)},
+		{Key: "ce_source", Value: []byte(ceSource)},
+		{Key: "ce_id", Value: []byte(uuid.New().String())},
+		{Key: "ce_time", Value: []byte(now.Format(time.RFC3339))},
+		{Key: "ce_subject", Value: []byte(key)},
+		{Key: "content-type", Value: []byte("application/json")},
+	},
+}
+
+telemetry.InjectTraceContext(ctx, record)
+
+results := p.client.ProduceSync(ctx, record)
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `go test ./services/reviews/internal/adapter/outbound/kafka/... -race -count=1 -v`
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/reviews/internal/adapter/outbound/kafka/
+git commit -m "feat(reviews): inject W3C traceparent into Kafka record headers
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Wire injector into ratings producer
+
+**Files:**
+
+- Modify: `services/ratings/internal/adapter/outbound/kafka/producer.go`
+- Modify: `services/ratings/internal/adapter/outbound/kafka/producer_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `services/ratings/internal/adapter/outbound/kafka/producer_test.go`. Add at the bottom:
+
+```go
+func TestPublishRatingSubmitted_InjectsTraceparent(t *testing.T) {
+	t.Parallel()
+
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	ctx, span := otel.Tracer("test").Start(context.Background(), "parent")
+	defer span.End()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_ratings_events")
+
+	if err := p.PublishRatingSubmitted(ctx, domain.RatingSubmittedEvent{
+		ID: "rt1", ProductID: "p", Reviewer: "u", Stars: 5, IdempotencyKey: "k1",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	headers := map[string]string{}
+	for _, h := range fc.records[0].Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["traceparent"] == "" {
+		t.Fatal("expected traceparent header, got none")
+	}
+	want := span.SpanContext().TraceID().String()
+	if got := headers["traceparent"]; len(got) < 35 || got[3:35] != want {
+		t.Errorf("traceparent = %q, want embedded trace_id %q", got, want)
+	}
+}
+```
+
+Add imports if not already present:
+
+```go
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `go test ./services/ratings/internal/adapter/outbound/kafka/... -run TestPublishRatingSubmitted_InjectsTraceparent -v`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Add the inject call to the ratings producer**
+
+Open `services/ratings/internal/adapter/outbound/kafka/producer.go`. Add import:
+
+```go
+"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
+```
+
+In `PublishRatingSubmitted`, insert one line between record construction and the `ProduceSync` call:
+
+```go
+record := &kgo.Record{
+	Topic: p.topic,
+	Key:   recordKey,
+	Value: value,
+	Headers: []kgo.RecordHeader{
+		{Key: "ce_specversion", Value: []byte(ceVersion)},
+		{Key: "ce_type", Value: []byte(ceTypeRatingSubmitted)},
+		{Key: "ce_source", Value: []byte(ceSource)},
+		{Key: "ce_id", Value: []byte(uuid.New().String())},
+		{Key: "ce_time", Value: []byte(now.Format(time.RFC3339))},
+		{Key: "ce_subject", Value: []byte(evt.IdempotencyKey)},
+		{Key: "content-type", Value: []byte("application/json")},
+	},
+}
+
+telemetry.InjectTraceContext(ctx, record)
+
+results := p.client.ProduceSync(ctx, record)
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `go test ./services/ratings/internal/adapter/outbound/kafka/... -race -count=1 -v`
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/ratings/internal/adapter/outbound/kafka/
+git commit -m "feat(ratings): inject W3C traceparent into Kafka record headers
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Wire injector into ingestion producer
+
+**Files:**
+
+- Modify: `services/ingestion/internal/adapter/outbound/kafka/producer.go`
+- Modify: `services/ingestion/internal/adapter/outbound/kafka/producer_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `services/ingestion/internal/adapter/outbound/kafka/producer_test.go`. Add at the bottom:
+
+```go
+func TestPublishBookAdded_InjectsTraceparent(t *testing.T) {
+	t.Parallel()
+
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	ctx, span := otel.Tracer("test").Start(context.Background(), "parent")
+	defer span.End()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "raw_books_details")
+
+	book := domain.Book{
+		Title:       "T",
+		Authors:     []string{"A"},
+		ISBN:        "9780000000099",
+		PublishYear: 2024,
+	}
+	if err := p.PublishBookAdded(ctx, book); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	headers := map[string]string{}
+	for _, h := range fc.records[0].Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["traceparent"] == "" {
+		t.Fatal("expected traceparent header, got none")
+	}
+	want := span.SpanContext().TraceID().String()
+	if got := headers["traceparent"]; len(got) < 35 || got[3:35] != want {
+		t.Errorf("traceparent = %q, want embedded trace_id %q", got, want)
+	}
+}
+```
+
+Add imports if not already present:
+
+```go
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `go test ./services/ingestion/internal/adapter/outbound/kafka/... -run TestPublishBookAdded_InjectsTraceparent -v`
+
+Expected: FAIL with `expected traceparent header, got none`.
+
+- [ ] **Step 3: Add the inject call to the ingestion producer**
+
+Open `services/ingestion/internal/adapter/outbound/kafka/producer.go`. Add import:
+
+```go
+"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
+```
+
+In `PublishBookAdded`, insert one line between record construction and the `ProduceSync` call:
+
+```go
+record := &kgo.Record{
+	Topic: p.topic,
+	Key:   []byte(book.ISBN),
+	Value: value,
+	Headers: []kgo.RecordHeader{
+		{Key: "ce_specversion", Value: []byte(ceVersion)},
+		{Key: "ce_type", Value: []byte(ceType)},
+		{Key: "ce_source", Value: []byte(ceSource)},
+		{Key: "ce_id", Value: []byte(uuid.New().String())},
+		{Key: "ce_time", Value: []byte(now.Format(time.RFC3339))},
+		{Key: "ce_subject", Value: []byte(book.ISBN)},
+		{Key: "content-type", Value: []byte("application/json")},
+	},
+}
+
+telemetry.InjectTraceContext(ctx, record)
+
+results := p.client.ProduceSync(ctx, record)
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `go test ./services/ingestion/internal/adapter/outbound/kafka/... -race -count=1 -v`
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/ingestion/internal/adapter/outbound/kafka/
+git commit -m "feat(ingestion): inject W3C traceparent into Kafka record headers
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Producer-side full lint + test sweep
+
+- [ ] **Step 1: Lint**
+
+Run: `make lint`
+
+Expected: `0 issues.`
+
+- [ ] **Step 2: All tests**
+
+Run: `make test`
+
+Expected: every package OK; no FAIL line.
+
+- [ ] **Step 3: No additional commit needed if everything passes**
+
+If lint reports formatting issues, run `gofmt -w` on the affected files and commit:
+
+```bash
+git add -A
+git commit -m "chore: gofmt sweep after traceparent injection
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 2 — Argo Events fork (`feat/cloudevents-compliance-otel-tracing`)
+
+**Constraints (apply to every commit in this phase):**
+
+1. Preserve the 12 existing PR-3961 commits (`7e5371a8` … `30401397`) unchanged. Append-only.
+2. Sign off every commit: `git commit -s`. DCO required by argoproj/argo-events upstream.
+3. **NO** `Co-Authored-By: Claude` trailer on these commits.
+4. Push as fast-forward only — no `--force` / `--force-with-lease`.
+
+### Task 7: Verify branch state and switch worktree
+
+- [ ] **Step 1: Switch to the fork repo and confirm branch**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+git status
+git branch --show-current
+```
+
+Expected: clean working tree. If current branch is not `feat/cloudevents-compliance-otel-tracing`, run:
+
+```bash
+git checkout feat/cloudevents-compliance-otel-tracing
+```
+
+- [ ] **Step 2: Snapshot the existing 12 commits to verify untouched later**
+
+```bash
+git log --oneline master..feat/cloudevents-compliance-otel-tracing > /tmp/argo-events-pr3961-baseline.txt
+wc -l /tmp/argo-events-pr3961-baseline.txt
+```
+
+Expected: file lists 12 SHAs (top-most `30401397`, oldest `7e5371a8`). Will compare after pushing.
+
+- [ ] **Step 3: Pull from origin (defensive)**
+
+```bash
+git pull --ff-only origin feat/cloudevents-compliance-otel-tracing
+```
+
+Expected: `Already up to date.` or fast-forward without merge.
+
+---
+
+### Task 8: Add `WithKafkaHeaders` Option to `eventsourcecommon`
+
+**Files:**
+
+- Modify: `pkg/eventsources/common/common.go`
+- Modify: `pkg/eventsources/common/common_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `pkg/eventsources/common/common_test.go`. Add the following test (preserve existing tests; add to the same package):
+
+```go
+func TestWithKafkaHeaders(t *testing.T) {
+	tests := []struct {
+		name        string
+		headers     map[string]string
+		wantTP      string
+		wantTS      string
+	}{
+		{
+			name:    "traceparent and tracestate present",
+			headers: map[string]string{
+				"traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+				"tracestate":  "rojo=00f067aa0ba902b7",
+			},
+			wantTP: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+			wantTS: "rojo=00f067aa0ba902b7",
+		},
+		{
+			name:    "only traceparent",
+			headers: map[string]string{
+				"traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+			},
+			wantTP: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+			wantTS: "",
+		},
+		{
+			name:    "no trace headers — no extension set",
+			headers: map[string]string{"x-other": "v"},
+			wantTP:  "",
+			wantTS:  "",
+		},
+		{
+			name:    "nil headers — safe no-op",
+			headers: nil,
+			wantTP:  "",
+			wantTS:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			e := cloudevents.NewEvent()
+			if err := common.WithKafkaHeaders(tt.headers)(&e); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got, _ := e.Extensions()["traceparent"].(string); got != tt.wantTP {
+				t.Errorf("traceparent extension = %q, want %q", got, tt.wantTP)
+			}
+			if got, _ := e.Extensions()["tracestate"].(string); got != tt.wantTS {
+				t.Errorf("tracestate extension = %q, want %q", got, tt.wantTS)
+			}
+		})
+	}
+}
+```
+
+If `cloudevents` is not yet imported in this test file, add to imports:
+
+```go
+import (
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+go test ./pkg/eventsources/common/ -run TestWithKafkaHeaders -v
+```
+
+Expected: compile failure `undefined: common.WithKafkaHeaders`.
+
+- [ ] **Step 3: Implement `WithKafkaHeaders`**
+
+Open `pkg/eventsources/common/common.go`. Add this function at the end of the file (after `WithHTTPHeaders`, mirroring its shape):
+
+```go
+// WithKafkaHeaders extracts W3C trace context headers (traceparent/tracestate)
+// from a Kafka record's headers map and sets them as CloudEvent extensions.
+// This enables trace propagation from Kafka producers (e.g. franz-go via
+// otel.GetTextMapPropagator().Inject) into the eventbus dispatch chain
+// where SpanFromCloudEvent will pick them up as the parent span.
+func WithKafkaHeaders(headers map[string]string) Option {
+	return func(e *event.Event) error {
+		if tp, ok := headers["traceparent"]; ok && tp != "" {
+			e.SetExtension("traceparent", tp)
+		}
+		if ts, ok := headers["tracestate"]; ok && ts != "" {
+			e.SetExtension("tracestate", ts)
+		}
+		return nil
+	}
+}
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+```bash
+go test ./pkg/eventsources/common/ -run TestWithKafkaHeaders -race -count=1 -v
+```
+
+Expected: all 4 sub-tests PASS.
+
+- [ ] **Step 5: Run full common package test suite**
+
+```bash
+go test ./pkg/eventsources/common/ -race -count=1
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit (signed off, no Claude trailer)**
+
+```bash
+git add pkg/eventsources/common/common.go pkg/eventsources/common/common_test.go
+git commit -s -m "feat(eventsource): add WithKafkaHeaders option to propagate W3C trace context
+
+Mirrors the existing WithHTTPHeaders option. When a Kafka record carries
+W3C trace context (traceparent/tracestate) in its headers, this option
+copies them into the CloudEvent extensions so the existing
+tracing.SpanFromCloudEvent extractor in eventing.go can pick them up as
+the parent span for the eventsource.publish PRODUCER span. Closes the
+producer-to-eventsource trace gap when used by the kafka source's
+dispatch call."
+```
+
+Verify the trailer is exactly `Signed-off-by: ...`:
+
+```bash
+git log -1 --format=%B | tail -3
+```
+
+Expected: ends with `Signed-off-by: <Name> <email>` and no `Co-Authored-By` line.
+
+---
+
+### Task 9: Use `WithKafkaHeaders` in the Kafka source dispatch
+
+**Files:**
+
+- Modify: `pkg/eventsources/sources/kafka/start.go`
+
+- [ ] **Step 1: Locate the two dispatch sites**
+
+```bash
+grep -n "dispatch(eventBody" pkg/eventsources/sources/kafka/start.go
+```
+
+Expected output (paths and line numbers may vary slightly — current head shows two matches):
+
+```
+291:		if err = dispatch(eventBody, eventsourcecommon.WithID(kafkaID)); err != nil {
+482:		if err = dispatch(eventBody, eventsourcecommon.WithID(kafkaID)); err != nil {
+```
+
+These are the consumerGroupConsumer path (~line 291) and partitionConsumer path (~line 482).
+
+- [ ] **Step 2: Update the consumerGroupConsumer dispatch site**
+
+Open `pkg/eventsources/sources/kafka/start.go`. Find the block around line 291. The lines just before look like:
+
+```go
+headers := make(map[string]string)
+for _, recordHeader := range msg.Headers {
+	headers[string(recordHeader.Key)] = string(recordHeader.Value)
+}
+eventData.Headers = headers
+
+// ... (json marshaling) ...
+
+if err = dispatch(eventBody, eventsourcecommon.WithID(kafkaID)); err != nil {
+	return fmt.Errorf("failed to dispatch a Kafka event, %w", err)
+}
+```
+
+Modify the `dispatch` call to also pass `WithKafkaHeaders(headers)`:
+
+```go
+if err = dispatch(eventBody, eventsourcecommon.WithID(kafkaID), eventsourcecommon.WithKafkaHeaders(headers)); err != nil {
+	return fmt.Errorf("failed to dispatch a Kafka event, %w", err)
+}
+```
+
+- [ ] **Step 3: Update the partitionConsumer dispatch site**
+
+Find the block around line 482. The same `headers` map is built locally (different variable scope but same name). Apply the identical change:
+
+```go
+if err = dispatch(eventBody, eventsourcecommon.WithID(kafkaID), eventsourcecommon.WithKafkaHeaders(headers)); err != nil {
+	return fmt.Errorf("failed to dispatch a Kafka event, %w", err)
+}
+```
+
+- [ ] **Step 4: Build and run package tests**
+
+```bash
+go build ./pkg/eventsources/sources/kafka/...
+go test ./pkg/eventsources/sources/kafka/... -race -count=1
+```
+
+Expected: build OK, tests PASS (existing tests unaffected).
+
+- [ ] **Step 5: Run lint and codegen check**
+
+If the project has Make targets for lint and codegen, run them:
+
+```bash
+make lint || true
+make codegen || true
+```
+
+If unavailable, run gofmt:
+
+```bash
+gofmt -w pkg/eventsources/sources/kafka/start.go pkg/eventsources/common/common.go
+```
+
+If `make codegen` produces changes, include them in the same commit (matches the existing pattern where codegen-only commits sit alongside their feature changes — see `b039f558 chore: regenerate codegen after combining PRs #3961 + #3983`).
+
+- [ ] **Step 6: Verify the 12 baseline commits are still present and unchanged**
+
+```bash
+diff <(git log --oneline master..feat/cloudevents-compliance-otel-tracing | tail -12) <(tail -12 /tmp/argo-events-pr3961-baseline.txt)
+```
+
+Expected: no output (12 baseline SHAs identical).
+
+- [ ] **Step 7: Commit (signed off, no Claude trailer)**
+
+```bash
+git add pkg/eventsources/sources/kafka/start.go
+git commit -s -m "feat(eventsource/kafka): propagate W3C trace context from record headers
+
+Pass WithKafkaHeaders alongside WithID at both dispatch sites
+(consumerGroupConsumer and partitionConsumer) so traceparent/tracestate
+present on the Kafka record become CloudEvent extensions. The existing
+SpanFromCloudEvent in eventing.go then chains the eventsource.publish
+PRODUCER span under the upstream producer span, closing the trace gap
+between Kafka producers and the eventbus."
+```
+
+Verify trailer:
+
+```bash
+git log -1 --format=%B
+```
+
+Expected: ends with `Signed-off-by: ...`, no `Co-Authored-By` line.
+
+- [ ] **Step 8: Push to origin (fast-forward only)**
+
+```bash
+git push origin feat/cloudevents-compliance-otel-tracing
+```
+
+If the push is rejected with "non-fast-forward", STOP — do not force. Pull with rebase instead:
+
+```bash
+git pull --rebase origin feat/cloudevents-compliance-otel-tracing
+```
+
+Then re-run the previous push.
+
+Expected: GitHub PR 3961 picks up the two new commits (Task 8 + Task 9 outputs).
+
+---
+
+### Task 10: Cherry-pick onto the consumed branch and trigger image build
+
+- [ ] **Step 1: Capture the two new commit SHAs**
+
+```bash
+git log --oneline -2 feat/cloudevents-compliance-otel-tracing
+```
+
+Expected: top two lines are the new `feat(eventsource/kafka)` commit and the `feat(eventsource): add WithKafkaHeaders option` commit. Note both SHAs.
+
+- [ ] **Step 2: Switch to the consumed branch**
+
+```bash
+git checkout feat/combined-prs-3961-3983
+git pull --ff-only origin feat/combined-prs-3961-3983
+```
+
+Expected: branch is up to date with origin.
+
+- [ ] **Step 3: Cherry-pick the two new commits in order**
+
+Replace `<SHA_OPTION>` and `<SHA_KAFKA>` with the actual SHAs captured above (option commit first, then kafka source commit):
+
+```bash
+git cherry-pick -s <SHA_OPTION>
+git cherry-pick -s <SHA_KAFKA>
+```
+
+The `-s` flag re-signs the cherry-pick (DCO trailer is preserved on the original commits but cherry-pick adds a new author signature line; `-s` keeps it consistent on the consumed branch too).
+
+If a conflict appears, STOP and resolve manually before continuing. The consumed branch's only divergence from `feat/cloudevents-compliance-otel-tracing` is the kafka-latency commits and a codegen merge commit, none of which touch `pkg/eventsources/common/common.go` or `pkg/eventsources/sources/kafka/start.go` — so a clean cherry-pick is expected.
+
+- [ ] **Step 4: Re-run codegen if applicable**
+
+```bash
+make codegen || true
+```
+
+If codegen produced changes, commit them (preserve the existing project pattern):
+
+```bash
+git add -A
+git commit -s -m "chore: regenerate codegen after kafka trace propagation cherry-pick"
+```
+
+- [ ] **Step 5: Build and test**
+
+```bash
+go build ./...
+go test ./pkg/eventsources/common/ ./pkg/eventsources/sources/kafka/ -race -count=1
+```
+
+Expected: build OK, tests PASS.
+
+- [ ] **Step 6: Push the consumed branch**
+
+```bash
+git push origin feat/combined-prs-3961-3983
+```
+
+Expected: fast-forward push. Pushing this branch triggers the GitHub Actions workflow that builds and pushes `ghcr.io/kaio6fellipe/argo-events:<tag>`.
+
+- [ ] **Step 7: Confirm the image build completes**
+
+In a browser, open <https://github.com/kaio6fellipe/argo-events/actions> and watch the workflow triggered by this push. Expected: image build green.
+
+Or, from the CLI (if `gh` is authenticated against the fork repo):
+
+```bash
+gh -R kaio6fellipe/argo-events run list --branch feat/combined-prs-3961-3983 --limit 1
+```
+
+Expected: latest run `completed` / `success`.
+
+---
+
+## Phase 3 — End-to-end validation in `event-driven-bookinfo`
+
+### Task 11: Pull the new image into the running cluster
+
+- [ ] **Step 1: Switch back to the bookinfo repo**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/go-http-server
+git status
+```
+
+Expected: on `feat/event-driven-notifications` (or whatever branch the producer-side commits landed on), clean working tree.
+
+- [ ] **Step 2: Identify the argo-events image reference**
+
+```bash
+grep -rn "ghcr.io/kaio6fellipe/argo-events" deploy/ charts/ 2>&1 | head
+```
+
+Note the image reference (likely a `:latest` or pinned tag). If pinned to a specific SHA/tag that hasn't been updated, update it to the tag the new build produced (or to the moving `latest` tag).
+
+- [ ] **Step 3: Rolling restart the argo-events controllers and existing EventSource pods**
+
+```bash
+kubectl --context=k3d-bookinfo-local -n platform rollout restart deploy
+kubectl --context=k3d-bookinfo-local -n bookinfo delete pod -l eventsource-name
+kubectl --context=k3d-bookinfo-local -n bookinfo delete pod -l sensor-name
+```
+
+Wait for them to come back:
+
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo get pod -l eventsource-name -w
+```
+
+Press Ctrl+C once all show `Running 1/1`.
+
+- [ ] **Step 4: Rebuild and redeploy the bookinfo Go services**
+
+```bash
+make k8s-rebuild
+```
+
+Expected: images rebuilt, imported, deployments rolled.
+
+- [ ] **Step 5: Confirm all pods Running**
+
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo get pods --no-headers | awk '{print $3}' | sort | uniq -c
+```
+
+Expected: only `Running` (no Crash/Pending/Container).
+
+---
+
+### Task 12: Smoke test — single connected trace for a review submission
+
+- [ ] **Step 1: POST a review with a unique marker**
+
+```bash
+curl -sS -X POST http://localhost:8080/v1/reviews \
+  -H 'Content-Type: application/json' \
+  -d '{"product_id":"trace-e2e","reviewer":"u","text":"trace audit"}'
+echo
+sleep 5
+```
+
+- [ ] **Step 2: Capture the producing service's trace_id**
+
+```bash
+TRACE_REVIEWS=$(kubectl --context=k3d-bookinfo-local -n bookinfo logs deploy/reviews-write --since=30s 2>&1 \
+  | grep '"product_id":"trace-e2e"' \
+  | head -1 \
+  | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["trace_id"])')
+echo "reviews-write trace_id: $TRACE_REVIEWS"
+```
+
+Expected: a 32-char hex string.
+
+- [ ] **Step 3: Capture the notification service's trace_id**
+
+```bash
+TRACE_NOTIF=$(kubectl --context=k3d-bookinfo-local -n bookinfo logs deploy/notification --since=30s 2>&1 \
+  | grep '"subject":"trace-e2e"' \
+  | head -1 \
+  | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["trace_id"])')
+echo "notification trace_id: $TRACE_NOTIF"
+```
+
+Expected: a 32-char hex string.
+
+- [ ] **Step 4: Acceptance — IDs must match**
+
+```bash
+[ "$TRACE_REVIEWS" = "$TRACE_NOTIF" ] && echo "MATCH" || echo "MISMATCH: $TRACE_REVIEWS vs $TRACE_NOTIF"
+```
+
+Expected: `MATCH`. If `MISMATCH`, the producer→eventsource fix did not take effect. Check that the new image is actually running (`kubectl describe pod -l eventsource-name=reviews-events | grep Image`) and that the producer commit is actually deployed.
+
+---
+
+### Task 13: Tempo trace tree inspection
+
+- [ ] **Step 1: Open Grafana**
+
+In a browser: <http://localhost:3000>. Login `admin / admin` (project default; password may differ in newer deploys — read from secret if needed: `kubectl --context=k3d-bookinfo-local -n observability get secret prometheus-grafana -o jsonpath='{.data.admin-password}' | base64 -d`).
+
+- [ ] **Step 2: Query Tempo for the captured trace**
+
+In Grafana → Explore → select `Tempo` data source → query field, paste:
+
+```
+{ traceID="<TRACE_REVIEWS from Task 12 Step 2>" }
+```
+
+Submit. Click the resulting trace.
+
+- [ ] **Step 3: Verify the span tree contains every hop**
+
+Expected spans visible in the timeline (order from root to leaf):
+
+1. `envoy-gateway` (server kind, root)
+2. `reviews-write-api POST /v1/reviews` (server kind, child of CQRS sensor's HTTP CLIENT)
+3. `eventsource.publish` (PRODUCER kind) — emitted from the dispatch in eventing.go on the reviews-events EventSource side
+4. eventbus consumer span (CONSUMER kind) — emitted by the notification consumer sensor
+5. `notification-consumer-sensor` trigger span (CLIENT kind)
+6. `notification-api POST /v1/notifications` (server kind)
+
+Span tree depth >= 6. All under the same root trace_id.
+
+If the eventsource.publish span is missing or appears as a separate trace root, the `WithKafkaHeaders` option is not being applied — re-check Task 9 changes in the running image.
+
+- [ ] **Step 4: Repeat for the other three event types**
+
+Run the same smoke + trace check for:
+
+```bash
+# book-added
+curl -sS -X POST http://localhost:8080/v1/details -H 'Content-Type: application/json' \
+  -d '{"title":"trace-book","author":"a","year":2026,"type":"paperback","pages":1,"isbn_13":"9780000000111"}'
+
+# rating-submitted
+curl -sS -X POST http://localhost:8080/v1/ratings -H 'Content-Type: application/json' \
+  -d '{"product_id":"trace-rating","reviewer":"u","stars":4}'
+
+# review-deleted (uses the review created in Task 12)
+REVIEW_ID=$(kubectl --context=k3d-bookinfo-local -n bookinfo exec statefulset/reviews-postgresql -- \
+  bash -c "PGPASSWORD=bookinfo psql -U bookinfo -d bookinfo_reviews -t -c \"SELECT id FROM reviews WHERE product_id='trace-e2e' LIMIT 1;\"" | xargs)
+curl -sS -X POST http://localhost:8080/v1/reviews/delete -H 'Content-Type: application/json' \
+  -d "{\"review_id\":\"$REVIEW_ID\"}"
+```
+
+For each, repeat Task 12 Steps 2-4. Acceptance: `trace_id` matches between producer service and notification service.
+
+---
+
+### Task 14: Final lint sweep + push and PR update
+
+- [ ] **Step 1: Producer-side lint and tests**
+
+```bash
+make lint
+make test
+```
+
+Expected: all clean.
+
+- [ ] **Step 2: Push the bookinfo branch**
+
+```bash
+git push
+```
+
+Expected: PR (the existing `feat/event-driven-notifications` PR or a new branch — match the working branch) updated.
+
+- [ ] **Step 3: Verify CI passes**
+
+```bash
+gh pr checks --watch --interval 30 --fail-fast
+```
+
+Expected: all checks green.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Decision 1 (two-repo change) → Phase 1 + Phase 2 ✔
+- Decision 2 (cherry-pick) → Task 10 ✔
+- Decision 3 (mirror webhook pattern) → Task 8 mirrors `WithHTTPHeaders` exactly ✔
+- Decision 4 (all 4 producers) → Tasks 2-5 cover details, reviews, ratings, ingestion ✔
+- Decision 5 (DCO + no Claude trailer on fork) → Phase 2 constraints + Tasks 8 Step 6, 9 Step 7 ✔
+- Producer-side component (`pkg/telemetry/kafka.go`) → Task 1 ✔
+- Per-service producer change (one-line addition) → Tasks 2, 3, 4, 5 ✔
+- Argo-events fork component (`WithKafkaHeaders` option + Kafka dispatch wiring) → Tasks 8 + 9 ✔
+- Image release flow → Task 10 ✔
+- Constraints on fork branch (preserve 12 commits, no force-push, sign-off, no Claude trailer) → Phase 2 header + Task 7 Step 2 baseline + Task 9 Step 6 verification ✔
+- Data flow target state → Tasks 12, 13 verify ✔
+- Error handling cases (no active span, malformed traceparent, panic, producer fails) → covered by `propagation.Inject`'s no-op semantics + existing argo-events recovery; tested in Task 1 (no-active-span case) ✔
+- Producer unit test for traceparent presence → Tasks 1, 2, 3, 4, 5 ✔
+- Fork unit test → Task 8 ✔
+- E2E validation → Tasks 12, 13 ✔
+- All 7 acceptance criteria → covered across Tasks 1-13 ✔
+
+**Placeholder scan:** no "TBD", "TODO", "implement later", "similar to". The two cherry-pick SHAs in Task 10 Step 3 are correctly marked as placeholders that the executor reads from Task 10 Step 1 (concrete commands). The image-tag reference in Task 11 Step 2 reflects an actual file lookup, not an unfilled value.
+
+**Type consistency:** `InjectTraceContext(ctx context.Context, record *kgo.Record)` is the same signature in Task 1 (definition), Task 2-5 (call sites), and Task 12 (assertions). `WithKafkaHeaders(headers map[string]string) Option` matches in Task 8 (definition) and Task 9 (call sites). `kafkaHeaderCarrier` is internal to `pkg/telemetry` and not referenced elsewhere — no inconsistency.

--- a/docs/superpowers/plans/2026-04-25-kafka-eventsource-consume-span.md
+++ b/docs/superpowers/plans/2026-04-25-kafka-eventsource-consume-span.md
@@ -1,0 +1,808 @@
+# Kafka EventSource Consume Span Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Insert a `eventsource.consume` CONSUMER span between the upstream producer span and the existing `eventsource.publish` PRODUCER span on the Argo Events Kafka EventSource side only. After this change, Tempo shows the kafka source's read-from-topic operation as a distinct span ahead of the publish-to-eventbus span.
+
+**Architecture:** Single-file edit to `pkg/eventsources/sources/kafka/start.go` in the argo-events fork. Both `processOne` closures (consumerGroupConsumer and partitionConsumer) extract upstream traceparent from `msg.Headers`, start a CONSUMER span, then re-inject the consume span's traceparent back into the headers map. The existing `WithKafkaHeaders` + `SpanFromCloudEvent` chain in `eventing.go` then makes the `eventsource.publish` PRODUCER span a child of the new CONSUMER. No edits to shared code; webhook and other source types untouched.
+
+**Tech Stack:** Go 1.22, sarama (kafka client), `go.opentelemetry.io/otel`, argo-events fork's `tracing` package.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-25-kafka-eventsource-consume-span-design.md`
+
+**Repo:** `/Users/kaio.fellipe/Documents/git/others/argo-events` (NOT the bookinfo repo)
+**Branch:** `feat/cloudevents-compliance-otel-tracing` (PR 3961)
+**Remote:** `fork` = `git@github.com:kaio6fellipe/argo-events.git`
+
+---
+
+## File Structure
+
+Single file modified in argo-events fork. No new files. No test file edits (unit-test mocking sarama messages is heavyweight; cluster Tempo verification is the acceptance gate).
+
+```text
+pkg/eventsources/sources/kafka/start.go    # +consume span in both processOne closures
+```
+
+After this plan completes, the bookinfo cluster also gets a smoke verification (no source code change there) — the cluster pod restart and Tempo inspection are part of acceptance.
+
+---
+
+## Hard Constraints (apply to every commit in this plan)
+
+These come from the design spec; failure to follow them means the work is rejected:
+
+1. **Append-only on `feat/cloudevents-compliance-otel-tracing`.** The branch currently has 21 commits ahead of master. The new commit is the 22nd. The previous 21 commits MUST remain bit-identical after the push (verify with diff against a baseline snapshot).
+2. **Sign-off every commit** via `git commit -s`. DCO required by argoproj/argo-events upstream.
+3. **NO `Co-Authored-By: Claude ... <noreply@anthropic.com>` trailer.** NO `Co-Authored-By` of any kind on argo-events fork commits. (The bookinfo-side spec/plan commits in `event-driven-bookinfo` repo can keep the Claude trailer; this constraint applies to argo-events ONLY.)
+4. **Fast-forward push only.** No `--force` / `--force-with-lease`.
+5. **No edits to `eventing.go`** or other shared code. The Kafka source is the only file that changes.
+
+---
+
+## Task 1: Snapshot baseline + switch branch
+
+**Files:** none modified
+
+- [ ] **Step 1: Open the argo-events repo and verify clean state**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+git status
+```
+
+Expected: clean working tree.
+
+- [ ] **Step 2: Switch to the PR-3961 branch and sync**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+git checkout feat/cloudevents-compliance-otel-tracing
+git fetch fork feat/cloudevents-compliance-otel-tracing
+git status
+[ "$(git rev-parse HEAD)" = "$(git rev-parse fork/feat/cloudevents-compliance-otel-tracing)" ] && echo "LOCAL EQ FORK" || echo "DIVERGED"
+```
+
+Expected: `LOCAL EQ FORK`. If `DIVERGED`, run `git pull --ff-only fork feat/cloudevents-compliance-otel-tracing` and re-check.
+
+- [ ] **Step 3: Snapshot the existing 21 commits to a baseline file**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+git log --oneline master..feat/cloudevents-compliance-otel-tracing > /tmp/argo-events-pr3961-baseline-r2.txt
+wc -l /tmp/argo-events-pr3961-baseline-r2.txt
+```
+
+Expected: `21 /tmp/...`. The top line is `9d2ed451 feat(eventsource/kafka): propagate W3C trace context from record headers` (the prior PR-3961 round's last commit).
+
+- [ ] **Step 4: Verify `tracing.StartConsumerSpan` helper is present**
+
+```bash
+grep -n "func StartConsumerSpan" pkg/shared/tracing/tracing.go
+```
+
+Expected: a single line near `:140` showing `func StartConsumerSpan(ctx context.Context, tracer trace.Tracer, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span)`.
+
+If absent, abort — the spec assumes this helper exists. (It was added by an earlier PR-3961 commit.)
+
+- [ ] **Step 5: Verify imports already present in `start.go`**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+grep -E "go.opentelemetry.io/otel|/eventsourcecommon|/shared/tracing" pkg/eventsources/sources/kafka/start.go | head -10
+```
+
+Expected: shows imports for `go.opentelemetry.io/otel`, `go.opentelemetry.io/otel/attribute`, `go.opentelemetry.io/otel/propagation`, `eventsourcecommon`, and `tracing`. If `go.opentelemetry.io/otel/codes` is missing, Task 2 will add it.
+
+---
+
+## Task 2: Add consume span in `consumerGroupConsumer.processOne`
+
+**Files:**
+- Modify: `/Users/kaio.fellipe/Documents/git/others/argo-events/pkg/eventsources/sources/kafka/start.go`
+
+This task edits the FIRST `processOne` closure (around line 263). Task 3 edits the second (partitionConsumer, around line 449) with the same pattern.
+
+- [ ] **Step 1: Locate the first dispatch site and surrounding code**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+grep -n "dispatch(eventBody" pkg/eventsources/sources/kafka/start.go
+```
+
+Expected: two lines, first around 291 (consumerGroupConsumer) and second around 482 (partitionConsumer). Note both line numbers; use the first one for this task.
+
+- [ ] **Step 2: Read the consumerGroupConsumer block from headers map to dispatch**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+sed -n '260,295p' pkg/eventsources/sources/kafka/start.go
+```
+
+Expected: shows the `headers := make(map[string]string)` block, the for-loop populating it from `msg.Headers`, the `eventData.Headers = headers` assignment, the json marshal, and the `dispatch(eventBody, eventsourcecommon.WithID(kafkaID), eventsourcecommon.WithKafkaHeaders(headers))` call.
+
+- [ ] **Step 3: Add `codes` import if missing**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+grep -n "go.opentelemetry.io/otel/codes" pkg/eventsources/sources/kafka/start.go
+```
+
+If the grep returns nothing, edit the imports block to add (alongside the other otel imports):
+
+```go
+"go.opentelemetry.io/otel/codes"
+```
+
+If the grep returns a line, skip this step.
+
+- [ ] **Step 4: Replace the dispatch block in consumerGroupConsumer**
+
+In the first `processOne` closure inside `consumerGroupConsumer`, replace this exact block:
+
+```go
+		headers := make(map[string]string)
+
+		for _, recordHeader := range msg.Headers {
+			headers[string(recordHeader.Key)] = string(recordHeader.Value)
+		}
+
+		eventData.Headers = headers
+
+		if kafkaEventSource.JSONBody {
+			if el.SchemaRegistry != nil {
+				value, err := toJson(el.SchemaRegistry, msg)
+				if err != nil {
+					return fmt.Errorf("failed to retrieve json value using the schema registry, %w", err)
+				}
+				eventData.Body = (*json.RawMessage)(&value)
+			} else {
+				eventData.Body = (*json.RawMessage)(&msg.Value)
+			}
+		} else {
+			eventData.Body = msg.Value
+		}
+		eventBody, err := json.Marshal(eventData)
+		if err != nil {
+			return fmt.Errorf("failed to marshal the event data, rejecting the event, %w", err)
+		}
+
+		kafkaID := genUniqueID(el.GetEventSourceName(), el.GetEventName(), kafkaEventSource.URL, msg.Topic, msg.Partition, msg.Offset)
+
+		if err = dispatch(eventBody, eventsourcecommon.WithID(kafkaID), eventsourcecommon.WithKafkaHeaders(headers)); err != nil {
+			return fmt.Errorf("failed to dispatch a Kafka event, %w", err)
+		}
+```
+
+with:
+
+```go
+		headers := make(map[string]string)
+
+		for _, recordHeader := range msg.Headers {
+			headers[string(recordHeader.Key)] = string(recordHeader.Value)
+		}
+
+		// Extract upstream W3C trace context from the Kafka record headers
+		parentCtx := otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier(headers))
+
+		// Start an eventsource.consume CONSUMER span as the parent for the
+		// downstream eventsource.publish PRODUCER span emitted in eventing.go.
+		spanCtx, consumeSpan := tracing.StartConsumerSpan(parentCtx, otel.Tracer("argo-events-eventsource"), "eventsource.consume",
+			attribute.String("eventsource.name", el.GetEventSourceName()),
+			attribute.String("eventsource.type", "kafka"),
+			attribute.String("messaging.system", "kafka"),
+			attribute.String("messaging.destination.name", msg.Topic),
+			attribute.String("messaging.operation.type", "receive"),
+			attribute.String("messaging.kafka.message.key", string(msg.Key)),
+			attribute.Int("messaging.kafka.message.partition", int(msg.Partition)),
+			attribute.Int64("messaging.kafka.message.offset", msg.Offset),
+		)
+		defer consumeSpan.End()
+
+		// Re-inject the CONSUMER span's trace context into the headers map so
+		// WithKafkaHeaders writes the CONSUMER traceparent as the CloudEvent
+		// extension. eventing.go's SpanFromCloudEvent then makes the
+		// eventsource.publish PRODUCER span a child of CONSUMER.
+		otel.GetTextMapPropagator().Inject(spanCtx, propagation.MapCarrier(headers))
+
+		eventData.Headers = headers
+
+		if kafkaEventSource.JSONBody {
+			if el.SchemaRegistry != nil {
+				value, err := toJson(el.SchemaRegistry, msg)
+				if err != nil {
+					return fmt.Errorf("failed to retrieve json value using the schema registry, %w", err)
+				}
+				eventData.Body = (*json.RawMessage)(&value)
+			} else {
+				eventData.Body = (*json.RawMessage)(&msg.Value)
+			}
+		} else {
+			eventData.Body = msg.Value
+		}
+		eventBody, err := json.Marshal(eventData)
+		if err != nil {
+			return fmt.Errorf("failed to marshal the event data, rejecting the event, %w", err)
+		}
+
+		kafkaID := genUniqueID(el.GetEventSourceName(), el.GetEventName(), kafkaEventSource.URL, msg.Topic, msg.Partition, msg.Offset)
+
+		if err = dispatch(eventBody, eventsourcecommon.WithID(kafkaID), eventsourcecommon.WithKafkaHeaders(headers)); err != nil {
+			consumeSpan.RecordError(err)
+			consumeSpan.SetStatus(codes.Error, err.Error())
+			return fmt.Errorf("failed to dispatch a Kafka event, %w", err)
+		}
+```
+
+The diff inserts:
+1. Extract upstream traceparent
+2. Start CONSUMER span (with `defer span.End()`)
+3. Re-inject CONSUMER traceparent
+4. Add `RecordError`/`SetStatus` on dispatch error
+
+`eventData.Headers = headers` MOVES from before-inject to after-inject so the dispatched event body carries the CONSUMER's traceparent.
+
+- [ ] **Step 5: Build to confirm compile**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+GOFLAGS=-mod=mod go build ./pkg/eventsources/sources/kafka/...
+```
+
+Expected: no output, exit 0. If build fails, fix imports/syntax before continuing.
+
+- [ ] **Step 6: Run gofmt + vet**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+gofmt -w pkg/eventsources/sources/kafka/start.go
+GOFLAGS=-mod=mod go vet ./pkg/eventsources/sources/kafka/...
+```
+
+Expected: no formatter changes (or trivial whitespace), no vet errors.
+
+- [ ] **Step 7: Verify second dispatch site is still present and untouched**
+
+```bash
+grep -n "dispatch(eventBody" pkg/eventsources/sources/kafka/start.go
+```
+
+Expected: TWO matches. The first (in consumerGroupConsumer) now has the CONSUMER wrap; the second (in partitionConsumer) is still the bare form. Task 3 will update the second.
+
+> NOTE: do NOT commit yet — Task 3 edits the same file. One commit covers both edits.
+
+---
+
+## Task 3: Add consume span in `partitionConsumer.processOne`
+
+**Files:**
+- Modify: `/Users/kaio.fellipe/Documents/git/others/argo-events/pkg/eventsources/sources/kafka/start.go`
+
+This is the second dispatch site, around line 482 (post-Task-2 line numbers may shift slightly). Same edit as Task 2.
+
+- [ ] **Step 1: Locate the second dispatch site**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+grep -n "dispatch(eventBody" pkg/eventsources/sources/kafka/start.go
+```
+
+Expected: two matches; the second is the one to update.
+
+- [ ] **Step 2: Read the partitionConsumer block from headers map to dispatch**
+
+Look at the `partitionConsumer` function (`func (el *EventListener) partitionConsumer(...)`). The structure of its `processOne` closure mirrors consumerGroupConsumer's:
+
+```go
+		headers := make(map[string]string)
+
+		for _, recordHeader := range message.Headers {
+			headers[string(recordHeader.Key)] = string(recordHeader.Value)
+		}
+
+		eventData.Headers = headers
+
+		if kafkaEventSource.JSONBody {
+			if el.SchemaRegistry != nil {
+				value, err := toJson(el.SchemaRegistry, message)
+				if err != nil {
+					return fmt.Errorf("failed to retrieve json value using the schema registry, %w", err)
+				}
+				eventData.Body = (*json.RawMessage)(&value)
+			} else {
+				eventData.Body = (*json.RawMessage)(&message.Value)
+			}
+		} else {
+			eventData.Body = message.Value
+		}
+		eventBody, err := json.Marshal(eventData)
+		if err != nil {
+			return fmt.Errorf("failed to marshal the event data, rejecting the event, %w", err)
+		}
+
+		kafkaID := genUniqueID(el.GetEventSourceName(), el.GetEventName(), kafkaEventSource.URL, message.Topic, message.Partition, message.Offset)
+
+		if err = dispatch(eventBody, eventsourcecommon.WithID(kafkaID), eventsourcecommon.WithKafkaHeaders(headers)); err != nil {
+			return fmt.Errorf("failed to dispatch a Kafka event, %w", err)
+		}
+```
+
+> NOTE: variable name is `message` here (vs `msg` in consumerGroupConsumer). Use `message` consistently in the new code.
+
+- [ ] **Step 3: Replace the partitionConsumer block**
+
+Replace it with:
+
+```go
+		headers := make(map[string]string)
+
+		for _, recordHeader := range message.Headers {
+			headers[string(recordHeader.Key)] = string(recordHeader.Value)
+		}
+
+		// Extract upstream W3C trace context from the Kafka record headers
+		parentCtx := otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier(headers))
+
+		// Start an eventsource.consume CONSUMER span as the parent for the
+		// downstream eventsource.publish PRODUCER span emitted in eventing.go.
+		spanCtx, consumeSpan := tracing.StartConsumerSpan(parentCtx, otel.Tracer("argo-events-eventsource"), "eventsource.consume",
+			attribute.String("eventsource.name", el.GetEventSourceName()),
+			attribute.String("eventsource.type", "kafka"),
+			attribute.String("messaging.system", "kafka"),
+			attribute.String("messaging.destination.name", message.Topic),
+			attribute.String("messaging.operation.type", "receive"),
+			attribute.String("messaging.kafka.message.key", string(message.Key)),
+			attribute.Int("messaging.kafka.message.partition", int(message.Partition)),
+			attribute.Int64("messaging.kafka.message.offset", message.Offset),
+		)
+		defer consumeSpan.End()
+
+		// Re-inject the CONSUMER span's trace context into the headers map so
+		// WithKafkaHeaders writes the CONSUMER traceparent as the CloudEvent
+		// extension. eventing.go's SpanFromCloudEvent then makes the
+		// eventsource.publish PRODUCER span a child of CONSUMER.
+		otel.GetTextMapPropagator().Inject(spanCtx, propagation.MapCarrier(headers))
+
+		eventData.Headers = headers
+
+		if kafkaEventSource.JSONBody {
+			if el.SchemaRegistry != nil {
+				value, err := toJson(el.SchemaRegistry, message)
+				if err != nil {
+					return fmt.Errorf("failed to retrieve json value using the schema registry, %w", err)
+				}
+				eventData.Body = (*json.RawMessage)(&value)
+			} else {
+				eventData.Body = (*json.RawMessage)(&message.Value)
+			}
+		} else {
+			eventData.Body = message.Value
+		}
+		eventBody, err := json.Marshal(eventData)
+		if err != nil {
+			return fmt.Errorf("failed to marshal the event data, rejecting the event, %w", err)
+		}
+
+		kafkaID := genUniqueID(el.GetEventSourceName(), el.GetEventName(), kafkaEventSource.URL, message.Topic, message.Partition, message.Offset)
+
+		if err = dispatch(eventBody, eventsourcecommon.WithID(kafkaID), eventsourcecommon.WithKafkaHeaders(headers)); err != nil {
+			consumeSpan.RecordError(err)
+			consumeSpan.SetStatus(codes.Error, err.Error())
+			return fmt.Errorf("failed to dispatch a Kafka event, %w", err)
+		}
+```
+
+> NOTE: identical pattern to Task 2, only with `message.*` instead of `msg.*`. The function-local variable `ctx` may not exist at this scope in `partitionConsumer.processOne` — verify by inspecting the enclosing function signature. The closure captures whatever ctx is in scope; both processOne closures should have access to a `ctx`. If `ctx` is unavailable, use `context.Background()` and report DONE_WITH_CONCERNS so the controller can fix.
+
+- [ ] **Step 4: Build, vet, gofmt**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+gofmt -w pkg/eventsources/sources/kafka/start.go
+GOFLAGS=-mod=mod go build ./pkg/eventsources/sources/kafka/...
+GOFLAGS=-mod=mod go vet ./pkg/eventsources/sources/kafka/...
+```
+
+Expected: clean. If build fails on `ctx` not being in scope at the partitionConsumer site, see the NOTE in Step 3.
+
+- [ ] **Step 5: Verify both dispatch sites updated**
+
+```bash
+grep -B2 "consumeSpan.End" pkg/eventsources/sources/kafka/start.go | head -20
+```
+
+Expected: TWO `defer consumeSpan.End()` lines visible (one per processOne closure).
+
+- [ ] **Step 6: Verify the existing 21 commits are still present and unchanged**
+
+```bash
+diff <(git log --oneline master..HEAD) /tmp/argo-events-pr3961-baseline-r2.txt && echo "BASELINE INTACT"
+```
+
+Expected: `BASELINE INTACT` (no `+`/`-` lines). The working tree has uncommitted edits — those don't appear in the log.
+
+- [ ] **Step 7: Stage and commit (signed off, no Claude trailer)**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+git add pkg/eventsources/sources/kafka/start.go
+git commit -s -m "feat(eventsource/kafka): add eventsource.consume CONSUMER span before dispatch
+
+Inserts an eventsource.consume CONSUMER span in both processOne
+closures (consumerGroupConsumer and partitionConsumer). The span is
+parented to the upstream traceparent extracted from msg.Headers, then
+its own traceparent is re-injected into the headers map so
+WithKafkaHeaders + SpanFromCloudEvent in eventing.go make the existing
+eventsource.publish PRODUCER span a child of CONSUMER (instead of
+directly under upstream).
+
+Span carries OTel messaging semconv attributes: messaging.system=kafka,
+destination.name=<topic>, operation.type=receive, kafka.message.key,
+kafka.message.partition, kafka.message.offset. Errors from dispatch
+are recorded on the CONSUMER span via RecordError + SetStatus.
+
+Webhook and other source types are not affected — only the kafka
+source's processOne closures get the new span."
+```
+
+- [ ] **Step 8: Verify commit trailer**
+
+```bash
+git log -1 --format=%B
+```
+
+Expected output ENDS with exactly:
+
+```
+Signed-off-by: <Name> <email>
+```
+
+NO `Co-Authored-By` anywhere in the output. If `Co-Authored-By` is present, run `git reset HEAD~1`, recommit without that trailer.
+
+- [ ] **Step 9: Verify branch state**
+
+```bash
+git log --oneline master..HEAD | wc -l
+```
+
+Expected: `22`.
+
+```bash
+diff <(git log --oneline master..HEAD | tail -21) /tmp/argo-events-pr3961-baseline-r2.txt && echo "BASELINE INTACT (top 21 unchanged, new commit on top)"
+```
+
+Expected: `BASELINE INTACT (top 21 unchanged, new commit on top)`.
+
+- [ ] **Step 10: Push to fork (fast-forward only)**
+
+```bash
+git push fork feat/cloudevents-compliance-otel-tracing
+```
+
+Expected: fast-forward push. PR 3961 picks up the new commit.
+
+If rejected with "non-fast-forward", STOP — do not force. Investigate (likely someone else pushed) and report.
+
+---
+
+## Task 4: Cherry-pick onto `feat/combined-prs-3961-3983`
+
+**Files:** none modified directly; cherry-picks the Task-3 commit
+
+- [ ] **Step 1: Capture the new commit SHA**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+NEW_SHA=$(git rev-parse HEAD)
+echo "New commit SHA: $NEW_SHA"
+git log --format='%s' -1 HEAD
+```
+
+Expected: SHA of the Task-3 commit; subject `feat(eventsource/kafka): add eventsource.consume CONSUMER span before dispatch`.
+
+- [ ] **Step 2: Switch to the consumed branch and sync**
+
+```bash
+git checkout feat/combined-prs-3961-3983
+git fetch fork feat/combined-prs-3961-3983
+git pull --ff-only fork feat/combined-prs-3961-3983
+```
+
+Expected: `Already up to date` or fast-forward.
+
+- [ ] **Step 3: Cherry-pick with sign-off**
+
+```bash
+git cherry-pick -s "$NEW_SHA"
+```
+
+Expected: clean cherry-pick. Conflict is unlikely — combined branch's only divergence from `feat/cloudevents-compliance-otel-tracing` is the kafka-latency commits and the codegen merge, none of which touch `pkg/eventsources/sources/kafka/start.go` in the same lines.
+
+If a conflict arises, STOP and report. Do not force.
+
+- [ ] **Step 4: Build to confirm**
+
+```bash
+GOFLAGS=-mod=mod go build ./pkg/eventsources/sources/kafka/...
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Verify cherry-picked commit is on top**
+
+```bash
+git log --oneline -2
+```
+
+Expected: top line is the cherry-picked commit on this branch (different SHA from `feat/cloudevents-compliance-otel-tracing` because cherry-pick rewrites SHAs); subject matches.
+
+- [ ] **Step 6: Verify trailer on the cherry-picked commit**
+
+```bash
+git log -1 --format=%B
+```
+
+Expected: ends with `Signed-off-by: ...`. NO `Co-Authored-By`.
+
+- [ ] **Step 7: Push to fork**
+
+```bash
+git push fork feat/combined-prs-3961-3983
+```
+
+Expected: fast-forward push.
+
+---
+
+## Task 5: Build + push image to ghcr.io
+
+- [ ] **Step 1: Confirm on combined branch**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+git branch --show-current
+git log --oneline -1
+```
+
+Expected: branch `feat/combined-prs-3961-3983`; HEAD is the cherry-picked commit from Task 4.
+
+- [ ] **Step 2: Purge stale dist artifacts**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+rm -f dist/argo-events-linux-*
+ls dist/
+```
+
+Expected: only `kubefied.swagger.json` and `kubernetes.swagger.json` remain (or similar non-binary files); no `argo-events-linux-*` files.
+
+> WHY this matters: Make sees the existing `.gz` files and skips rebuild, packaging stale binaries. Last round this caused the image to ship the old code.
+
+- [ ] **Step 3: Verify ghcr.io login**
+
+```bash
+cat ~/.docker/config.json | python3 -c 'import json,sys; print("ghcr.io" in json.load(sys.stdin).get("auths", {}))'
+```
+
+Expected: `True`. If `False`, run `docker login ghcr.io -u kaio6fellipe` first (interactive — abort plan execution and ask the user).
+
+- [ ] **Step 4: Build and push the multi-arch image**
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+GOFLAGS=-mod=mod IMAGE_NAMESPACE=ghcr.io/kaio6fellipe DOCKER_PUSH=true VERSION=prs-3961-3983 make image-multi 2>&1 | tee /tmp/argo-events-image-build-r2.log
+```
+
+Expected: exit 0. Log ends with the buildx push step. Takes 5-10 min on arm64 Mac.
+
+If the build hits the `inconsistent vendoring` error, the `GOFLAGS=-mod=mod` flag should bypass it. If it still fails, investigate the error message and STOP.
+
+- [ ] **Step 5: Verify the manifest digest changed**
+
+```bash
+docker buildx imagetools inspect ghcr.io/kaio6fellipe/argo-events:prs-3961-3983 2>&1 | head -10
+```
+
+Expected: a `Digest:` line. Note the digest. Compare against the prior round's `4ae7d54320c22b5f56f2b24886ed6c190903d65f1b9631366d678791e3b8fa38` — it MUST be different.
+
+- [ ] **Step 6: Verify the embedded gitCommit matches**
+
+```bash
+docker pull --quiet ghcr.io/kaio6fellipe/argo-events:prs-3961-3983
+docker create --name ae-inspect-r2 ghcr.io/kaio6fellipe/argo-events:prs-3961-3983
+docker cp ae-inspect-r2:/bin/argo-events /tmp/argo-events-binary-r2
+docker rm ae-inspect-r2
+echo "=== gitCommit ==="
+strings /tmp/argo-events-binary-r2 | grep -oE "gitCommit=[a-f0-9]{40}" | head -1
+echo "=== buildDate ==="
+strings /tmp/argo-events-binary-r2 | grep -oE "buildDate=[0-9TZ:-]+" | head -1
+echo "=== expected gitCommit (combined branch HEAD) ==="
+cd /Users/kaio.fellipe/Documents/git/others/argo-events && git rev-parse HEAD
+```
+
+Expected: gitCommit matches the combined-branch HEAD. buildDate is today's UTC.
+
+If gitCommit DOESN'T match, the build packaged a stale binary. Re-purge dist/ and rebuild.
+
+---
+
+## Task 6: Pull new image into k3d cluster
+
+- [ ] **Step 1: Confirm bookinfo cluster up**
+
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo get pods --no-headers | awk '{print $3}' | sort | uniq -c
+```
+
+Expected: only `Running`. If pods are missing, ask user — cluster may have been torn down.
+
+- [ ] **Step 2: Import the new image into k3d**
+
+```bash
+k3d image import ghcr.io/kaio6fellipe/argo-events:prs-3961-3983 -c bookinfo-local
+```
+
+Expected: `Successfully imported image(s)`.
+
+- [ ] **Step 3: Restart EventSource and Sensor pods to pick up the new image**
+
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo delete pod -l eventsource-name
+kubectl --context=k3d-bookinfo-local -n bookinfo delete pod -l sensor-name
+sleep 12
+kubectl --context=k3d-bookinfo-local -n bookinfo get pods -l eventsource-name --no-headers | head
+```
+
+Expected: pods restarted, all `1/1 Running`.
+
+- [ ] **Step 4: Verify a pod is on the expected new digest**
+
+```bash
+EXPECTED_DIGEST=$(docker buildx imagetools inspect ghcr.io/kaio6fellipe/argo-events:prs-3961-3983 2>&1 | grep "^Digest:" | awk '{print $2}')
+ACTUAL_IMAGE_ID=$(kubectl --context=k3d-bookinfo-local -n bookinfo get pod -l eventsource-name=reviews-events -o jsonpath='{.items[0].status.containerStatuses[0].imageID}')
+echo "Expected digest: $EXPECTED_DIGEST"
+echo "Pod imageID:     $ACTUAL_IMAGE_ID"
+```
+
+Expected: pod's `imageID` ends with the manifest's digest sha256.
+
+If they don't match, the pod is still on the old image — re-run Step 2 (`k3d image import`) and Step 3 (delete pods).
+
+---
+
+## Task 7: Cluster smoke test — capture trace IDs to verify consume span
+
+After this task completes, the user inspects each trace ID in Grafana Tempo at `http://localhost:3000`.
+
+- [ ] **Step 1: book-added**
+
+```bash
+curl -sS -X POST http://localhost:8080/v1/details \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"consume-test-book","author":"a","year":2026,"type":"paperback","pages":1,"isbn_13":"9780000000444"}'
+echo
+sleep 5
+TRACE_BOOK=$(kubectl --context=k3d-bookinfo-local -n bookinfo logs deploy/details-write --since=20s 2>&1 \
+  | grep '"title":"consume-test-book"' \
+  | head -1 \
+  | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["trace_id"])')
+echo "book-added trace_id: $TRACE_BOOK"
+```
+
+Expected: 32-char hex trace_id printed.
+
+- [ ] **Step 2: review-submitted**
+
+```bash
+curl -sS -X POST http://localhost:8080/v1/reviews \
+  -H 'Content-Type: application/json' \
+  -d '{"product_id":"consume-test-prod","reviewer":"u","text":"consume audit"}'
+echo
+sleep 5
+TRACE_REVIEW=$(kubectl --context=k3d-bookinfo-local -n bookinfo logs deploy/reviews-write --since=20s 2>&1 \
+  | grep '"product_id":"consume-test-prod"' \
+  | head -1 \
+  | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["trace_id"])')
+echo "review-submitted trace_id: $TRACE_REVIEW"
+```
+
+- [ ] **Step 3: rating-submitted**
+
+```bash
+curl -sS -X POST http://localhost:8080/v1/ratings \
+  -H 'Content-Type: application/json' \
+  -d '{"product_id":"consume-test-rating","reviewer":"u","stars":4}'
+echo
+sleep 5
+TRACE_RATING=$(kubectl --context=k3d-bookinfo-local -n bookinfo logs deploy/ratings-write --since=20s 2>&1 \
+  | grep '"product_id":"consume-test-rating"' \
+  | head -1 \
+  | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["trace_id"])')
+echo "rating-submitted trace_id: $TRACE_RATING"
+```
+
+- [ ] **Step 4: review-deleted**
+
+Insert a fresh review then delete it (so no log-line confusion with prior review-submitted entries):
+
+```bash
+curl -sS -X POST http://localhost:8080/v1/reviews \
+  -H 'Content-Type: application/json' \
+  -d '{"product_id":"consume-test-prod-del","reviewer":"u","text":"to delete"}'
+echo
+sleep 4
+DEL_RID=$(kubectl --context=k3d-bookinfo-local -n bookinfo exec statefulset/reviews-postgresql -- \
+  bash -c "PGPASSWORD=bookinfo psql -U bookinfo -d bookinfo_reviews -t -c \"SELECT id FROM reviews WHERE product_id='consume-test-prod-del' LIMIT 1;\"" 2>&1 | xargs)
+echo "Deleting review_id: $DEL_RID"
+
+curl -sS -X POST http://localhost:8080/v1/reviews/delete \
+  -H 'Content-Type: application/json' \
+  -d "{\"review_id\":\"$DEL_RID\"}"
+echo
+sleep 5
+TRACE_DELETE=$(kubectl --context=k3d-bookinfo-local -n bookinfo logs deploy/reviews-write --since=20s 2>&1 \
+  | grep '"path":"/v1/reviews/delete"' \
+  | grep '"msg":"review deleted"' \
+  | head -1 \
+  | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["trace_id"])')
+echo "review-deleted trace_id: $TRACE_DELETE"
+```
+
+- [ ] **Step 5: Print summary table**
+
+```bash
+echo "=================================================="
+echo "Trace IDs to inspect at http://localhost:3000 (Grafana → Explore → Tempo):"
+echo "=================================================="
+echo "book-added        : $TRACE_BOOK"
+echo "review-submitted  : $TRACE_REVIEW"
+echo "rating-submitted  : $TRACE_RATING"
+echo "review-deleted    : $TRACE_DELETE"
+echo
+echo "Expected span tree per trace:"
+echo "  <service>-write-api POST /v1/<resource>      [SERVER]"
+echo "  ├── pool.acquire / INSERT / etc              [INTERNAL via otelpgx]"
+echo "  └── bookinfo_<service>_events publish        [PRODUCER]"
+echo "      └── eventsource.consume                  [CONSUMER]  ← NEW"
+echo "          └── eventsource.publish              [PRODUCER]"
+echo "              └── eventbus consume             [CONSUMER]"
+echo "                  └── trigger HTTP             [CLIENT]"
+echo "                      └── notification-api     [SERVER]"
+```
+
+The user opens each trace_id in Tempo and confirms the new `eventsource.consume` span sits between `bookinfo_<service>_events publish` and `eventsource.publish`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Decision 1 (span name `eventsource.consume`) → Tasks 2, 3 use exactly this name ✔
+- Decision 2 (SpanKindConsumer via `tracing.StartConsumerSpan`) → Tasks 2, 3 ✔
+- Decision 3 (Kafka source only) → Tasks 2, 3 modify only `pkg/eventsources/sources/kafka/start.go`; no other source touched ✔
+- Decision 4 (re-inject CONSUMER traceparent into headers map) → Tasks 2, 3 include the inject step before `eventData.Headers = headers` ✔
+- Decision 5 (append-only on PR 3961) → Task 1 baseline snapshot + Task 3 verification ✔
+- Decision 6 (cherry-pick to combined branch + image build) → Tasks 4, 5 ✔
+- Decision 7 (sign-off `-s`, no Claude trailer) → Task 3 Step 7 commit + Step 8 verification; Task 4 Step 3 cherry-pick `-s` + Step 6 verification ✔
+- Component: file modified (`pkg/eventsources/sources/kafka/start.go`) → Tasks 2, 3 ✔
+- Component: replacement pattern with all 8 attributes → Tasks 2, 3 list each `attribute.String` line ✔
+- Component: imports needed (`codes`) → Task 2 Step 3 conditional ✔
+- Component: branch-state preservation → Task 1 snapshot + Task 3 verification ✔
+- Component: image build (purge dist/, GOFLAGS=-mod=mod, build-multi) → Task 5 ✔
+- Data flow: target span tree → Task 7 Step 5 prints expected tree ✔
+- Error handling: dispatch error records on CONSUMER span → Tasks 2 Step 4 + 3 Step 3 include `RecordError`+`SetStatus` ✔
+- Testing: build verification → Tasks 2 Step 5, 3 Step 4, 4 Step 4, 5 Step 4 ✔
+- Testing: cluster smoke for all 4 event types → Task 7 Steps 1-4 ✔
+- Acceptance criteria 1-6 → Task 1 (baseline), Task 3 (commit + sign-off + verify), Task 4 (cherry-pick), Task 5 (image gitCommit match), Task 6 (pod imageID match), Task 7 (Tempo verification) ✔
+
+**Placeholder scan:** no "TBD", "TODO", "implement later", "similar to". The `ctx` availability check in Task 3 Step 3 is a defensive note with concrete instructions ("verify by inspecting … if unavailable, use `context.Background()` and report DONE_WITH_CONCERNS"), not an unfilled placeholder.
+
+**Type consistency:**
+
+- `tracing.StartConsumerSpan(ctx, tracer, name, attrs...)` is the same signature in Task 2 (call) and Task 3 (call). Helper definition lives in `pkg/shared/tracing/tracing.go:140` (verified in Task 1 Step 4).
+- `attribute.String/Int/Int64` calls match across both tasks for all 8 attributes.
+- `consumeSpan.End()`, `consumeSpan.RecordError(err)`, `consumeSpan.SetStatus(codes.Error, err.Error())` consistent across Tasks 2 and 3.
+- Variable names: `msg` vs `message` is correctly distinguished (consumerGroupConsumer uses `msg`, partitionConsumer uses `message`); each task's code uses the right one.
+- `ghcr.io/kaio6fellipe/argo-events:prs-3961-3983` is the same image reference across Tasks 5, 6, and 7 verification commands.

--- a/docs/superpowers/plans/2026-04-25-kafka-producer-span.md
+++ b/docs/superpowers/plans/2026-04-25-kafka-producer-span.md
@@ -1,0 +1,692 @@
+# Kafka Producer Span Instrumentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wrap each Kafka `ProduceSync` call in a child OTel span (SpanKindProducer, OTel messaging semconv attributes) so Tempo shows the publish operation as a peer of the DB spans under the API server span.
+
+**Architecture:** Single helper `telemetry.StartProducerSpan(ctx, topic, key)` added to existing `pkg/telemetry/kafka.go`. Each producer (details, reviews, ratings, ingestion) wraps its `ProduceSync` call in a 4-line block: start span (defer end) → InjectTraceContext (already there) → produce → record error on failure. No new module deps; raw OTel attribute strings.
+
+**Tech Stack:** Go 1.22, `go.opentelemetry.io/otel` (already pulled at v1.43.0), `github.com/twmb/franz-go/pkg/kgo`.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-25-kafka-producer-span-design.md`
+
+---
+
+## File Structure
+
+Existing files modified — no new files.
+
+```text
+pkg/telemetry/kafka.go              # +helper StartProducerSpan
+pkg/telemetry/kafka_test.go         # +unit test for helper
+
+services/details/internal/adapter/outbound/kafka/producer.go        # 4-line wrap in PublishBookAdded
+services/reviews/internal/adapter/outbound/kafka/producer.go        # 4-line wrap in produce helper
+services/ratings/internal/adapter/outbound/kafka/producer.go        # 4-line wrap in PublishRatingSubmitted
+services/ingestion/internal/adapter/outbound/kafka/producer.go      # 4-line wrap in PublishBookAdded
+```
+
+Producer test files are NOT modified — the existing `Test...InjectsTraceparent` tests already verify traceparent presence and continue to pass with the wrap in place. Adding extra assertions about parent-span identity is out of scope (covered by the helper unit test plus end-to-end Tempo inspection).
+
+---
+
+## Task 1: Add `StartProducerSpan` helper to `pkg/telemetry/kafka.go`
+
+**Files:**
+
+- Modify: `pkg/telemetry/kafka.go`
+- Modify: `pkg/telemetry/kafka_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `pkg/telemetry/kafka_test.go`. Add to imports (alongside existing imports):
+
+```go
+"go.opentelemetry.io/otel/trace"
+```
+
+Append at the end of the file (preserve existing tests):
+
+```go
+func TestStartProducerSpan_AttachesSpanToContext(t *testing.T) {
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	parentCtx, parent := otel.Tracer("test").Start(context.Background(), "parent")
+	defer parent.End()
+
+	ctx, span := telemetry.StartProducerSpan(parentCtx, "my_topic", "my_key")
+	defer span.End()
+
+	// The returned ctx must carry the new span (not the parent).
+	got := trace.SpanFromContext(ctx)
+	if got.SpanContext().SpanID() == parent.SpanContext().SpanID() {
+		t.Fatalf("ctx still references parent span %q; expected new producer span",
+			parent.SpanContext().SpanID().String())
+	}
+	if !got.SpanContext().IsValid() {
+		t.Fatal("returned ctx has no valid span context")
+	}
+	// Trace ID is inherited from parent.
+	if got.SpanContext().TraceID() != parent.SpanContext().TraceID() {
+		t.Errorf("trace_id = %s, want inherited %s",
+			got.SpanContext().TraceID(), parent.SpanContext().TraceID())
+	}
+}
+
+func TestStartProducerSpan_NoParent_StillReturnsValidSpan(t *testing.T) {
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+
+	ctx, span := telemetry.StartProducerSpan(context.Background(), "my_topic", "my_key")
+	defer span.End()
+
+	if !trace.SpanFromContext(ctx).SpanContext().IsValid() {
+		t.Fatal("expected valid span context even without a parent span")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+go test ./pkg/telemetry/... -run TestStartProducerSpan -v
+```
+
+Expected: compile error `undefined: telemetry.StartProducerSpan`.
+
+- [ ] **Step 3: Implement the helper**
+
+Open `pkg/telemetry/kafka.go`. Append to the imports block (preserve existing imports — `context`, `kgo`, `otel`, `propagation` are already there):
+
+```go
+"go.opentelemetry.io/otel/attribute"
+"go.opentelemetry.io/otel/trace"
+```
+
+Append the helper at the END of the file (after `InjectTraceContext`):
+
+```go
+// StartProducerSpan starts a child span for a Kafka publish operation following
+// OTel messaging semantic conventions. The caller must End() the span (use defer).
+// Span name is "<topic> publish"; SpanKind is Producer.
+func StartProducerSpan(ctx context.Context, topic, key string) (context.Context, trace.Span) {
+	return otel.Tracer("kafka-producer").Start(ctx,
+		topic+" publish",
+		trace.WithSpanKind(trace.SpanKindProducer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "kafka"),
+			attribute.String("messaging.destination.name", topic),
+			attribute.String("messaging.operation.type", "publish"),
+			attribute.String("messaging.kafka.message.key", key),
+		),
+	)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+go test ./pkg/telemetry/... -race -count=1 -v
+```
+
+Expected: all tests PASS, including the two new `TestStartProducerSpan_*` cases plus pre-existing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/telemetry/kafka.go pkg/telemetry/kafka_test.go
+git commit -m "$(cat <<'EOF'
+feat(pkg/telemetry): add StartProducerSpan helper for Kafka publish
+
+Returns a context + trace.Span with SpanKindProducer and OTel messaging
+semconv attributes (messaging.system=kafka, destination.name=<topic>,
+operation.type=publish, kafka.message.key=<key>). Span name follows the
+"<destination> <operation>" convention. Producers wrap their ProduceSync
+call with this helper so Tempo shows the publish op as a child of the
+API server span.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Wrap details producer
+
+**Files:**
+
+- Modify: `services/details/internal/adapter/outbound/kafka/producer.go`
+
+- [ ] **Step 1: Read the current PublishBookAdded function**
+
+Run:
+
+```bash
+grep -n "PublishBookAdded\|ProduceSync\|telemetry.InjectTraceContext\|FirstErr" services/details/internal/adapter/outbound/kafka/producer.go
+```
+
+Note the line numbers for: function signature, `InjectTraceContext` call, `ProduceSync` call, and `FirstErr` error check.
+
+- [ ] **Step 2: Add `codes` import if not present**
+
+Open `services/details/internal/adapter/outbound/kafka/producer.go`. Check if `"go.opentelemetry.io/otel/codes"` is already in the imports block. If not, add it (alongside the existing OTel imports).
+
+- [ ] **Step 3: Wrap the ProduceSync call**
+
+Locate this existing block in `PublishBookAdded`:
+
+```go
+telemetry.InjectTraceContext(ctx, record)
+
+results := p.client.ProduceSync(ctx, record)
+if err := results.FirstErr(); err != nil {
+	return fmt.Errorf("producing to Kafka: %w", err)
+}
+```
+
+Replace it with:
+
+```go
+ctx, span := telemetry.StartProducerSpan(ctx, p.topic, evt.IdempotencyKey)
+defer span.End()
+
+telemetry.InjectTraceContext(ctx, record)
+
+results := p.client.ProduceSync(ctx, record)
+if err := results.FirstErr(); err != nil {
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+	return fmt.Errorf("producing to Kafka: %w", err)
+}
+```
+
+- [ ] **Step 4: Build and run tests**
+
+Run:
+
+```bash
+go test ./services/details/internal/adapter/outbound/kafka/... -race -count=1 -v
+```
+
+Expected: all tests PASS, including pre-existing `TestPublishBookAdded`, `TestPublishBookAdded_ProduceError`, `TestPublishBookAdded_InjectsTraceparent`.
+
+The error-path test (`TestPublishBookAdded_ProduceError`) exercises `span.RecordError` + `SetStatus`; it should still pass — the error is wrapped and returned exactly as before.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/details/internal/adapter/outbound/kafka/producer.go
+git commit -m "$(cat <<'EOF'
+feat(details): wrap Kafka publish in producer span
+
+Calls telemetry.StartProducerSpan before InjectTraceContext + ProduceSync
+so Tempo shows the publish operation as a peer of the DB spans under
+the API server span. Errors recorded on the span via RecordError +
+SetStatus.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Wrap reviews producer
+
+**Files:**
+
+- Modify: `services/reviews/internal/adapter/outbound/kafka/producer.go`
+
+Reviews has TWO publish methods (`PublishReviewSubmitted`, `PublishReviewDeleted`) that delegate to a private `produce(ctx, ceType, key, partitionHint, body)` helper. Wrapping the helper covers both events.
+
+- [ ] **Step 1: Read the current produce helper**
+
+Run:
+
+```bash
+grep -n "func (p \*Producer) produce\|ProduceSync\|telemetry.InjectTraceContext\|FirstErr" services/reviews/internal/adapter/outbound/kafka/producer.go
+```
+
+Note the line numbers for: `produce` function signature, `InjectTraceContext` call, `ProduceSync` call.
+
+- [ ] **Step 2: Add `codes` import if not present**
+
+Open `services/reviews/internal/adapter/outbound/kafka/producer.go`. Add `"go.opentelemetry.io/otel/codes"` to the imports if not already there.
+
+- [ ] **Step 3: Wrap the ProduceSync call inside `produce`**
+
+Locate this existing block in `produce`:
+
+```go
+telemetry.InjectTraceContext(ctx, record)
+
+results := p.client.ProduceSync(ctx, record)
+if err := results.FirstErr(); err != nil {
+	return fmt.Errorf("producing to Kafka: %w", err)
+}
+```
+
+Replace it with:
+
+```go
+ctx, span := telemetry.StartProducerSpan(ctx, p.topic, key)
+defer span.End()
+
+telemetry.InjectTraceContext(ctx, record)
+
+results := p.client.ProduceSync(ctx, record)
+if err := results.FirstErr(); err != nil {
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+	return fmt.Errorf("producing to Kafka: %w", err)
+}
+```
+
+> NOTE: the local variable `key` already exists in `produce` (it's the function's third parameter — the idempotency key). Reuse it as the span's message key attribute. Both publish methods pass their `evt.IdempotencyKey` as this argument.
+
+- [ ] **Step 4: Build and run tests**
+
+Run:
+
+```bash
+go test ./services/reviews/internal/adapter/outbound/kafka/... -race -count=1 -v
+```
+
+Expected: all tests PASS, including pre-existing `TestPublishReviewSubmitted`, `TestPublishReviewDeleted`, `TestPublishReviewSubmitted_InjectsTraceparent`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/reviews/internal/adapter/outbound/kafka/producer.go
+git commit -m "$(cat <<'EOF'
+feat(reviews): wrap Kafka publish in producer span
+
+Wraps the shared produce helper so both PublishReviewSubmitted and
+PublishReviewDeleted emit a SpanKindProducer span under the API server
+span. Errors recorded on the span via RecordError + SetStatus.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Wrap ratings producer
+
+**Files:**
+
+- Modify: `services/ratings/internal/adapter/outbound/kafka/producer.go`
+
+- [ ] **Step 1: Read the current PublishRatingSubmitted function**
+
+Run:
+
+```bash
+grep -n "PublishRatingSubmitted\|ProduceSync\|telemetry.InjectTraceContext\|FirstErr" services/ratings/internal/adapter/outbound/kafka/producer.go
+```
+
+- [ ] **Step 2: Add `codes` import if not present**
+
+Open `services/ratings/internal/adapter/outbound/kafka/producer.go`. Add `"go.opentelemetry.io/otel/codes"` to imports if not present.
+
+- [ ] **Step 3: Wrap the ProduceSync call**
+
+Locate this existing block in `PublishRatingSubmitted`:
+
+```go
+telemetry.InjectTraceContext(ctx, record)
+
+results := p.client.ProduceSync(ctx, record)
+if err := results.FirstErr(); err != nil {
+	return fmt.Errorf("producing to Kafka: %w", err)
+}
+```
+
+Replace it with:
+
+```go
+ctx, span := telemetry.StartProducerSpan(ctx, p.topic, evt.IdempotencyKey)
+defer span.End()
+
+telemetry.InjectTraceContext(ctx, record)
+
+results := p.client.ProduceSync(ctx, record)
+if err := results.FirstErr(); err != nil {
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+	return fmt.Errorf("producing to Kafka: %w", err)
+}
+```
+
+- [ ] **Step 4: Build and run tests**
+
+Run:
+
+```bash
+go test ./services/ratings/internal/adapter/outbound/kafka/... -race -count=1 -v
+```
+
+Expected: all tests PASS, including `TestPublishRatingSubmitted`, `TestPublishRatingSubmitted_InjectsTraceparent`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/ratings/internal/adapter/outbound/kafka/producer.go
+git commit -m "$(cat <<'EOF'
+feat(ratings): wrap Kafka publish in producer span
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Wrap ingestion producer
+
+**Files:**
+
+- Modify: `services/ingestion/internal/adapter/outbound/kafka/producer.go`
+
+Ingestion uses `book.ISBN` as the Kafka record key, not an idempotency key. Pass that as the span's message key attribute.
+
+- [ ] **Step 1: Read the current PublishBookAdded function**
+
+Run:
+
+```bash
+grep -n "PublishBookAdded\|ProduceSync\|telemetry.InjectTraceContext\|FirstErr" services/ingestion/internal/adapter/outbound/kafka/producer.go
+```
+
+- [ ] **Step 2: Add `codes` import if not present**
+
+Open `services/ingestion/internal/adapter/outbound/kafka/producer.go`. Add `"go.opentelemetry.io/otel/codes"` to imports if not present.
+
+- [ ] **Step 3: Wrap the ProduceSync call**
+
+Locate this existing block in `PublishBookAdded`:
+
+```go
+telemetry.InjectTraceContext(ctx, record)
+
+results := p.client.ProduceSync(ctx, record)
+if err := results.FirstErr(); err != nil {
+	return fmt.Errorf("producing to Kafka: %w", err)
+}
+```
+
+Replace it with:
+
+```go
+ctx, span := telemetry.StartProducerSpan(ctx, p.topic, book.ISBN)
+defer span.End()
+
+telemetry.InjectTraceContext(ctx, record)
+
+results := p.client.ProduceSync(ctx, record)
+if err := results.FirstErr(); err != nil {
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+	return fmt.Errorf("producing to Kafka: %w", err)
+}
+```
+
+> NOTE: `book.ISBN` is the function's input field used elsewhere in the same method as the Kafka record key (`Key: []byte(book.ISBN)`). Reuse it.
+
+- [ ] **Step 4: Build and run tests**
+
+Run:
+
+```bash
+go test ./services/ingestion/internal/adapter/outbound/kafka/... -race -count=1 -v
+```
+
+Expected: all tests PASS, including the pre-existing `TestPublishBookAdded` table tests, `TestPublishBookAdded_ProduceError`, and `TestPublishBookAdded_InjectsTraceparent`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/ingestion/internal/adapter/outbound/kafka/producer.go
+git commit -m "$(cat <<'EOF'
+feat(ingestion): wrap Kafka publish in producer span
+
+Uses book.ISBN as messaging.kafka.message.key (matches the value also
+used as the Kafka record key).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Full lint + test sweep
+
+- [ ] **Step 1: Run lint**
+
+Run:
+
+```bash
+make lint
+```
+
+Expected: `0 issues.`
+
+- [ ] **Step 2: Run all tests**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: every package OK; no FAIL lines.
+
+- [ ] **Step 3: If lint failed, fix and re-run**
+
+If `make lint` reports anything (commonly: gofmt or unused imports if `codes` was added speculatively where it wasn't needed), fix and recommit:
+
+```bash
+gofmt -w pkg/telemetry/ services/details/internal/adapter/outbound/kafka/ services/reviews/internal/adapter/outbound/kafka/ services/ratings/internal/adapter/outbound/kafka/ services/ingestion/internal/adapter/outbound/kafka/
+make lint
+git add -A
+git commit -m "chore: gofmt sweep after producer span wrap
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+If no lint issues, no commit needed.
+
+---
+
+## Task 7: Rebuild bookinfo services in cluster
+
+- [ ] **Step 1: Confirm cluster up**
+
+Run:
+
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo get pods --no-headers | awk '{print $3}' | sort | uniq -c
+```
+
+Expected: only `Running`. If pods are missing, the cluster may have been torn down — abort this task and re-run `make run-k8s` first.
+
+- [ ] **Step 2: Rebuild and redeploy bookinfo Go services**
+
+Run:
+
+```bash
+make k8s-rebuild
+```
+
+Expected: images rebuilt, imported into k3d, deployments rolled. Takes ~1-2 min.
+
+- [ ] **Step 3: Wait for rollout**
+
+Run:
+
+```bash
+sleep 15
+kubectl --context=k3d-bookinfo-local -n bookinfo get pods --no-headers | awk '{print $3}' | sort | uniq -c
+```
+
+Expected: only `Running`.
+
+---
+
+## Task 8: Cluster smoke test — capture trace IDs for each event type
+
+After this task completes, you will have 4 trace IDs to inspect manually in Grafana Tempo at <http://localhost:3000>.
+
+- [ ] **Step 1: book-added**
+
+Run:
+
+```bash
+curl -sS -X POST http://localhost:8080/v1/details \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"span-test-book","author":"a","year":2026,"type":"paperback","pages":1,"isbn_13":"9780000000333"}'
+echo
+sleep 5
+TRACE_BOOK=$(kubectl --context=k3d-bookinfo-local -n bookinfo logs deploy/details-write --since=20s 2>&1 \
+  | grep '"title":"span-test-book"' \
+  | head -1 \
+  | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["trace_id"])')
+echo "book-added trace_id: $TRACE_BOOK"
+```
+
+Expected: a 32-char hex string.
+
+- [ ] **Step 2: review-submitted**
+
+```bash
+curl -sS -X POST http://localhost:8080/v1/reviews \
+  -H 'Content-Type: application/json' \
+  -d '{"product_id":"span-test-prod","reviewer":"u","text":"span audit"}'
+echo
+sleep 5
+TRACE_REVIEW=$(kubectl --context=k3d-bookinfo-local -n bookinfo logs deploy/reviews-write --since=20s 2>&1 \
+  | grep '"product_id":"span-test-prod"' \
+  | head -1 \
+  | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["trace_id"])')
+echo "review-submitted trace_id: $TRACE_REVIEW"
+```
+
+- [ ] **Step 3: rating-submitted**
+
+```bash
+curl -sS -X POST http://localhost:8080/v1/ratings \
+  -H 'Content-Type: application/json' \
+  -d '{"product_id":"span-test-rating","reviewer":"u","stars":4}'
+echo
+sleep 5
+TRACE_RATING=$(kubectl --context=k3d-bookinfo-local -n bookinfo logs deploy/ratings-write --since=20s 2>&1 \
+  | grep '"product_id":"span-test-rating"' \
+  | head -1 \
+  | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["trace_id"])')
+echo "rating-submitted trace_id: $TRACE_RATING"
+```
+
+- [ ] **Step 4: review-deleted**
+
+```bash
+RID=$(kubectl --context=k3d-bookinfo-local -n bookinfo exec statefulset/reviews-postgresql -- \
+  bash -c "PGPASSWORD=bookinfo psql -U bookinfo -d bookinfo_reviews -t -c \"SELECT id FROM reviews WHERE product_id='span-test-prod' LIMIT 1;\"" 2>&1 | xargs)
+echo "Deleting review id: $RID"
+
+curl -sS -X POST http://localhost:8080/v1/reviews/delete \
+  -H 'Content-Type: application/json' \
+  -d "{\"review_id\":\"$RID\"}"
+echo
+sleep 5
+TRACE_DELETE=$(kubectl --context=k3d-bookinfo-local -n bookinfo logs deploy/reviews-write --since=20s 2>&1 \
+  | grep "$RID" \
+  | head -1 \
+  | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["trace_id"])')
+echo "review-deleted trace_id: $TRACE_DELETE"
+```
+
+- [ ] **Step 5: Print summary table for the user**
+
+```bash
+echo "=================================================="
+echo "Trace IDs to inspect at http://localhost:3000 (Grafana → Explore → Tempo):"
+echo "=================================================="
+echo "book-added        : $TRACE_BOOK"
+echo "review-submitted  : $TRACE_REVIEW"
+echo "rating-submitted  : $TRACE_RATING"
+echo "review-deleted    : $TRACE_DELETE"
+echo
+echo "Expected for each: a span tree with"
+echo "  <service>-write-api POST /v1/<resource>      [SERVER]"
+echo "  ├── pool.acquire / INSERT / etc              [INTERNAL via otelpgx]"
+echo "  └── <topic> publish                          [PRODUCER, NEW]"
+echo "      └── eventsource.receive                  [SERVER, argo-events fork]"
+echo "          └── eventsource.publish              [PRODUCER]"
+echo "              └── eventbus consume             [CONSUMER]"
+echo "                  └── trigger HTTP             [CLIENT]"
+echo "                      └── notification-api     [SERVER]"
+```
+
+---
+
+## Task 9: Push to PR #54
+
+- [ ] **Step 1: Verify branch and clean state**
+
+```bash
+git branch --show-current
+git status
+```
+
+Expected: on `feat/event-driven-notifications`, clean working tree.
+
+- [ ] **Step 2: Push**
+
+```bash
+git push
+```
+
+Expected: branch updated; PR #54 picks up the new commits.
+
+- [ ] **Step 3: Watch CI**
+
+```bash
+gh pr checks 54 --watch --interval 30 --fail-fast
+```
+
+Expected: all checks green.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Decision 1 (hand-rolled, not kotel) → Tasks 1-5 use the manual approach ✔
+- Decision 2 (raw attribute strings) → Task 1 uses `attribute.String("messaging.system", "kafka")` etc. ✔
+- Decision 3 (span name `<topic> publish`) → Task 1 uses `topic+" publish"` ✔
+- Decision 4 (all four producers in scope) → Tasks 2-5 cover details/reviews/ratings/ingestion ✔
+- Decision 5 (RecordError + SetStatus on failure) → Tasks 2-5 each include the error-recording branch ✔
+- Component: helper in `pkg/telemetry/kafka.go` → Task 1 ✔
+- Component: per-producer 4-line wrap → Tasks 2-5 ✔
+- Error-handling: ProduceSync error path records on span → Tasks 2-5 ✔
+- Testing: helper unit test → Task 1 (two test cases) ✔
+- Testing: existing producer tests continue passing → Tasks 2-5 verify with full test runs ✔
+- Testing: cluster smoke test capturing 4 trace IDs → Task 8 ✔
+- Acceptance criteria 1-5 → Task 1 (helper test), Tasks 2-5 (producer tests), Task 8 (cluster Tempo verification) ✔
+
+**Placeholder scan:** no "TBD", "TODO", "implement later". The "If `WithContext` exists" type of conditional check from prior plans is not present here — Task 1 specifies exactly what to import and write.
+
+**Type consistency:**
+
+- `StartProducerSpan(ctx context.Context, topic, key string) (context.Context, trace.Span)` is the same signature in Task 1 (definition) and Tasks 2-5 (call sites).
+- Each producer call site passes the appropriate per-service key: `evt.IdempotencyKey` for details/reviews/ratings, `book.ISBN` for ingestion. The `key` parameter is type-consistent (`string`).
+- Error recording uses `span.RecordError(err)` and `span.SetStatus(codes.Error, err.Error())` consistently across Tasks 2-5.
+- `defer span.End()` is consistent across all wraps.

--- a/docs/superpowers/specs/2026-04-24-event-driven-notifications-design.md
+++ b/docs/superpowers/specs/2026-04-24-event-driven-notifications-design.md
@@ -1,0 +1,432 @@
+# Event-Driven Notifications — Design
+
+**Date:** 2026-04-24
+**Status:** Design — pending implementation
+
+## Problem
+
+Today, CQRS sensors for `details`, `reviews`, and `ratings` fan out to two triggers in parallel: one writes to the service (`create-detail`, `create-review`, `delete-review-write`, `create-rating`) and one POSTs the notification service (`notify-book-added`, `notify-review-submitted`, `notify-review-deleted`, `notify-rating-submitted`). Argo Events runs sensor triggers concurrently, so the notification request leaves regardless of whether the write succeeded. A failed `Save` still produces a notification — the system claims work happened that didn't.
+
+Concrete example (`deploy/details/values-local.yaml`):
+```yaml
+cqrs.endpoints.book-added.triggers:
+  - name: create-detail              # may fail
+    url: self
+  - name: notify-book-added          # fires anyway, in parallel
+    url: http://notification.bookinfo.svc.cluster.local/v1/notifications
+```
+
+## Goal
+
+Notifications must reflect actual persisted state. A notification fires if and only if the corresponding write succeeded.
+
+## Approach
+
+Write services publish a CloudEvents-formatted Kafka event after their `Save` returns (success or idempotency-dedup). Notification subscribes to those events via a Consumer Sensor with `ce_type` filtering. The `notify-*` triggers are removed from CQRS sensors entirely — CQRS sensors return to the single-purpose role of driving the write service.
+
+```mermaid
+flowchart LR
+    Gateway[Envoy Gateway] -->|POST /v1/details| ES[CQRS EventSource<br/>book-added]
+    ES --> Sensor[details CQRS Sensor]
+    Sensor -->|create-detail trigger ONLY| DW[details-write]
+    DW -->|Save| DB[(Postgres)]
+    DW -->|publish ce| K[Kafka topic<br/>bookinfo_details_events]
+    K --> DES[details-events EventSource]
+    DES --> NS[notification Consumer Sensor]
+    NS -->|filtered by ce_type| NW[notification-write]
+    NW --> NDB[(Postgres)]
+```
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Scope: all four events | `details.book-added`, `reviews.review-submitted`, `reviews.review-deleted`, `ratings.rating-submitted`. One coordinated change; leaving any `notify-*` trigger on the parallel pattern keeps the bug alive. |
+| 2 | Failure handling: return 500, sensor retries | Stronger guarantee than fire-and-forget without the outbox machinery. Existing idempotency keys make the retry loop safe. |
+| 3 | Event payload: full entity + CloudEvents headers | Mirrors ingestion's producer. Producer stays domain-focused; mapping (`title → subject`, etc.) lives in consumer sensor YAML where it's already configured today. |
+| 4 | One topic per service, multiple `ce_type` carried | `bookinfo_<service>_events` carries every event type the service emits. Reviews emits both `review-submitted` and `review-deleted` to the same topic, distinguished by `ce_type`. Avoids topic proliferation. |
+| 5 | Publish location: always-publish in service layer | Service calls `repo.Save` (which dedups), then unconditionally calls `publisher.Publish`. On retry-after-Kafka-blip, Save dedups but publish fires → consumer sensor delivers → notification dedupes via natural-key. No new repo methods. |
+| 6 | EventSource naming: chart unchanged | Keep current `{fullname}-{eventName}` template. New keys are `events.exposed.events` per service (rendering `details-events`, `reviews-events`, `ratings-events`). Tautology in YAML accepted; rendered k8s names are clean. |
+| 7 | ce_type contract via annotation | Producer values declare `eventTypes:` list; chart renders it as `bookinfo.io/emitted-ce-types` annotation on the EventSource. Discoverable via `kubectl describe`. |
+
+## Components
+
+### Producer side — details, reviews, ratings
+
+Each write service gains:
+
+**Outbound port** (`internal/core/port/outbound.go`):
+```go
+type EventPublisher interface {
+    Publish(ctx context.Context, event domain.Event) error
+}
+```
+
+**Kafka adapter** (`internal/adapter/outbound/kafka/producer.go`): franz-go client mirroring `services/ingestion/internal/adapter/outbound/kafka/producer.go`. Same `kgo.NewClient`, `ProduceSync`, CloudEvents headers (`ce_specversion`, `ce_type`, `ce_id`, `ce_source`, `ce_time`, `ce_subject`, `content-type`). `ensureTopic` on startup. Per-service `ce_type` constants.
+
+| Service | `ce_source` | `ce_type` values | Topic |
+|---|---|---|---|
+| details | `details` | `com.bookinfo.details.book-added` | `bookinfo_details_events` |
+| reviews | `reviews` | `com.bookinfo.reviews.review-submitted`, `com.bookinfo.reviews.review-deleted` | `bookinfo_reviews_events` |
+| ratings | `ratings` | `com.bookinfo.ratings.rating-submitted` | `bookinfo_ratings_events` |
+
+**Service-layer change**: constructor accepts `EventPublisher`. Each write method (`AddDetail`, `AddReview`, `DeleteReview`, `AddRating`) calls `publisher.Publish` after the idempotency branch joins. On publish error → returns error → handler 500 → sensor retries.
+
+**Composition root** (`cmd/main.go`): wire kafka producer when `KAFKA_BROKERS` is set; inject a no-op publisher when unset (for docker-compose e2e and unit tests).
+
+**Config additions** (handled in `pkg/config`): `KAFKA_BROKERS`, `KAFKA_TOPIC` env vars per service.
+
+### Consumer side — notification
+
+No Go code changes. Notification stays HTTP-only — events arrive as POSTs to `/v1/notifications` from the consumer sensor. Mapping from event payload to notification fields lives in chart YAML.
+
+`deploy/notification/values-local.yaml`:
+```yaml
+events:
+  kafka:
+    broker: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  consumed:
+    book-added:
+      eventSourceName: details-events
+      eventName: events
+      filter:
+        ceType: com.bookinfo.details.book-added
+      triggers:
+        - name: notify-book-added
+          url: self
+          path: /v1/notifications
+          method: POST
+          payload:
+            - src: { dataKey: body.title }
+              dest: subject
+            - src: { value: "New book added" }
+              dest: body
+            - src: { value: "system@bookinfo" }
+              dest: recipient
+            - src: { value: "email" }
+              dest: channel
+      dlq:
+        enabled: true
+        url: "http://dlq-event-received-eventsource-svc.bookinfo.svc.cluster.local:12004/v1/events"
+    review-submitted:
+      eventSourceName: reviews-events
+      eventName: events
+      filter:
+        ceType: com.bookinfo.reviews.review-submitted
+      triggers:
+        - name: notify-review-submitted
+          url: self
+          path: /v1/notifications
+          payload:
+            - src: { dataKey: body.product_id }
+              dest: subject
+            - src: { value: "New review submitted" }
+              dest: body
+            - src: { value: "system@bookinfo" }
+              dest: recipient
+            - src: { value: "email" }
+              dest: channel
+      dlq: { enabled: true, url: "..." }
+    review-deleted:
+      eventSourceName: reviews-events
+      eventName: events
+      filter:
+        ceType: com.bookinfo.reviews.review-deleted
+      triggers:
+        - name: notify-review-deleted
+          url: self
+          path: /v1/notifications
+          payload:
+            - src: { dataKey: body.product_id }
+              dest: subject
+            - src: { value: "Review deleted" }
+              dest: body
+            - src: { value: "system@bookinfo" }
+              dest: recipient
+            - src: { value: "email" }
+              dest: channel
+      dlq: { enabled: true, url: "..." }
+    rating-submitted:
+      eventSourceName: ratings-events
+      eventName: events
+      filter:
+        ceType: com.bookinfo.ratings.rating-submitted
+      triggers:
+        - name: notify-rating-submitted
+          url: self
+          path: /v1/notifications
+          payload:
+            - src: { dataKey: body.product_id }
+              dest: subject
+            - src: { value: "New rating submitted" }
+              dest: body
+            - src: { value: "system@bookinfo" }
+              dest: recipient
+            - src: { value: "email" }
+              dest: channel
+      dlq: { enabled: true, url: "..." }
+```
+
+### Chart additions — `bookinfo-service`
+
+`charts/bookinfo-service/templates/kafka-eventsource.yaml`: render `eventTypes` list as annotation:
+```yaml
+metadata:
+  name: {{ include "bookinfo-service.fullname" $ }}-{{ $eventName }}
+  labels:
+    {{- include "bookinfo-service.labels" $ | nindent 4 }}
+  {{- with $event.eventTypes }}
+  annotations:
+    bookinfo.io/emitted-ce-types: {{ join "," . | quote }}
+  {{- end }}
+```
+
+`charts/bookinfo-service/templates/consumer-sensor.yaml`: add optional ce_type filter inside `dependencies[]`:
+```yaml
+- name: {{ $eventName }}-dep
+  eventSourceName: {{ $event.eventSourceName }}
+  eventName: {{ $event.eventName }}
+  {{- with $event.filter.ceType }}
+  filters:
+    context:
+      type: {{ . | quote }}
+  {{- end }}
+```
+
+`charts/bookinfo-service/values.yaml`: document the new fields in the commented schema:
+```yaml
+events:
+  exposed: {}
+    # event-name:
+    #   topic: kafka_topic_name
+    #   eventBusName: kafka
+    #   contentType: application/json
+    #   eventTypes:                       # optional, rendered as bookinfo.io/emitted-ce-types annotation
+    #     - com.bookinfo.<service>.<event>
+  consumed: {}
+    # event-name:
+    #   eventSourceName: producer-event-name
+    #   eventName: event-name
+    #   filter:                            # optional
+    #     ceType: com.bookinfo.<service>.<event>
+    #   triggers: [...]
+    #   dlq: {...}
+```
+
+### Removed configuration
+
+Per-service `values-local.yaml` for details, reviews, ratings:
+- Remove `notify-*` triggers from `cqrs.endpoints.<event>.triggers` — leaves only the `create-*` / `delete-*` triggers
+- Add `events.exposed.events` block with the topic and `eventTypes` list
+- Add `events.kafka.broker` and `KAFKA_BROKERS` / `KAFKA_TOPIC` env vars under `config`
+
+Example (`deploy/reviews/values-local.yaml` after change):
+```yaml
+config:
+  LOG_LEVEL: "debug"
+  RATINGS_SERVICE_URL: "http://ratings.bookinfo.svc.cluster.local"
+  KAFKA_BROKERS: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  KAFKA_TOPIC: "bookinfo_reviews_events"
+
+events:
+  kafka:
+    broker: "bookinfo-kafka-kafka-bootstrap.platform.svc.cluster.local:9092"
+  exposed:
+    events:
+      topic: bookinfo_reviews_events
+      eventBusName: kafka
+      contentType: application/json
+      eventTypes:
+        - com.bookinfo.reviews.review-submitted
+        - com.bookinfo.reviews.review-deleted
+
+cqrs:
+  enabled: true
+  endpoints:
+    review-submitted:
+      port: 12001
+      method: POST
+      endpoint: /v1/reviews
+      triggers:
+        - name: create-review        # only the write trigger remains
+          url: self
+          payload:
+            - passthrough
+    review-deleted:
+      port: 12003
+      method: POST
+      endpoint: /v1/reviews/delete
+      triggers:
+        - name: delete-review-write  # only the write trigger remains
+          url: self
+          payload:
+            - src:
+                dependencyName: review-deleted-dep
+                dataKey: body.review_id
+              dest: review_id
+```
+
+## Data flow
+
+### Happy path (book added)
+
+```mermaid
+sequenceDiagram
+    participant Caller as POST /v1/details
+    participant GW as Envoy Gateway
+    participant CES as CQRS EventSource (book-added)
+    participant CSensor as details CQRS Sensor
+    participant DW as details-write
+    participant DDB as details Postgres
+    participant K as Kafka<br/>bookinfo_details_events
+    participant DES as details-events EventSource
+    participant NSensor as notification Consumer Sensor
+    participant NW as notification-write
+    participant NDB as notification Postgres
+
+    Caller->>GW: POST /v1/details {title, author, ...}
+    GW->>CES: webhook
+    CES->>CSensor: book-added event
+    CSensor->>DW: POST /v1/details (create-detail trigger only)
+    DW->>DDB: idem.CheckAndRecord + Save
+    DDB-->>DW: ok
+    DW->>K: produce ce_type=com.bookinfo.details.book-added
+    K-->>DW: ack
+    DW-->>CSensor: 201
+    K->>DES: consume
+    DES->>NSensor: ce event with type filter
+    NSensor->>NSensor: filters.context.type matches book-added dep
+    NSensor->>NW: POST /v1/notifications {subject:title, body:"New book added", ...}
+    NW->>NDB: idem.CheckAndRecord + Save (Sent)
+    NW-->>NSensor: 201
+```
+
+### Failure recovery (Kafka blip)
+
+```mermaid
+sequenceDiagram
+    participant CSensor as CQRS Sensor
+    participant DW as details-write
+    participant DDB
+    participant K as Kafka
+
+    CSensor->>DW: POST /v1/details (attempt 1)
+    DW->>DDB: Save (idem key X recorded, row inserted)
+    DDB-->>DW: ok
+    DW->>K: produce
+    K-->>DW: ERROR
+    DW-->>CSensor: 500
+
+    Note over CSensor: retryStrategy fires
+
+    CSensor->>DW: POST /v1/details (attempt 2, same payload)
+    DW->>DDB: Save (idem key X dup → skip insert)
+    DDB-->>DW: already processed
+    DW->>K: produce (Kafka recovered)
+    K-->>DW: ack
+    DW-->>CSensor: 201
+```
+
+## Error handling
+
+| Failure | Behavior |
+|---|---|
+| DB Save error | service returns error → handler 500 → CQRS sensor retries |
+| Save dedups (idem hit) | publish proceeds anyway (always-publish semantics) |
+| Kafka publish error | service returns error → 500 → sensor retries whole call → Save dedups → publish retries |
+| `KAFKA_BROKERS` unset | no-op publisher injected at composition root (docker-compose / unit tests) |
+| Topic missing on startup | `ensureTopic` creates it (mirrors ingestion); startup fails if Kafka unreachable |
+| `ce_type` matches no consumer filter | dependency doesn't fire, message ack'd silently |
+| Notification HTTP 5xx | consumer sensor retry per `retryStrategy` |
+| Consumer retries exhausted | DLQ trigger writes to dlqueue (existing infra) |
+| Notification idempotency dup | returns 200 OK → sensor stops retrying |
+
+## Testing & validation
+
+### Unit tests
+
+Per producer service (details, reviews, ratings):
+- `internal/adapter/outbound/kafka/producer_test.go` mirrors `services/ingestion/internal/adapter/outbound/kafka/producer_test.go`. Fake `Client` matching `ProduceSync(ctx, rs ...*kgo.Record) kgo.ProduceResults`. Asserts: topic, key, marshaled body, all CE headers.
+- `internal/core/service/<entity>_service_test.go` extended with a fake `EventPublisher`. Asserts: publish called on fresh save AND on idempotency dedup; publish error propagates as service error.
+
+### Helm tests
+
+```bash
+make helm-lint
+make helm-template SERVICE=reviews   # verify EventSource carries bookinfo.io/emitted-ce-types annotation
+make helm-template SERVICE=notification  # verify Consumer Sensor renders 4 deps with filters.context.type
+```
+
+### End-to-end on k8s
+
+```bash
+make stop-k8s && make run-k8s
+make k8s-status   # all pods Ready, EventSources running
+```
+
+**Smoke tests (manual curl)**, repeated for each event:
+```bash
+# Add a book → triggers details create + book-added event
+curl -X POST http://localhost:8080/v1/details \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Smoke","author":"Test","year":2026,"type":"paperback"}'
+
+# Verify details persisted
+curl http://localhost:8080/v1/details | jq '.[] | select(.title=="Smoke")'
+
+# Verify Kafka event landed with the right CE headers
+kubectl --context=k3d-bookinfo-local -n platform exec bookinfo-kafka-cluster-kafka-0 -- \
+  bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 \
+  --topic bookinfo_details_events --from-beginning --max-messages 1 --property print.headers=true
+
+# Verify notification dispatched (matches book title in subject)
+curl 'http://localhost:8080/v1/notifications?recipient=system@bookinfo' | jq '.[] | select(.subject=="Smoke")'
+```
+
+**Failure-recovery smoke test:**
+```bash
+# Scale Kafka down → POST a book → expect 5xx
+kubectl --context=k3d-bookinfo-local -n platform scale strimzipodset bookinfo-kafka-cluster-kafka --replicas=0
+curl -i -X POST http://localhost:8080/v1/details -d '{...}'   # expect 500
+
+# Scale Kafka back up
+kubectl --context=k3d-bookinfo-local -n platform scale strimzipodset bookinfo-kafka-cluster-kafka --replicas=1
+
+# Within retry window: book persisted exactly once + notification fires exactly once
+```
+
+**k6 load:**
+```bash
+DURATION=2m BASE_RATE=5 make k8s-load
+```
+Existing scenarios POST details/reviews/ratings. Asserts (qualitative): notification dispatch count tracks successful write count 1:1.
+
+**Grafana / Tempo trace check:**
+- Open `http://localhost:3000` → Explore → Tempo
+- Query: `{service.name="details-write"}` → pick a span from a load-test request
+- Verify trace contains the full chain:
+  ```
+  envoy-gateway → details-eventsource → details-cqrs-sensor →
+    details-write (HTTP) → details-write (kafka producer span) →
+    details-events-eventsource (kafka consumer span) →
+    notification-consumer-sensor → notification-write (HTTP)
+  ```
+- Verify CloudEvents headers populate span attributes (`messaging.kafka.message.key`, `cloudevents.type`)
+- Compare against ingestion's existing trace shape (validated end-to-end in prior work)
+
+## Acceptance criteria
+
+1. POST a successful `book-added` / `review-submitted` / `review-deleted` / `rating-submitted` → notification persisted with matching subject
+2. POST that fails the write → no notification persisted (the bug being fixed)
+3. Kafka outage scenario → sensor retries → eventual notification when Kafka recovers; book persisted exactly once via idempotency dedup
+4. k6 run produces Tempo traces with the full chain end-to-end
+5. `kubectl describe eventsource details-events` shows `bookinfo.io/emitted-ce-types: com.bookinfo.details.book-added` annotation; same for reviews-events (two values) and ratings-events
+6. No `notify-*` triggers remain in any CQRS sensor across details/reviews/ratings values files
+7. `make helm-lint` passes; `make test` passes including new producer + service tests
+
+## Out of scope
+
+- Transactional outbox pattern (deferred — `Option C` from publish-failure-handling)
+- Renaming the EventSource template / fullname prefix migration (deferred — chart stays as-is)
+- Migrating ingestion's `raw-books-details` topic naming (deferred — semantic of "raw_" preserved)
+- Productpage notification rendering (notifications today are an audit log; UI surface unchanged)

--- a/docs/superpowers/specs/2026-04-25-compose-lite-mode-docs-design.md
+++ b/docs/superpowers/specs/2026-04-25-compose-lite-mode-docs-design.md
@@ -1,0 +1,137 @@
+# Compose Lite-Mode Documentation — Design
+
+**Date:** 2026-04-25
+**Status:** Design — pending implementation
+
+## Problem
+
+The recent event-driven notifications work introduced producer-side Kafka publishing in details/reviews/ratings/ingestion services and notification consumption via Argo Events sensors. The `make run-k8s` (k3d) path covers the full chain. The `make run` (docker-compose) path does not — `docker-compose.yml` has no Kafka broker, no ingestion service, no Argo Events components.
+
+In compose, services start with `KAFKA_BROKERS=""`; producers fall back to `NoopPublisher`. Notifications are exercised via direct HTTP POST in e2e tests. None of the recently-added event-chain code is meaningfully exercised under compose.
+
+Today this is undocumented. A developer running `make run` or reading `make e2e` could reasonably assume compose covers the full event-driven flow. It does not.
+
+## Goal
+
+Document compose as a "lite" development environment with explicit scope boundaries, so:
+
+1. Developers understand which path exercises which code.
+2. The choice of compose vs `make run-k8s` matches the work being tested (HTTP CRUD vs full event chain).
+3. The decision to NOT extend compose with Kafka + a sensor bridge is captured for future reference.
+
+This is a docs-only change. No new compose file overlays, no new make targets, no code changes.
+
+## Approach
+
+Three coordinated edits to existing files. Same wording reused across each so the message is consistent:
+
+- `docker-compose.yml` — top-of-file header comment, ~6 lines
+- `README.md` — extend the existing `make run` and `make e2e` sections, ~12 lines
+- `CLAUDE.md` — add a short paragraph under build/run instructions explaining the compose-vs-k8s boundary, ~5 lines
+
+## Decisions
+
+| # | Decision | Rationale |
+| --- | --- | --- |
+| 1 | Document, do not extend compose | k3s-in-compose duplicates `make run-k8s` with worse ergonomics; argo-events is too k8s-coupled for standalone running; a Redpanda-Connect-style bridge introduces dev/prod drift. The simplest correct choice is to scope compose narrowly. |
+| 2 | Same wording across all three files | Consistency. A reader hitting any one of the three docs gets the same accurate picture. |
+| 3 | Mention NoopPublisher behavior explicitly | Producers don't error on missing `KAFKA_BROKERS`; they silently no-op. This is non-obvious and a likely source of "where are my events?" confusion under compose. |
+| 4 | Reference `make run-k8s` as the full-chain path | Points the reader at the existing solution rather than implying a gap to be filled. |
+
+## Components
+
+### `docker-compose.yml`
+
+Current header (lines 1-3):
+
+```yaml
+# Local development compose file.
+# Usage: make run | make run-logs | make stop | make seed
+#   or:  docker compose up --build
+```
+
+Replace with:
+
+```yaml
+# Local development compose file — lite mode.
+#
+# Scope: postgres + redis + 5 backend services + productpage.
+# NOT included: Kafka, ingestion service, Argo Events, observability.
+# Producers detect missing KAFKA_BROKERS and fall back to a no-op
+# publisher; events are dropped silently.
+#
+# The full event-driven path (ingestion → Kafka → Argo Events sensor
+# → notification HTTP trigger) requires `make run-k8s` (k3d cluster).
+#
+# Usage: make run | make run-logs | make stop | make seed
+#   or:  docker compose up --build
+```
+
+### `README.md`
+
+Find the existing `make run` section (around the "Or use Docker Compose" paragraph). Add a callout block immediately after the existing fenced code listing:
+
+```markdown
+> **Lite mode.** Docker Compose runs the synchronous service mesh
+> only: postgres + redis + 5 backend services + productpage. Kafka,
+> the ingestion service, Argo Events, and the observability stack
+> are NOT included. Producers detect missing `KAFKA_BROKERS` and
+> fall back to a no-op publisher; events are dropped silently.
+>
+> The full event-driven path (ingestion polling Open Library →
+> Kafka → Argo Events EventSource → Sensor → notification HTTP
+> trigger) is exercised only via `make run-k8s` (k3d-based local
+> cluster).
+```
+
+Find the `make e2e` section (or the row in the make-target table). Append:
+
+```markdown
+> `make e2e` covers HTTP-level acceptance tests (idempotency,
+> validation, CRUD round-trips) under the lite-mode compose stack.
+> The event chain is verified end-to-end via trace inspection in
+> Tempo after `make run-k8s`.
+```
+
+### `CLAUDE.md`
+
+Find the existing `## Build Commands` or `## Local Kubernetes` section. Add a new paragraph between them (or in an appropriate adjacent location):
+
+```markdown
+**Compose vs k8s scope:** `make run` (docker-compose) is a lite
+development environment — postgres + redis + 5 backend services +
+productpage. Compose does NOT include Kafka, the ingestion service,
+Argo Events, or the observability stack. Producers fall back to a
+no-op publisher when `KAFKA_BROKERS` is unset; events are dropped.
+The full event-driven flow (ingestion + Kafka + Argo Events sensors
+driving notifications) and observability stack are exercised only
+via `make run-k8s`. Use `make e2e` for HTTP-level acceptance tests;
+the event chain is verified via Tempo traces after `make run-k8s`.
+```
+
+## Files modified
+
+```text
+docker-compose.yml        # ~6 lines change — header comment block
+README.md                 # ~12 lines added — under existing run/e2e sections
+CLAUDE.md                 # ~5 lines added — under build/run instructions
+```
+
+Total diff: ~25 lines. No code change.
+
+## Out of scope
+
+- New compose overlay (`docker-compose.full.yml`) with Kafka + bridge container
+- New make target
+- New e2e test scope
+- Changes to argo-events, helm charts, or service code
+- Adding ingestion service to compose
+- Refactoring existing compose layout
+
+## Acceptance criteria
+
+1. `docker-compose.yml` opens with the lite-mode header comment.
+2. `README.md` `make run` and `make e2e` sections each carry the lite-mode disclaimer.
+3. `CLAUDE.md` has the compose-vs-k8s scope paragraph adjacent to existing build/run instructions.
+4. Wording is consistent across all three (one canonical message, repeated where appropriate, not three drift-prone variants).
+5. No code, helm, or compose-service changes.

--- a/docs/superpowers/specs/2026-04-25-e2e-tracing-kafka-design.md
+++ b/docs/superpowers/specs/2026-04-25-e2e-tracing-kafka-design.md
@@ -60,7 +60,7 @@ flowchart LR
 ## Decisions
 
 | # | Decision | Rationale |
-|---|---|---|
+| --- | --- | --- |
 | 1 | Two-repo change | Producer-only fix is invisible (header on wire but no extractor); fork-only fix has nothing to extract. Both required to close the loop. |
 | 2 | Cherry-pick fork branch propagation | Land commit on `feat/cloudevents-compliance-otel-tracing` (PR 3961), cherry-pick onto `feat/combined-prs-3961-3983` (consumed branch). No force-push, no history rewrite. |
 | 3 | Mirror webhook source pattern in Kafka source | Existing established pattern in the same fork at `pkg/eventsources/sources/webhook/start.go:108`. Minimum surface area, maximum review velocity. |
@@ -190,7 +190,7 @@ If `WithContext` is not already an option for the `dispatch` callback, add one. 
 
 ### Image release flow
 
-```
+```text
 1. Add commit to feat/cloudevents-compliance-otel-tracing (signed off, no Claude trailer)
 2. git push origin feat/cloudevents-compliance-otel-tracing  (fast-forward; updates PR 3961)
 3. git checkout feat/combined-prs-3961-3983
@@ -220,6 +220,8 @@ git log -1 --format=%B                                                          
 
 ## Data flow (target state)
 
+`bookinfo_reviews_events` and `argo-events` are both topics on the same Strimzi Kafka cluster, which serves as the Argo Events bus. The diagram shows Kafka as a single participant with topic names called out per arrow.
+
 ```mermaid
 sequenceDiagram
   participant Caller
@@ -227,30 +229,30 @@ sequenceDiagram
   participant CQRSes as CQRS EventSource
   participant CQRSse as CQRS Sensor
   participant RW as reviews-write
-  participant Kafka as bookinfo_reviews_events
+  participant Kafka as Strimzi Kafka (argo-events bus)
   participant ESrc as reviews-events EventSource (fork)
-  participant Bus as argo-events bus
   participant NSe as notification consumer sensor
   participant Notif as notification
 
   Caller->>Gateway: POST /v1/reviews [traceparent: T1]
   Gateway->>CQRSes: webhook [traceparent: T1]
-  CQRSes->>Bus: publish (PRODUCER, parent=T1)
-  Bus->>CQRSse: deliver
-  CQRSse->>RW: HTTP POST [traceparent: T1.x]
+  CQRSes->>Kafka: publish to argo-events topic<br/>(PRODUCER span, parent=T1)
+  Kafka->>CQRSse: deliver from argo-events topic<br/>(CONSUMER span)
+  CQRSse->>RW: HTTP POST [traceparent: T1.x]<br/>(trigger CLIENT span)
   Note over RW: otelhttp server span (parent=T1.x)<br/>service + producer share ctx
-  RW->>Kafka: produce + InjectTraceContext(ctx, record)<br/>headers: ce_*, traceparent=T1.x.y
-  ESrc->>ESrc: processOne extracts traceparent<br/>StartServerSpan eventsource.receive (parent=T1.x.y)
-  ESrc->>Bus: dispatch(ctx, eventBody) → publish PRODUCER span chains under receive
-  Bus->>NSe: deliver (CONSUMER span)
-  NSe->>Notif: HTTP POST [traceparent: T1.x.y.z] → trigger CLIENT span
+  RW->>Kafka: produce to bookinfo_reviews_events topic<br/>InjectTraceContext(ctx, record)<br/>headers: ce_*, traceparent=T1.x.y
+  Kafka->>ESrc: deliver from bookinfo_reviews_events topic
+  Note over ESrc: processOne extracts traceparent from msg.Headers<br/>StartServerSpan eventsource.receive (parent=T1.x.y)
+  ESrc->>Kafka: dispatch eventBody to argo-events topic<br/>(eventsource.publish PRODUCER span chains under receive)
+  Kafka->>NSe: deliver from argo-events topic<br/>(CONSUMER span)
+  NSe->>Notif: HTTP POST [traceparent: T1.x.y.z]<br/>(trigger CLIENT span)
   Note over Notif: otelhttp server span chains under T1
 ```
 
 ## Error handling
 
 | Failure | Behavior |
-|---|---|
+| --- | --- |
 | No active span at producer call | `InjectTraceContext` is a no-op; record sent without traceparent. Existing flow continues; no new error. |
 | `traceparent` header malformed at consumer | `propagation.MapCarrier.Extract` returns the original ctx unchanged; SERVER span starts as a fresh root (current behavior). |
 | `tracing.StartServerSpan` panics | Existing argo-events panic-recovery in source listeners catches and logs. Event still dispatches. |
@@ -261,6 +263,7 @@ sequenceDiagram
 ### Producer side — unit tests
 
 `pkg/telemetry/kafka_test.go`:
+
 - Carrier `Get`/`Set`/`Keys` round-trip a known `traceparent` value.
 - `InjectTraceContext` with active ctx writes both `traceparent` and `tracestate` headers.
 - `InjectTraceContext` with empty ctx writes nothing.
@@ -292,6 +295,7 @@ func TestPublishX_InjectsTraceparent(t *testing.T) {
 ### Argo-events fork — unit test
 
 `pkg/eventsources/sources/kafka/start_test.go` (new test):
+
 - Build a sarama `ConsumerMessage` with `traceparent` in `Headers` (e.g. `00-<hex32>-<hex16>-01`).
 - Capture ctx passed to a fake `dispatch` shim.
 - Assert the ctx carries a valid `SpanContext` with the expected `TraceID`.

--- a/docs/superpowers/specs/2026-04-25-e2e-tracing-kafka-design.md
+++ b/docs/superpowers/specs/2026-04-25-e2e-tracing-kafka-design.md
@@ -1,0 +1,331 @@
+# End-to-End Distributed Tracing Across Kafka — Design
+
+**Date:** 2026-04-25
+**Status:** Design — pending implementation
+
+## Problem
+
+A request flowing from Envoy Gateway → CQRS Sensor → write service → Kafka → Argo Events → Notification produces **two disjoint traces** in Tempo:
+
+- **Trace A** ends at the Go Kafka producer (no `traceparent` injected into the record).
+- **Trace B** starts as a fresh root in the Argo Events Kafka EventSource (no extraction from `msg.Headers`).
+
+Audit run on the live cluster (2026-04-25):
+
+| Hop | trace_id |
+|---|---|
+| reviews-write (HTTP server, OTel-instrumented) | `1decff1e46c3af2f4b87b38515d0ffbc` |
+| notification (HTTP server, OTel-instrumented) | `31103ad019a882a199acf7572d7c439c` |
+
+`bookinfo_reviews_events` Kafka records contain only `ce_*` headers — no `traceparent`. Argo Events fork (branch `feat/combined-prs-3961-3983`) propagates trace correctly through eventbus → sensor → HTTP trigger via PRs 3961 + 3983, but the Kafka EventSource itself starts a fresh root span because nothing in `msg.Headers` is extracted.
+
+Webhook source already extracts trace context (`pkg/eventsources/sources/webhook/start.go:108`); Kafka source does not.
+
+## Goal
+
+A single connected trace from the originating client request through to the notification persist, regardless of which producer service emits the event.
+
+## Approach
+
+Two coordinated changes across two repos:
+
+1. **Producer side (`event-driven-bookinfo`):** Each Go Kafka producer injects W3C `traceparent` + `tracestate` from the active span context into the record headers via a shared `pkg/telemetry/kafka.go` helper.
+2. **Argo Events fork (`feat/cloudevents-compliance-otel-tracing` branch, PR 3961):** The Kafka source extracts the upstream trace context from `msg.Headers` and starts an `eventsource.receive` SERVER span as the parent of the existing `eventsource.publish` PRODUCER span — mirroring the webhook source's pattern verbatim.
+
+After both land and the fork image rebuilds, the existing PR 3961 + 3983 chain (PRODUCER → CONSUMER → CLIENT spans) inherits the upstream trace and produces one connected tree.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  subgraph go-http-server [event-driven-bookinfo]
+    Producer[Kafka producer.go<br/>InjectTraceContext into record headers]
+  end
+  subgraph argo-events [argo-events fork PR 3961]
+    KafkaSrc[kafka source start.go<br/>extract traceparent from msg.Headers<br/>start eventsource.receive SERVER span]
+    Existing[existing PRODUCER/CONSUMER/CLIENT span chain]
+  end
+
+  Caller --> Gateway --> CQRSSensor --> ReviewsWrite[reviews-write]
+  ReviewsWrite --> Producer
+  Producer -->|kafka record with W3C headers| KafkaSrc
+  KafkaSrc --> Existing
+  Existing --> NotifSensor[notification consumer sensor]
+  NotifSensor -->|HTTP with traceparent| Notification
+
+  style Producer fill:#fef
+  style KafkaSrc fill:#fef
+```
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Two-repo change | Producer-only fix is invisible (header on wire but no extractor); fork-only fix has nothing to extract. Both required to close the loop. |
+| 2 | Cherry-pick fork branch propagation | Land commit on `feat/cloudevents-compliance-otel-tracing` (PR 3961), cherry-pick onto `feat/combined-prs-3961-3983` (consumed branch). No force-push, no history rewrite. |
+| 3 | Mirror webhook source pattern in Kafka source | Existing established pattern in the same fork at `pkg/eventsources/sources/webhook/start.go:108`. Minimum surface area, maximum review velocity. |
+| 4 | All 4 producer flows in scope | Details book-added, reviews submitted/deleted, ratings submitted, ingestion book-added. Single shared helper in `pkg/telemetry/kafka.go`; per-service additions are one-liners. |
+| 5 | DCO sign-off + no Claude trailer on fork commits | Argoproj/argo-events upstream requires DCO. Memory rule `feedback_no_coauthor_argo` excludes the Claude co-author trailer on argo-events fork commits. |
+
+## Components
+
+### `event-driven-bookinfo` — producer side
+
+**New file: `pkg/telemetry/kafka.go`**
+
+```go
+// Package telemetry exports observability helpers shared across services.
+package telemetry
+
+import (
+    "context"
+
+    "github.com/twmb/franz-go/pkg/kgo"
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/propagation"
+)
+
+// kafkaHeaderCarrier adapts a *kgo.Record's Headers to TextMapCarrier for
+// W3C trace context propagation.
+type kafkaHeaderCarrier struct {
+    record *kgo.Record
+}
+
+func (c *kafkaHeaderCarrier) Get(key string) string {
+    for _, h := range c.record.Headers {
+        if h.Key == key {
+            return string(h.Value)
+        }
+    }
+    return ""
+}
+
+func (c *kafkaHeaderCarrier) Set(key, value string) {
+    for i := range c.record.Headers {
+        if c.record.Headers[i].Key == key {
+            c.record.Headers[i].Value = []byte(value)
+            return
+        }
+    }
+    c.record.Headers = append(c.record.Headers, kgo.RecordHeader{Key: key, Value: []byte(value)})
+}
+
+func (c *kafkaHeaderCarrier) Keys() []string {
+    keys := make([]string, 0, len(c.record.Headers))
+    for _, h := range c.record.Headers {
+        keys = append(keys, h.Key)
+    }
+    return keys
+}
+
+// InjectTraceContext writes W3C traceparent and tracestate from ctx into the
+// Kafka record headers. No-op when ctx carries no active span.
+func InjectTraceContext(ctx context.Context, record *kgo.Record) {
+    otel.GetTextMapPropagator().Inject(ctx, &kafkaHeaderCarrier{record: record})
+}
+```
+
+**Per-service producer change:**
+
+Each of `services/{details,reviews,ratings,ingestion}/internal/adapter/outbound/kafka/producer.go` adds one line before `ProduceSync`:
+
+```go
+record := &kgo.Record{ /* topic, key, value, headers */ }
+telemetry.InjectTraceContext(ctx, record) // <-- new line
+results := p.client.ProduceSync(ctx, record)
+```
+
+Imports the shared helper: `"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"`.
+
+### `argo-events` fork — consumer side
+
+**Modified file: `pkg/eventsources/sources/kafka/start.go`**
+
+Two call sites need updating: `processOne` (around line 249) and the partition-consumer variant (around line 449). Both currently dump `msg.Headers` into `eventData.Headers` without trace propagation.
+
+The new logic mirrors the webhook source pattern at `pkg/eventsources/sources/webhook/start.go:97-119`:
+
+```go
+// Existing:
+headers := make(map[string]string)
+for _, recordHeader := range msg.Headers {
+    headers[string(recordHeader.Key)] = string(recordHeader.Value)
+}
+eventData.Headers = headers
+
+// New: extract upstream W3C trace context and start a SERVER span
+ctx := otel.GetTextMapPropagator().Extract(parentCtx, propagation.MapCarrier(headers))
+ctx, receiveSpan := tracing.StartServerSpan(ctx, otel.Tracer("argo-events-eventsource"), "eventsource.receive",
+    attribute.String("eventsource.name", el.GetEventSourceName()),
+    attribute.String("eventsource.type", "kafka"),
+    attribute.String("messaging.system", "kafka"),
+    attribute.String("messaging.destination.name", msg.Topic),
+    attribute.Int("messaging.kafka.message.partition", int(msg.Partition)),
+    attribute.Int64("messaging.kafka.message.offset", msg.Offset),
+)
+defer receiveSpan.End()
+
+// Pass ctx to dispatch so eventsource.publish PRODUCER span chains under receiveSpan
+if err = dispatch(eventBody, eventsourcecommon.WithID(kafkaID), eventsourcecommon.WithContext(ctx)); err != nil {
+    receiveSpan.RecordError(err)
+    receiveSpan.SetStatus(codes.Error, err.Error())
+    return fmt.Errorf("failed to dispatch a Kafka event, %w", err)
+}
+```
+
+**Possible secondary change: `pkg/eventsources/common/options.go`**
+
+If `WithContext` is not already an option for the `dispatch` callback, add one. Verify before the patch lands; webhook source's equivalent is `WithHTTPHeaders`, so the pattern of context-carrying options exists.
+
+**Imports needed in `kafka/start.go`:**
+
+```go
+"go.opentelemetry.io/otel"
+"go.opentelemetry.io/otel/attribute"
+"go.opentelemetry.io/otel/codes"
+"go.opentelemetry.io/otel/propagation"
+
+"github.com/argoproj/argo-events/pkg/shared/tracing"
+```
+
+### Image release flow
+
+```
+1. Add commit to feat/cloudevents-compliance-otel-tracing (signed off, no Claude trailer)
+2. git push origin feat/cloudevents-compliance-otel-tracing  (fast-forward; updates PR 3961)
+3. git checkout feat/combined-prs-3961-3983
+4. git cherry-pick <new-sha>
+5. git push origin feat/combined-prs-3961-3983
+6. CI builds + pushes ghcr.io/kaio6fellipe/argo-events:<tag>
+7. event-driven-bookinfo: `make k8s-rebuild` to pull new image
+8. Run smoke test (Section "Testing & validation")
+```
+
+## Constraints on the fork branch
+
+`feat/cloudevents-compliance-otel-tracing` already contains 12 substantive PR-3961 commits (`7e5371a8` through `30401397`). The new commit is **append-only**:
+
+- Preserve all 12 existing commits unchanged. No rebase, amend, or squash that touches them.
+- New commit signed off via `git commit -s`. DCO required by argoproj/argo-events upstream.
+- No `Co-Authored-By: Claude ... <noreply@anthropic.com>` trailer.
+- Fast-forward push only — no `--force` / `--force-with-lease`.
+
+**Verification before push:**
+
+```bash
+git log --oneline master..feat/cloudevents-compliance-otel-tracing | head -12   # 12 SHAs match pre-change list
+git diff <last-existing-sha>..HEAD -- pkg/eventsources/sources/kafka/           # diff scoped to Kafka source
+git log -1 --format=%B                                                          # trailer block: only "Signed-off-by: ..."
+```
+
+## Data flow (target state)
+
+```mermaid
+sequenceDiagram
+  participant Caller
+  participant Gateway as Envoy Gateway
+  participant CQRSes as CQRS EventSource
+  participant CQRSse as CQRS Sensor
+  participant RW as reviews-write
+  participant Kafka as bookinfo_reviews_events
+  participant ESrc as reviews-events EventSource (fork)
+  participant Bus as argo-events bus
+  participant NSe as notification consumer sensor
+  participant Notif as notification
+
+  Caller->>Gateway: POST /v1/reviews [traceparent: T1]
+  Gateway->>CQRSes: webhook [traceparent: T1]
+  CQRSes->>Bus: publish (PRODUCER, parent=T1)
+  Bus->>CQRSse: deliver
+  CQRSse->>RW: HTTP POST [traceparent: T1.x]
+  Note over RW: otelhttp server span (parent=T1.x)<br/>service + producer share ctx
+  RW->>Kafka: produce + InjectTraceContext(ctx, record)<br/>headers: ce_*, traceparent=T1.x.y
+  ESrc->>ESrc: processOne extracts traceparent<br/>StartServerSpan eventsource.receive (parent=T1.x.y)
+  ESrc->>Bus: dispatch(ctx, eventBody) → publish PRODUCER span chains under receive
+  Bus->>NSe: deliver (CONSUMER span)
+  NSe->>Notif: HTTP POST [traceparent: T1.x.y.z] → trigger CLIENT span
+  Note over Notif: otelhttp server span chains under T1
+```
+
+## Error handling
+
+| Failure | Behavior |
+|---|---|
+| No active span at producer call | `InjectTraceContext` is a no-op; record sent without traceparent. Existing flow continues; no new error. |
+| `traceparent` header malformed at consumer | `propagation.MapCarrier.Extract` returns the original ctx unchanged; SERVER span starts as a fresh root (current behavior). |
+| `tracing.StartServerSpan` panics | Existing argo-events panic-recovery in source listeners catches and logs. Event still dispatches. |
+| Kafka producer fails entirely | Existing error path returns; record never produced; no trace gap concern. |
+
+## Testing & validation
+
+### Producer side — unit tests
+
+`pkg/telemetry/kafka_test.go`:
+- Carrier `Get`/`Set`/`Keys` round-trip a known `traceparent` value.
+- `InjectTraceContext` with active ctx writes both `traceparent` and `tracestate` headers.
+- `InjectTraceContext` with empty ctx writes nothing.
+
+Per-service `producer_test.go` extension — one new test per service:
+
+```go
+func TestPublishX_InjectsTraceparent(t *testing.T) {
+    tp := sdktrace.NewTracerProvider()
+    otel.SetTracerProvider(tp)
+    otel.SetTextMapPropagator(propagation.TraceContext{})
+    ctx, span := otel.Tracer("test").Start(context.Background(), "parent")
+    defer span.End()
+
+    fc := &fakeClient{}
+    p := kafkaadapter.NewProducerWithClient(fc, "topic")
+    if err := p.PublishX(ctx, evt); err != nil { t.Fatal(err) }
+
+    fc.mu.Lock()
+    defer fc.mu.Unlock()
+    headers := map[string]string{}
+    for _, h := range fc.records[0].Headers { headers[h.Key] = string(h.Value) }
+    if headers["traceparent"] == "" {
+        t.Error("expected traceparent header, got none")
+    }
+}
+```
+
+### Argo-events fork — unit test
+
+`pkg/eventsources/sources/kafka/start_test.go` (new test):
+- Build a sarama `ConsumerMessage` with `traceparent` in `Headers` (e.g. `00-<hex32>-<hex16>-01`).
+- Capture ctx passed to a fake `dispatch` shim.
+- Assert the ctx carries a valid `SpanContext` with the expected `TraceID`.
+
+### End-to-end on local k8s
+
+After image rebuild + cluster rollout:
+
+1. `curl -sS -X POST http://localhost:8080/v1/reviews -H 'Content-Type: application/json' -d '{"product_id":"trace-e2e","reviewer":"u","text":"trace check"}'`
+2. `kubectl logs deploy/reviews-write --since=10s | grep trace-e2e | jq -r .trace_id` → capture A
+3. `kubectl logs deploy/notification --since=10s | grep trace-e2e | jq -r .trace_id` → capture B
+4. **Acceptance:** A == B
+5. Open Tempo, query `{traceID="<A>"}`, verify the span tree includes:
+   - `envoy-gateway` server span
+   - `reviews-write-api` server span
+   - `eventsource.receive` SERVER span on `reviews-events` (the new span)
+   - `eventsource.publish` PRODUCER span
+   - sensor CONSUMER + CLIENT spans
+   - `notification-api` server span
+6. Repeat for `book-added`, `review-deleted`, `rating-submitted` — confirm all 4 producer flows propagate.
+
+## Acceptance criteria
+
+1. Producer-side unit tests assert traceparent presence/absence per active span state
+2. Fork-side unit test asserts trace extraction from `msg.Headers`
+3. Local k8s e2e: `trace_id` matches between producing service and notification logs for the same request
+4. Tempo trace tree spans all 9 hops as one connected trace
+5. PR 3961 contains exactly 13 substantive commits (12 existing + 1 new); all signed off; no Claude co-author trailer
+6. `feat/combined-prs-3961-3983` cleanly cherry-picks the new commit (no manual conflict resolution)
+7. Combined image builds successfully and runs without regressions in the bookinfo cluster
+
+## Out of scope
+
+- Patching upstream argoproj/argo-events directly (this PR builds on top of in-flight PR 3961)
+- Trace propagation for non-Kafka EventSource types (Redis, NATS, etc.) — only the kafka source is patched here
+- Trace propagation through the Schema Registry path (`toJson(el.SchemaRegistry, msg)`) — out of scope; that branch flows the same context through dispatch unchanged
+- Adding span attributes for CloudEvents `ce_*` headers as separate semantic attributes — current implementation logs them as part of `messaging.*` attributes only

--- a/docs/superpowers/specs/2026-04-25-kafka-eventsource-consume-span-design.md
+++ b/docs/superpowers/specs/2026-04-25-kafka-eventsource-consume-span-design.md
@@ -1,0 +1,261 @@
+# Kafka EventSource Consume Span — Design
+
+**Date:** 2026-04-25
+**Status:** Design — pending implementation
+
+## Problem
+
+In Tempo, a request to `POST /v1/reviews` shows the following span tree on the producer side:
+
+```
+reviews-write-api POST /v1/reviews                  [SERVER]
+├── pool.acquire / INSERT / etc                     [INTERNAL via otelpgx]
+└── bookinfo_reviews_events publish                 [PRODUCER]
+    └── eventsource.publish                         [PRODUCER]   ← starts here on the EventSource side
+        └── eventbus consume                        [CONSUMER]
+            └── trigger HTTP                        [CLIENT]
+                └── notification-api POST           [SERVER]
+```
+
+The Kafka EventSource opens its work with `eventsource.publish` — which is misleading. Before forwarding the event to the eventbus, the source first **consumes** the message from the upstream Kafka topic. There is no span representing that consume step, so the trace conflates the read-from-topic with the publish-to-eventbus into a single PRODUCER span.
+
+## Goal
+
+Insert an explicit `eventsource.consume` span (`SpanKindConsumer`) as the parent of the existing `eventsource.publish` PRODUCER span on the Kafka EventSource side. The consume span follows OTel messaging semantic conventions and carries the Kafka coordinates (topic, partition, offset, key) of the consumed message. The change applies **only to the Kafka source** — webhook and other source types are not affected.
+
+## Approach
+
+Modify `pkg/eventsources/sources/kafka/start.go` (both `processOne` closures: `consumerGroupConsumer` and `partitionConsumer`). After building the `headers` map from `msg.Headers`:
+
+1. Extract upstream W3C trace context from the headers (was implicitly done later via `WithKafkaHeaders` + `SpanFromCloudEvent`)
+2. Start `eventsource.consume` CONSUMER span as a child of the upstream context
+3. **Re-inject the CONSUMER span's traceparent into the `headers` map**, overwriting the upstream value
+4. Continue with existing dispatch — `WithKafkaHeaders(headers)` now writes the CONSUMER's traceparent as the CloudEvent extension; `SpanFromCloudEvent` extracts it; the existing `eventsource.publish` PRODUCER span chains under the CONSUMER
+
+This re-inject step is the load-bearing mechanic. It's the only way to inject a span into the existing chain without modifying shared dispatch code in `eventing.go` (which the user requires stay untouched, since the change must be Kafka-only).
+
+## Architecture
+
+```mermaid
+flowchart TD
+  US[upstream span<br/>e.g. reviews-write 'bookinfo_reviews_events publish' PRODUCER]
+  C[eventsource.consume CONSUMER ← NEW<br/>parent: upstream<br/>only on kafka source]
+  P[eventsource.publish PRODUCER<br/>existing in eventing.go<br/>parent: now CONSUMER, was upstream]
+  EB[eventbus consume CONSUMER]
+  S[sensor trigger CLIENT]
+  N[notification SERVER]
+
+  US --> C --> P --> EB --> S --> N
+
+  style C fill:#fef
+```
+
+## Decisions
+
+| # | Decision | Rationale |
+| --- | --- | --- |
+| 1 | Span name `eventsource.consume` | Matches the user's explicit request. Aligns with the existing `eventsource.publish` and `eventsource.receive` (webhook) naming conventions in the fork. |
+| 2 | `SpanKindConsumer` | OTel messaging semconv: receive operations are CONSUMER kind. Helper `tracing.StartConsumerSpan` already exists in the fork. |
+| 3 | Modify only the Kafka source | User requirement: "the eventsource.consume should be only added at kafka eventsource". No edits to `eventing.go` or other sources. |
+| 4 | Re-inject CONSUMER traceparent into the headers map | Lets the existing `WithKafkaHeaders` + `SpanFromCloudEvent` chain pick the CONSUMER as parent for `eventsource.publish` without touching shared code. |
+| 5 | Append-only on `feat/cloudevents-compliance-otel-tracing` (PR 3961) | User requirement: PR 3961 stays at its existing commits + 1 new. No rebase, no force-push. |
+| 6 | Cherry-pick to `feat/combined-prs-3961-3983` | Same workflow as the prior trace-propagation work. Build + push image locally with `GOFLAGS=-mod=mod` after deleting stale `dist/` artifacts. |
+| 7 | Sign-off `-s`, no Claude trailer | DCO required by argoproj/argo-events upstream; memory rule excludes Claude co-author trailer on argo-events fork commits. |
+
+## Components
+
+### Modified file (only)
+
+`/Users/kaio.fellipe/Documents/git/others/argo-events/pkg/eventsources/sources/kafka/start.go`
+
+Two call sites get the same edit (`processOne` inside `consumerGroupConsumer` ~line 263 and inside `partitionConsumer` ~line 449).
+
+### Replacement pattern
+
+Existing code in each `processOne` closure (already updated by the prior PR-3961 commit):
+
+```go
+headers := make(map[string]string)
+for _, recordHeader := range msg.Headers {
+    headers[string(recordHeader.Key)] = string(recordHeader.Value)
+}
+eventData.Headers = headers
+// ... json marshaling ...
+if err = dispatch(eventBody, eventsourcecommon.WithID(kafkaID), eventsourcecommon.WithKafkaHeaders(headers)); err != nil {
+    return fmt.Errorf("failed to dispatch a Kafka event, %w", err)
+}
+```
+
+New code:
+
+```go
+headers := make(map[string]string)
+for _, recordHeader := range msg.Headers {
+    headers[string(recordHeader.Key)] = string(recordHeader.Value)
+}
+
+// Extract upstream W3C trace context from the Kafka record headers
+parentCtx := otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier(headers))
+
+// Start an eventsource.consume CONSUMER span as the parent for the
+// downstream eventsource.publish PRODUCER span emitted in eventing.go.
+spanCtx, consumeSpan := tracing.StartConsumerSpan(parentCtx, otel.Tracer("argo-events-eventsource"), "eventsource.consume",
+    attribute.String("eventsource.name", el.GetEventSourceName()),
+    attribute.String("eventsource.type", "kafka"),
+    attribute.String("messaging.system", "kafka"),
+    attribute.String("messaging.destination.name", msg.Topic),
+    attribute.String("messaging.operation.type", "receive"),
+    attribute.String("messaging.kafka.message.key", string(msg.Key)),
+    attribute.Int("messaging.kafka.message.partition", int(msg.Partition)),
+    attribute.Int64("messaging.kafka.message.offset", msg.Offset),
+)
+defer consumeSpan.End()
+
+// Re-inject the CONSUMER span's trace context into the headers map so
+// WithKafkaHeaders writes the CONSUMER traceparent as the CloudEvent
+// extension. eventing.go's SpanFromCloudEvent then makes the
+// eventsource.publish PRODUCER span a child of CONSUMER (instead of
+// directly under upstream).
+otel.GetTextMapPropagator().Inject(spanCtx, propagation.MapCarrier(headers))
+
+eventData.Headers = headers
+// ... json marshaling unchanged ...
+if err = dispatch(eventBody, eventsourcecommon.WithID(kafkaID), eventsourcecommon.WithKafkaHeaders(headers)); err != nil {
+    consumeSpan.RecordError(err)
+    consumeSpan.SetStatus(codes.Error, err.Error())
+    return fmt.Errorf("failed to dispatch a Kafka event, %w", err)
+}
+```
+
+`eventData.Headers = headers` MUST move to after the inject so the dispatched event body carries the consume-span's traceparent (in `data.headers.traceparent`).
+
+### Imports needed
+
+The file already imports `otel`, `propagation`, `attribute`, `eventsourcecommon`, and `tracing` (used by adjacent code in the fork). Need to add (if absent):
+
+```go
+"go.opentelemetry.io/otel/codes"
+```
+
+`codes.Error` is needed for the error-recording branch. Verify before edit.
+
+### Branch state
+
+Snapshot before commit:
+
+```bash
+git log --oneline master..feat/cloudevents-compliance-otel-tracing > /tmp/argo-events-pr3961-baseline-r2.txt
+wc -l /tmp/argo-events-pr3961-baseline-r2.txt   # expect 21
+```
+
+After commit:
+
+```bash
+git log --oneline master..feat/cloudevents-compliance-otel-tracing | wc -l   # expect 22
+diff <(git log --oneline master..HEAD | tail -21) /tmp/argo-events-pr3961-baseline-r2.txt   # must be no output
+```
+
+### Image build
+
+Stale `dist/argo-events-linux-*` artifacts cache the previous build; Make's file-existence rule skips rebuild. Purge first:
+
+```bash
+cd /Users/kaio.fellipe/Documents/git/others/argo-events
+rm -f dist/argo-events-linux-*
+GOFLAGS=-mod=mod IMAGE_NAMESPACE=ghcr.io/kaio6fellipe DOCKER_PUSH=true VERSION=prs-3961-3983 make image-multi
+```
+
+Verify push:
+
+```bash
+docker pull --quiet ghcr.io/kaio6fellipe/argo-events:prs-3961-3983
+docker create --name ae-inspect-r2 ghcr.io/kaio6fellipe/argo-events:prs-3961-3983
+docker cp ae-inspect-r2:/bin/argo-events /tmp/argo-events-binary-r2
+docker rm ae-inspect-r2
+strings /tmp/argo-events-binary-r2 | grep -oE "gitCommit=[a-f0-9]{40}" | head -1
+# expect: gitCommit=<the cherry-picked SHA on feat/combined-prs-3961-3983>
+strings /tmp/argo-events-binary-r2 | grep -oE "buildDate=[0-9TZ:-]+" | head -1
+# expect: today's UTC timestamp
+```
+
+Then import into k3d and restart EventSource pods:
+
+```bash
+k3d image import ghcr.io/kaio6fellipe/argo-events:prs-3961-3983 -c bookinfo-local
+kubectl --context=k3d-bookinfo-local -n bookinfo delete pod -l eventsource-name
+kubectl --context=k3d-bookinfo-local -n bookinfo delete pod -l sensor-name
+```
+
+## Data flow (target trace tree)
+
+```
+<service>-write-api POST /v1/<resource>             [SERVER]
+├── pool.acquire / INSERT / etc                     [INTERNAL via otelpgx]
+└── bookinfo_<service>_events publish               [PRODUCER]
+    └── eventsource.consume                         [CONSUMER] ← NEW
+        └── eventsource.publish                     [PRODUCER]
+            └── eventbus consume                    [CONSUMER]
+                └── trigger HTTP                    [CLIENT]
+                    └── notification-api POST       [SERVER]
+```
+
+Span depth grows by one. trace_id remains constant across all hops (continuity preserved).
+
+## Error handling
+
+| Failure | Behavior |
+| --- | --- |
+| `propagation.Extract` finds no traceparent in headers | Returns ctx unchanged; CONSUMER span starts as a fresh root. Same as current behavior when upstream doesn't propagate. |
+| `dispatch` returns error | `consumeSpan.RecordError(err)` + `consumeSpan.SetStatus(codes.Error, ...)`; error returned as before. Tempo highlights the failed CONSUMER span. |
+| `tracing.StartConsumerSpan` panics | Existing argo-events panic-recovery in source listeners catches and logs. Event still dispatches. |
+| `eventData.Headers` referenced before re-inject (caller order bug) | Caught at code review and by the spec — re-inject MUST precede the `eventData.Headers = headers` assignment. |
+
+## Testing
+
+### Build verification
+
+```bash
+GOFLAGS=-mod=mod go build ./pkg/eventsources/sources/kafka/...
+GOFLAGS=-mod=mod go vet ./pkg/eventsources/sources/kafka/...
+```
+
+Both clean.
+
+### Unit test
+
+Skipped — building a sarama `ConsumerMessage` mock and asserting on span tree shape is heavy for a one-span addition. The combination of:
+- Existing `WithKafkaHeaders` test (validates CE extension extraction)
+- Cluster Tempo verification (validates the actual span tree)
+
+provides sufficient confidence. Strict TDD not required for this commit.
+
+### Cluster smoke test
+
+After image push + pod restart:
+
+1. POST a `/v1/reviews` request, capture trace_id from `reviews-write` log
+2. Open Tempo, query the trace_id
+3. **Verify** the span tree contains, in order:
+   - `reviews-write-api POST /v1/reviews` (SERVER)
+   - `bookinfo_reviews_events publish` (PRODUCER)
+   - `eventsource.consume` (CONSUMER) ← the new span
+   - `eventsource.publish` (PRODUCER)
+   - downstream chain
+4. Confirm `eventsource.consume` attributes include `messaging.system=kafka`, `messaging.destination.name=bookinfo_reviews_events`, `messaging.kafka.message.partition`, `.offset`, `.key`
+5. Repeat for `book-added`, `review-deleted`, `rating-submitted`
+
+## Acceptance criteria
+
+1. PR 3961 picks up exactly **one new commit**; the existing 21 commits remain bit-identical (verified by `diff` against the baseline snapshot).
+2. New commit on `feat/cloudevents-compliance-otel-tracing` is signed off and contains no `Co-Authored-By` trailer.
+3. `feat/combined-prs-3961-3983` cherry-picks the new commit cleanly; build + push to `ghcr.io/kaio6fellipe/argo-events:prs-3961-3983` succeeds; embedded `gitCommit` matches the new combined-branch HEAD; `buildDate` is today.
+4. After cluster restart: each of the four event types produces a Tempo trace containing the new `eventsource.consume` CONSUMER span between the producer-service publish and the eventbus publish.
+5. trace_id continuity preserved: producer service trace_id == notification trace_id (no regression from the prior trace-propagation work).
+6. `go build ./pkg/eventsources/sources/kafka/...` clean (with `GOFLAGS=-mod=mod`).
+
+## Out of scope
+
+- Equivalent CONSUMER spans for other source types (webhook already has `eventsource.receive` SERVER span; other sources unchanged)
+- Changes to `eventing.go` or shared dispatch path
+- Schema-registry-aware processing path (`toJson(el.SchemaRegistry, msg)`) — same change applies regardless; the inject precedes any branching
+- Updating the bookinfo cluster's image reference (uses moving tag `prs-3961-3983`; pull on restart picks up the new digest)

--- a/docs/superpowers/specs/2026-04-25-kafka-producer-span-design.md
+++ b/docs/superpowers/specs/2026-04-25-kafka-producer-span-design.md
@@ -1,0 +1,243 @@
+# Kafka Producer Span Instrumentation — Design
+
+**Date:** 2026-04-25
+**Status:** Design — pending implementation
+
+## Problem
+
+In Tempo, an API request like `POST /v1/reviews` shows the server span with child spans for the database operations (`pool.acquire`, `INSERT review`, etc.) emitted by `otelpgx` auto-instrumentation. But the actual Kafka publish operation is invisible — there is no span representing the call to `p.client.ProduceSync(ctx, record)`.
+
+Today the producer code path looks like:
+
+```go
+record := &kgo.Record{ ... }
+telemetry.InjectTraceContext(ctx, record)   // writes traceparent header
+results := p.client.ProduceSync(ctx, record) // raw call, no span
+```
+
+Because the producer never starts a span of its own, the `traceparent` header that flows into the Kafka record is the *API server span's* context. So the consumer side (Argo Events Kafka source → eventbus → notification) chains directly under the API server span, skipping the publish operation entirely. The user observing a Tempo trace cannot see when the publish happened, how long it took, or whether it errored.
+
+## Goal
+
+Each Kafka publish in details, reviews, ratings, and ingestion emits a child span with `SpanKindProducer` and OTel messaging semantic-convention attributes, so Tempo shows the publish operation as a peer of the database spans under the API server span. The downstream consumer chain hangs under this new span.
+
+## Approach
+
+Add a single helper `telemetry.StartProducerSpan(ctx, topic, key)` to the existing `pkg/telemetry/kafka.go`. Each producer wraps its `ProduceSync` call in a 4-line block: start span (defer end) → inject traceparent (already present) → produce → record error on failure.
+
+No new module dependency. Attributes use raw OTel messaging semantic-convention strings (stable across semconv versions).
+
+## Architecture
+
+```mermaid
+flowchart TD
+  API[reviews-write-api POST /v1/reviews<br/>SERVER span]
+  IDEM[idempotency.CheckAndRecord<br/>DB span via otelpgx]
+  POOL[pool.acquire]
+  SAVE[INSERT review]
+  KP[bookinfo_reviews_events publish<br/>PRODUCER span - NEW]
+  ESR[eventsource.receive<br/>argo-events fork]
+  EB[eventsource.publish PRODUCER]
+
+  API --> IDEM
+  API --> POOL
+  API --> SAVE
+  API --> KP
+  KP --> ESR
+  ESR --> EB
+
+  style KP fill:#fef
+```
+
+The new span name follows `<topic> publish` per OTel messaging convention. SpanKind is `Producer`. The traceparent injected into the Kafka record header now carries THIS span's context, so the downstream consumer span chains under the publish span (not directly under the API server span).
+
+## Decisions
+
+| # | Decision | Rationale |
+| --- | --- | --- |
+| 1 | Hand-rolled span helper, not `kotel` | One small change in already-modified `pkg/telemetry/kafka.go`. No new module. Surgical. |
+| 2 | Raw attribute strings, not `semconv` constants | Avoids version-pinning a separate `semconv/v1.X.Y` import. Keys (`messaging.system`, `messaging.destination.name`, etc.) are stable across semconv versions. |
+| 3 | Span name `<topic> publish` | OTel messaging semantic convention recommends `<destination> <operation>` format. Renders as e.g. `bookinfo_reviews_events publish`. |
+| 4 | All four producers in scope | Single helper used by details, reviews, ratings, ingestion. Consistent observability across all event flows. |
+| 5 | Error recording via `span.RecordError` + `SetStatus(codes.Error, ...)` | OTel idiom for failed operations; lets Tempo highlight failed spans. |
+
+## Components
+
+### `pkg/telemetry/kafka.go` — append
+
+```go
+import (
+    // existing imports...
+    "go.opentelemetry.io/otel/attribute"
+    "go.opentelemetry.io/otel/trace"
+)
+
+// StartProducerSpan starts a child span for a Kafka publish operation following
+// OTel messaging semantic conventions. Caller must End() the span (use defer).
+// Span name is "<topic> publish"; SpanKind is Producer.
+func StartProducerSpan(ctx context.Context, topic, key string) (context.Context, trace.Span) {
+    return otel.Tracer("kafka-producer").Start(ctx,
+        topic+" publish",
+        trace.WithSpanKind(trace.SpanKindProducer),
+        trace.WithAttributes(
+            attribute.String("messaging.system", "kafka"),
+            attribute.String("messaging.destination.name", topic),
+            attribute.String("messaging.operation.type", "publish"),
+            attribute.String("messaging.kafka.message.key", key),
+        ),
+    )
+}
+```
+
+### Per-producer 4-line wrap
+
+Inside each producer's `Publish*` method (or shared `produce` helper for reviews), wrap the `ProduceSync` call:
+
+```go
+ctx, span := telemetry.StartProducerSpan(ctx, p.topic, evt.IdempotencyKey)
+defer span.End()
+
+telemetry.InjectTraceContext(ctx, record) // already present; unchanged
+
+results := p.client.ProduceSync(ctx, record)
+if err := results.FirstErr(); err != nil {
+    span.RecordError(err)
+    span.SetStatus(codes.Error, err.Error())
+    return fmt.Errorf("producing to Kafka: %w", err)
+}
+```
+
+For ingestion (where the `key` is `book.ISBN`) and ratings (where there's no idempotency key explicitly — uses `evt.IdempotencyKey`), use the appropriate per-service identifier as the message key. Use the same value already passed to `kgo.Record.Key`.
+
+### Files modified
+
+```text
+pkg/telemetry/kafka.go              # +helper function
+pkg/telemetry/kafka_test.go         # +unit test for the helper
+
+services/details/internal/adapter/outbound/kafka/producer.go            # +4 lines in PublishBookAdded
+services/details/internal/adapter/outbound/kafka/producer_test.go       # +1 assertion (span recorded)
+
+services/reviews/internal/adapter/outbound/kafka/producer.go            # +4 lines in produce helper
+services/reviews/internal/adapter/outbound/kafka/producer_test.go       # +1 assertion
+
+services/ratings/internal/adapter/outbound/kafka/producer.go            # +4 lines in PublishRatingSubmitted
+services/ratings/internal/adapter/outbound/kafka/producer_test.go       # +1 assertion
+
+services/ingestion/internal/adapter/outbound/kafka/producer.go          # +4 lines in PublishBookAdded
+services/ingestion/internal/adapter/outbound/kafka/producer_test.go     # +1 assertion
+```
+
+## Data flow (target trace tree)
+
+```
+reviews-write-api POST /v1/reviews              [SERVER, parent of all below]
+├── idempotency.CheckAndRecord (DB query)       [INTERNAL via otelpgx]
+├── pool.acquire                                [INTERNAL via otelpgx]
+├── INSERT review                               [INTERNAL via otelpgx]
+└── bookinfo_reviews_events publish             [PRODUCER, NEW, traceparent source]
+    └── eventsource.receive                     [SERVER, argo-events fork]
+        └── eventsource.publish                 [PRODUCER]
+            └── eventbus consume                [CONSUMER]
+                └── trigger HTTP                [CLIENT]
+                    └── notification-api POST   [SERVER]
+```
+
+## Error handling
+
+| Failure | Behavior |
+| --- | --- |
+| Active context has no span | `Start` returns a NoOp span; injection still happens (no-op). Trace tree shows nothing extra; behavior unchanged from today. |
+| `ProduceSync` returns error | `span.RecordError(err)` records exception event; `span.SetStatus(codes.Error, ...)` marks span failed; producer returns wrapped error. Tempo highlights the failed span. |
+| Tracer not registered | `otel.Tracer("kafka-producer")` returns NoOp; `Start` returns NoOp ctx + span; behavior unchanged. |
+
+## Testing
+
+### Unit test for helper (`pkg/telemetry/kafka_test.go`)
+
+```go
+func TestStartProducerSpan_AttributesAndKind(t *testing.T) {
+    otel.SetTracerProvider(sdktrace.NewTracerProvider())
+    otel.SetTextMapPropagator(propagation.TraceContext{})
+
+    ctx, span := telemetry.StartProducerSpan(context.Background(), "my_topic", "my_key")
+    defer span.End()
+
+    if !span.SpanContext().IsValid() {
+        t.Fatal("expected valid span context")
+    }
+    // SpanKind is set on the readonly span; assert via the recording span if SDK exposes it.
+    // For minimal verification: just ensure ctx now carries a span.
+    if trace.SpanFromContext(ctx).SpanContext().TraceID() != span.SpanContext().TraceID() {
+        t.Error("ctx does not carry the started span")
+    }
+}
+```
+
+### Per-producer test extension
+
+Each existing `Test...InjectsTraceparent` test already creates an active span via `otel.Tracer("test").Start`. After the wrap is added, the test continues to pass because the wrap inherits the test's parent span and emits its own child. No assertion change strictly required, but we can add a sanity check that `fc.records[0].Headers["traceparent"]` parses to a different span_id than the test's parent span_id (proving the new span is the immediate parent of the record):
+
+```go
+func TestPublishX_TraceparentParentIsProducerSpan(t *testing.T) {
+    otel.SetTracerProvider(sdktrace.NewTracerProvider())
+    otel.SetTextMapPropagator(propagation.TraceContext{})
+    ctx, parent := otel.Tracer("test").Start(context.Background(), "parent")
+    defer parent.End()
+
+    fc := &fakeClient{}
+    p := kafkaadapter.NewProducerWithClient(fc, "topic")
+    _ = p.PublishX(ctx, /* event */)
+
+    fc.mu.Lock()
+    defer fc.mu.Unlock()
+    var tp string
+    for _, h := range fc.records[0].Headers {
+        if h.Key == "traceparent" {
+            tp = string(h.Value)
+        }
+    }
+    // traceparent format: 00-<trace_id 32hex>-<span_id 16hex>-<flags 2hex>
+    parts := strings.Split(tp, "-")
+    if len(parts) != 4 {
+        t.Fatalf("malformed traceparent: %q", tp)
+    }
+    parentSpanID := parent.SpanContext().SpanID().String()
+    if parts[2] == parentSpanID {
+        t.Errorf("traceparent span_id == parent span_id; expected different (the producer span)")
+    }
+}
+```
+
+This test is optional — the simple presence of `traceparent` (already verified) plus the new helper unit test together prove correctness.
+
+### End-to-end on cluster
+
+After deploy:
+
+1. POST `/v1/reviews` with a unique product_id.
+2. Capture trace_id from `reviews-write` log.
+3. Open Tempo, query the trace_id, verify the span tree includes a `bookinfo_reviews_events publish` PRODUCER span between the api server span and the eventsource.receive span.
+4. Repeat for `book-added`, `review-deleted`, `rating-submitted`.
+
+## Acceptance criteria
+
+1. Helper unit test passes
+2. All four producer tests pass with the new wrap
+3. Cluster smoke test: producer span visible in Tempo for every event type, attributes include `messaging.system=kafka` and `messaging.destination.name=<topic>`
+4. Trace continuity preserved: trace_id matches between producing service and notification service (already verified in prior work; must remain true)
+5. `make lint` clean; `make test` green
+
+## Out of scope
+
+- Switching to `kotel` for franz-go (alternative B from brainstorming)
+- Adding span attributes for CloudEvents `ce_*` headers
+- Consumer-side spans (already handled by argo-events fork's existing PRODUCER/CONSUMER classification)
+- Changing the Kafka source PR 3961 — that's done
+
+## Implementation effort
+
+- Helper: ~12 lines + import
+- 4 producers: ~4 lines wrap each = 16 lines + per-producer import
+- Tests: 1 helper test + (optional) 4 producer test extensions
+- Total diff: ~50 lines across 9 files

--- a/pkg/telemetry/kafka.go
+++ b/pkg/telemetry/kafka.go
@@ -1,0 +1,51 @@
+package telemetry
+
+import (
+	"context"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// kafkaHeaderCarrier adapts a *kgo.Record's Headers slice to TextMapCarrier
+// for W3C trace context propagation.
+type kafkaHeaderCarrier struct {
+	record *kgo.Record
+}
+
+func (c *kafkaHeaderCarrier) Get(key string) string {
+	for _, h := range c.record.Headers {
+		if h.Key == key {
+			return string(h.Value)
+		}
+	}
+	return ""
+}
+
+func (c *kafkaHeaderCarrier) Set(key, value string) {
+	for i := range c.record.Headers {
+		if c.record.Headers[i].Key == key {
+			c.record.Headers[i].Value = []byte(value)
+			return
+		}
+	}
+	c.record.Headers = append(c.record.Headers, kgo.RecordHeader{Key: key, Value: []byte(value)})
+}
+
+func (c *kafkaHeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(c.record.Headers))
+	for _, h := range c.record.Headers {
+		keys = append(keys, h.Key)
+	}
+	return keys
+}
+
+// InjectTraceContext writes W3C traceparent (and tracestate, when set) from
+// ctx into the Kafka record headers via the registered TextMapPropagator.
+// No-op when ctx carries no active span.
+func InjectTraceContext(ctx context.Context, record *kgo.Record) {
+	otel.GetTextMapPropagator().Inject(ctx, &kafkaHeaderCarrier{record: record})
+}
+
+var _ propagation.TextMapCarrier = (*kafkaHeaderCarrier)(nil)

--- a/pkg/telemetry/kafka.go
+++ b/pkg/telemetry/kafka.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // kafkaHeaderCarrier adapts a *kgo.Record's Headers slice to TextMapCarrier
@@ -49,3 +51,19 @@ func InjectTraceContext(ctx context.Context, record *kgo.Record) {
 }
 
 var _ propagation.TextMapCarrier = (*kafkaHeaderCarrier)(nil)
+
+// StartProducerSpan starts a child span for a Kafka publish operation following
+// OTel messaging semantic conventions. The caller must End() the span (use defer).
+// Span name is "<topic> publish"; SpanKind is Producer.
+func StartProducerSpan(ctx context.Context, topic, key string) (context.Context, trace.Span) {
+	return otel.Tracer("kafka-producer").Start(ctx,
+		topic+" publish",
+		trace.WithSpanKind(trace.SpanKindProducer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "kafka"),
+			attribute.String("messaging.destination.name", topic),
+			attribute.String("messaging.operation.type", "publish"),
+			attribute.String("messaging.kafka.message.key", key),
+		),
+	)
+}

--- a/pkg/telemetry/kafka_test.go
+++ b/pkg/telemetry/kafka_test.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
 )
@@ -80,5 +81,42 @@ func TestInjectTraceContext_PreservesExistingHeaders(t *testing.T) {
 	}
 	if !hasTP {
 		t.Error("traceparent was not added")
+	}
+}
+
+func TestStartProducerSpan_AttachesSpanToContext(t *testing.T) {
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	parentCtx, parent := otel.Tracer("test").Start(context.Background(), "parent")
+	defer parent.End()
+
+	ctx, span := telemetry.StartProducerSpan(parentCtx, "my_topic", "my_key")
+	defer span.End()
+
+	// The returned ctx must carry the new span (not the parent).
+	got := trace.SpanFromContext(ctx)
+	if got.SpanContext().SpanID() == parent.SpanContext().SpanID() {
+		t.Fatalf("ctx still references parent span %q; expected new producer span",
+			parent.SpanContext().SpanID().String())
+	}
+	if !got.SpanContext().IsValid() {
+		t.Fatal("returned ctx has no valid span context")
+	}
+	// Trace ID is inherited from parent.
+	if got.SpanContext().TraceID() != parent.SpanContext().TraceID() {
+		t.Errorf("trace_id = %s, want inherited %s",
+			got.SpanContext().TraceID(), parent.SpanContext().TraceID())
+	}
+}
+
+func TestStartProducerSpan_NoParent_StillReturnsValidSpan(t *testing.T) {
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+
+	ctx, span := telemetry.StartProducerSpan(context.Background(), "my_topic", "my_key")
+	defer span.End()
+
+	if !trace.SpanFromContext(ctx).SpanContext().IsValid() {
+		t.Fatal("expected valid span context even without a parent span")
 	}
 }

--- a/pkg/telemetry/kafka_test.go
+++ b/pkg/telemetry/kafka_test.go
@@ -1,0 +1,84 @@
+package telemetry_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
+)
+
+func TestInjectTraceContext_WithActiveSpan_AddsTraceparent(t *testing.T) {
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "parent")
+	defer span.End()
+
+	rec := &kgo.Record{Topic: "t"}
+	telemetry.InjectTraceContext(ctx, rec)
+
+	headers := map[string]string{}
+	for _, h := range rec.Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["traceparent"] == "" {
+		t.Fatal("expected traceparent header, got none")
+	}
+
+	want := span.SpanContext().TraceID().String()
+	got := headers["traceparent"]
+	if len(got) < 35 || got[3:35] != want {
+		t.Errorf("traceparent trace_id = %q, want trace_id %q embedded", got, want)
+	}
+}
+
+func TestInjectTraceContext_NoActiveSpan_NoTraceparent(t *testing.T) {
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	rec := &kgo.Record{Topic: "t"}
+	telemetry.InjectTraceContext(context.Background(), rec)
+
+	for _, h := range rec.Headers {
+		if h.Key == "traceparent" {
+			t.Fatalf("expected no traceparent header, got %q", string(h.Value))
+		}
+	}
+}
+
+func TestInjectTraceContext_PreservesExistingHeaders(t *testing.T) {
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "p")
+	defer span.End()
+
+	rec := &kgo.Record{
+		Topic: "t",
+		Headers: []kgo.RecordHeader{
+			{Key: "ce_type", Value: []byte("com.example.x")},
+		},
+	}
+	telemetry.InjectTraceContext(ctx, rec)
+
+	var hasCE, hasTP bool
+	for _, h := range rec.Headers {
+		if h.Key == "ce_type" {
+			hasCE = true
+		}
+		if h.Key == "traceparent" {
+			hasTP = true
+		}
+	}
+	if !hasCE {
+		t.Error("ce_type header was lost")
+	}
+	if !hasTP {
+		t.Error("traceparent was not added")
+	}
+}

--- a/services/details/cmd/main.go
+++ b/services/details/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/server"
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
 	handler "github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/inbound/http"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/kafka"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/memory"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/postgres"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/port"
@@ -107,7 +108,8 @@ func main() {
 		idemStore = idempotency.NewMemoryStore()
 	}
 
-	svc := service.NewDetailService(repo, idemStore)
+	// TODO(T9): replace NoopPublisher with the real Kafka producer wired from config
+	svc := service.NewDetailService(repo, idemStore, kafka.NewNoopPublisher())
 	h := handler.NewHandler(svc)
 
 	registerRoutes := func(mux *http.ServeMux) {

--- a/services/details/cmd/main.go
+++ b/services/details/cmd/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/server"
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
 	handler "github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/inbound/http"
-	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/kafka"
+	kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/kafka"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/memory"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/postgres"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/port"
@@ -108,8 +108,26 @@ func main() {
 		idemStore = idempotency.NewMemoryStore()
 	}
 
-	// TODO(T9): replace NoopPublisher with the real Kafka producer wired from config
-	svc := service.NewDetailService(repo, idemStore, kafka.NewNoopPublisher())
+	var publisher port.EventPublisher
+	if cfg.KafkaBrokers != "" {
+		kafkaTopic := cfg.KafkaTopic
+		if kafkaTopic == "" {
+			kafkaTopic = "bookinfo_details_events"
+		}
+		kProd, err := kafkaadapter.NewProducer(ctx, cfg.KafkaBrokers, kafkaTopic)
+		if err != nil {
+			logger.Error("failed to create Kafka producer", "error", err)
+			os.Exit(1)
+		}
+		defer kProd.Close()
+		publisher = kProd
+		logger.Info("kafka publisher enabled", "topic", kafkaTopic)
+	} else {
+		publisher = kafkaadapter.NewNoopPublisher()
+		logger.Info("kafka publisher disabled — using no-op")
+	}
+
+	svc := service.NewDetailService(repo, idemStore, publisher)
 	h := handler.NewHandler(svc)
 
 	registerRoutes := func(mux *http.ServeMux) {

--- a/services/details/internal/adapter/inbound/http/handler_test.go
+++ b/services/details/internal/adapter/inbound/http/handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/idempotency"
 	handler "github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/inbound/http"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/kafka"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/memory"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/service"
 )
@@ -16,7 +17,7 @@ import (
 func setupHandler(t *testing.T) *http.ServeMux {
 	t.Helper()
 	repo := memory.NewDetailRepository()
-	svc := service.NewDetailService(repo, idempotency.NewMemoryStore())
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), kafka.NewNoopPublisher())
 	mux := http.NewServeMux()
 	h := handler.NewHandler(svc)
 	h.RegisterRoutes(mux)

--- a/services/details/internal/adapter/outbound/kafka/noop.go
+++ b/services/details/internal/adapter/outbound/kafka/noop.go
@@ -1,0 +1,21 @@
+package kafka
+
+import (
+	"context"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/domain"
+)
+
+// NoopPublisher implements port.EventPublisher but performs no work.
+// Used when KAFKA_BROKERS is not set (e.g. docker-compose, unit tests).
+type NoopPublisher struct{}
+
+// NewNoopPublisher returns a publisher that silently succeeds.
+func NewNoopPublisher() *NoopPublisher { return &NoopPublisher{} }
+
+// PublishBookAdded logs at debug and returns nil.
+func (n *NoopPublisher) PublishBookAdded(ctx context.Context, evt domain.BookAddedEvent) error {
+	logging.FromContext(ctx).Debug("noop publisher: book-added event discarded", "idempotency_key", evt.IdempotencyKey)
+	return nil
+}

--- a/services/details/internal/adapter/outbound/kafka/producer.go
+++ b/services/details/internal/adapter/outbound/kafka/producer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/domain"
 )
 
@@ -116,6 +117,8 @@ func (p *Producer) PublishBookAdded(ctx context.Context, evt domain.BookAddedEve
 			{Key: "content-type", Value: []byte("application/json")},
 		},
 	}
+
+	telemetry.InjectTraceContext(ctx, record)
 
 	results := p.client.ProduceSync(ctx, record)
 	if err := results.FirstErr(); err != nil {

--- a/services/details/internal/adapter/outbound/kafka/producer.go
+++ b/services/details/internal/adapter/outbound/kafka/producer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
@@ -118,10 +119,15 @@ func (p *Producer) PublishBookAdded(ctx context.Context, evt domain.BookAddedEve
 		},
 	}
 
+	ctx, span := telemetry.StartProducerSpan(ctx, p.topic, evt.IdempotencyKey)
+	defer span.End()
+
 	telemetry.InjectTraceContext(ctx, record)
 
 	results := p.client.ProduceSync(ctx, record)
 	if err := results.FirstErr(); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("producing to Kafka: %w", err)
 	}
 

--- a/services/details/internal/adapter/outbound/kafka/producer.go
+++ b/services/details/internal/adapter/outbound/kafka/producer.go
@@ -1,0 +1,153 @@
+// Package kafka implements the EventPublisher port using a native Kafka producer.
+package kafka
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/domain"
+)
+
+const (
+	ceTypeBookAdded = "com.bookinfo.details.book-added"
+	ceSource        = "details"
+	ceVersion       = "1.0"
+
+	defaultPartitions        = 3
+	defaultReplicationFactor = 1
+)
+
+// bookAddedBody is the marshaled Kafka record value for a BookAddedEvent.
+type bookAddedBody struct {
+	ID             string `json:"id,omitempty"`
+	Title          string `json:"title"`
+	Author         string `json:"author"`
+	Year           int    `json:"year"`
+	Type           string `json:"type"`
+	Pages          int    `json:"pages,omitempty"`
+	Publisher      string `json:"publisher,omitempty"`
+	Language       string `json:"language,omitempty"`
+	ISBN10         string `json:"isbn_10,omitempty"`
+	ISBN13         string `json:"isbn_13,omitempty"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+// Client abstracts the franz-go client for testing.
+type Client interface {
+	ProduceSync(ctx context.Context, rs ...*kgo.Record) kgo.ProduceResults
+	Close()
+}
+
+// Producer implements port.EventPublisher by producing to Kafka.
+type Producer struct {
+	client Client
+	topic  string
+}
+
+// NewProducer creates a real Kafka producer connecting to the given brokers.
+// Auto-creates the topic if it does not exist.
+func NewProducer(ctx context.Context, brokers, topic string) (*Producer, error) {
+	seeds := strings.Split(brokers, ",")
+
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(seeds...),
+		kgo.DefaultProduceTopic(topic),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating Kafka client: %w", err)
+	}
+
+	if err := ensureTopic(ctx, client, topic); err != nil {
+		client.Close()
+		return nil, fmt.Errorf("ensuring topic %q: %w", topic, err)
+	}
+
+	return &Producer{client: client, topic: topic}, nil
+}
+
+// NewProducerWithClient creates a Producer with an injected client (for testing).
+func NewProducerWithClient(client Client, topic string) *Producer {
+	return &Producer{client: client, topic: topic}
+}
+
+// PublishBookAdded sends a book-added CloudEvent to Kafka.
+func (p *Producer) PublishBookAdded(ctx context.Context, evt domain.BookAddedEvent) error {
+	logger := logging.FromContext(ctx)
+
+	body := bookAddedBody{
+		ID:             evt.ID,
+		Title:          evt.Title,
+		Author:         evt.Author,
+		Year:           evt.Year,
+		Type:           evt.Type,
+		Pages:          evt.Pages,
+		Publisher:      evt.Publisher,
+		Language:       evt.Language,
+		ISBN10:         evt.ISBN10,
+		ISBN13:         evt.ISBN13,
+		IdempotencyKey: evt.IdempotencyKey,
+	}
+
+	value, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshaling book-added event: %w", err)
+	}
+
+	now := time.Now().UTC()
+	record := &kgo.Record{
+		Topic: p.topic,
+		Key:   []byte(evt.IdempotencyKey),
+		Value: value,
+		Headers: []kgo.RecordHeader{
+			{Key: "ce_specversion", Value: []byte(ceVersion)},
+			{Key: "ce_type", Value: []byte(ceTypeBookAdded)},
+			{Key: "ce_source", Value: []byte(ceSource)},
+			{Key: "ce_id", Value: []byte(uuid.New().String())},
+			{Key: "ce_time", Value: []byte(now.Format(time.RFC3339))},
+			{Key: "ce_subject", Value: []byte(evt.IdempotencyKey)},
+			{Key: "content-type", Value: []byte("application/json")},
+		},
+	}
+
+	results := p.client.ProduceSync(ctx, record)
+	if err := results.FirstErr(); err != nil {
+		return fmt.Errorf("producing to Kafka: %w", err)
+	}
+
+	logger.Debug("published book-added event to Kafka", "topic", p.topic, "idempotency_key", evt.IdempotencyKey)
+	return nil
+}
+
+// Close flushes pending messages and closes the Kafka client.
+func (p *Producer) Close() {
+	p.client.Close()
+}
+
+func ensureTopic(ctx context.Context, client *kgo.Client, topic string) error {
+	admin := kadm.NewClient(client)
+
+	resp, err := admin.CreateTopics(ctx, int32(defaultPartitions), int16(defaultReplicationFactor), nil, topic)
+	if err != nil {
+		return fmt.Errorf("creating topic: %w", err)
+	}
+
+	for _, t := range resp.Sorted() {
+		if t.Err != nil && t.ErrMessage != "" && !isTopicExistsError(t.ErrMessage) {
+			return fmt.Errorf("topic %q: %s", t.Topic, t.ErrMessage)
+		}
+	}
+
+	return nil
+}
+
+func isTopicExistsError(msg string) bool {
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "TOPIC_ALREADY_EXISTS")
+}

--- a/services/details/internal/adapter/outbound/kafka/producer_test.go
+++ b/services/details/internal/adapter/outbound/kafka/producer_test.go
@@ -1,0 +1,143 @@
+package kafka_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/kafka"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/domain"
+)
+
+type fakeClient struct {
+	mu      sync.Mutex
+	records []*kgo.Record
+}
+
+func (f *fakeClient) ProduceSync(_ context.Context, rs ...*kgo.Record) kgo.ProduceResults {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var results kgo.ProduceResults
+	for _, r := range rs {
+		f.records = append(f.records, r)
+		results = append(results, kgo.ProduceResult{Record: r})
+	}
+	return results
+}
+
+func (f *fakeClient) Close() {}
+
+type errorClient struct{}
+
+func (e *errorClient) ProduceSync(_ context.Context, rs ...*kgo.Record) kgo.ProduceResults {
+	var results kgo.ProduceResults
+	for _, r := range rs {
+		results = append(results, kgo.ProduceResult{Record: r, Err: context.DeadlineExceeded})
+	}
+	return results
+}
+
+func (e *errorClient) Close() {}
+
+func TestPublishBookAdded(t *testing.T) {
+	t.Parallel()
+
+	evt := domain.BookAddedEvent{
+		ID:             "det_123",
+		Title:          "The Go Programming Language",
+		Author:         "Alan Donovan, Brian Kernighan",
+		Year:           2015,
+		Type:           "paperback",
+		Pages:          380,
+		Publisher:      "Addison-Wesley",
+		Language:       "en",
+		ISBN10:         "",
+		ISBN13:         "9780134190440",
+		IdempotencyKey: "det-idem-123",
+	}
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_details_events")
+
+	if err := p.PublishBookAdded(context.Background(), evt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	if len(fc.records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(fc.records))
+	}
+	r := fc.records[0]
+
+	if r.Topic != "bookinfo_details_events" {
+		t.Errorf("topic = %q, want %q", r.Topic, "bookinfo_details_events")
+	}
+	if string(r.Key) != evt.IdempotencyKey {
+		t.Errorf("key = %q, want %q", string(r.Key), evt.IdempotencyKey)
+	}
+
+	headers := map[string]string{}
+	for _, h := range r.Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["ce_type"] != "com.bookinfo.details.book-added" {
+		t.Errorf("ce_type = %q, want %q", headers["ce_type"], "com.bookinfo.details.book-added")
+	}
+	if headers["ce_source"] != "details" {
+		t.Errorf("ce_source = %q, want %q", headers["ce_source"], "details")
+	}
+	if headers["ce_specversion"] != "1.0" {
+		t.Errorf("ce_specversion = %q, want %q", headers["ce_specversion"], "1.0")
+	}
+	if headers["ce_subject"] != evt.IdempotencyKey {
+		t.Errorf("ce_subject = %q, want %q", headers["ce_subject"], evt.IdempotencyKey)
+	}
+	if headers["content-type"] != "application/json" {
+		t.Errorf("content-type = %q, want %q", headers["content-type"], "application/json")
+	}
+	if headers["ce_id"] == "" {
+		t.Error("ce_id header is empty, expected a UUID")
+	}
+	if headers["ce_time"] == "" {
+		t.Error("ce_time header is empty, expected RFC3339 timestamp")
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(r.Value, &body); err != nil {
+		t.Fatalf("failed to unmarshal record value: %v", err)
+	}
+	if body["title"] != evt.Title {
+		t.Errorf("body title = %q, want %q", body["title"], evt.Title)
+	}
+	if body["author"] != evt.Author {
+		t.Errorf("body author = %q, want %q", body["author"], evt.Author)
+	}
+	if body["year"].(float64) != float64(evt.Year) {
+		t.Errorf("body year = %v, want %v", body["year"], evt.Year)
+	}
+	if body["isbn_13"] != evt.ISBN13 {
+		t.Errorf("body isbn_13 = %q, want %q", body["isbn_13"], evt.ISBN13)
+	}
+	if body["idempotency_key"] != evt.IdempotencyKey {
+		t.Errorf("body idempotency_key = %q, want %q", body["idempotency_key"], evt.IdempotencyKey)
+	}
+}
+
+func TestPublishBookAdded_ProduceError(t *testing.T) {
+	t.Parallel()
+
+	p := kafkaadapter.NewProducerWithClient(&errorClient{}, "bookinfo_details_events")
+
+	err := p.PublishBookAdded(context.Background(), domain.BookAddedEvent{
+		Title: "t", Author: "a", Year: 2024, Type: "paperback",
+		IdempotencyKey: "idem-x",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/services/details/internal/adapter/outbound/kafka/producer_test.go
+++ b/services/details/internal/adapter/outbound/kafka/producer_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/kafka"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/domain"
@@ -139,5 +142,38 @@ func TestPublishBookAdded_ProduceError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestPublishBookAdded_InjectsTraceparent(t *testing.T) {
+	t.Parallel()
+
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	ctx, span := otel.Tracer("test").Start(context.Background(), "parent")
+	defer span.End()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_details_events")
+
+	if err := p.PublishBookAdded(ctx, domain.BookAddedEvent{
+		Title: "T", Author: "A", Year: 2024, Type: "paperback",
+		IdempotencyKey: "k1",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	headers := map[string]string{}
+	for _, h := range fc.records[0].Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["traceparent"] == "" {
+		t.Fatal("expected traceparent header, got none")
+	}
+	want := span.SpanContext().TraceID().String()
+	if got := headers["traceparent"]; len(got) < 35 || got[3:35] != want {
+		t.Errorf("traceparent = %q, want embedded trace_id %q", got, want)
 	}
 }

--- a/services/details/internal/core/domain/event.go
+++ b/services/details/internal/core/domain/event.go
@@ -1,0 +1,18 @@
+// Package domain contains pure domain types for the details service.
+package domain
+
+// BookAddedEvent is the domain event emitted after a successful AddDetail.
+// Carries the business payload shape consumed by downstream services (e.g. notification).
+type BookAddedEvent struct {
+	ID             string
+	Title          string
+	Author         string
+	Year           int
+	Type           string
+	Pages          int
+	Publisher      string
+	Language       string
+	ISBN10         string
+	ISBN13         string
+	IdempotencyKey string
+}

--- a/services/details/internal/core/port/publisher.go
+++ b/services/details/internal/core/port/publisher.go
@@ -1,0 +1,13 @@
+// file: services/details/internal/core/port/publisher.go
+package port
+
+import (
+	"context"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/domain"
+)
+
+// EventPublisher is the outbound port for emitting domain events to a message broker.
+type EventPublisher interface {
+	PublishBookAdded(ctx context.Context, evt domain.BookAddedEvent) error
+}

--- a/services/details/internal/core/service/detail_service.go
+++ b/services/details/internal/core/service/detail_service.go
@@ -21,11 +21,12 @@ var ErrAlreadyProcessed = errors.New("request already processed")
 type DetailService struct {
 	repo        port.DetailRepository
 	idempotency idempotency.Store
+	publisher   port.EventPublisher
 }
 
-// NewDetailService creates a new DetailService with the given repository.
-func NewDetailService(repo port.DetailRepository, idem idempotency.Store) *DetailService {
-	return &DetailService{repo: repo, idempotency: idem}
+// NewDetailService creates a new DetailService with the given repository, idempotency store, and event publisher.
+func NewDetailService(repo port.DetailRepository, idem idempotency.Store, publisher port.EventPublisher) *DetailService {
+	return &DetailService{repo: repo, idempotency: idem, publisher: publisher}
 }
 
 // GetDetail returns a book detail by ID.
@@ -37,30 +38,50 @@ func (s *DetailService) GetDetail(ctx context.Context, id string) (*domain.Detai
 	return detail, nil
 }
 
-// AddDetail creates and persists a new book detail. Deduplicates on idempotencyKey
-// (falls back to a natural key derived from title+author+year+bookType+pages+publisher+language+isbn10+isbn13).
+// AddDetail creates and persists a new book detail, then publishes a BookAddedEvent.
+// Always publishes (even on idempotency dedup) so that a retry after a Kafka blip still delivers the event.
 func (s *DetailService) AddDetail(ctx context.Context, title, author string, year int, bookType string, pages int, publisher, language, isbn10, isbn13, idempotencyKey string) (*domain.Detail, error) {
 	key := idempotency.Resolve(idempotencyKey, title, author, strconv.Itoa(year), bookType, strconv.Itoa(pages), publisher, language, isbn10, isbn13)
-
-	alreadyProcessed, err := s.idempotency.CheckAndRecord(ctx, key)
-	if err != nil {
-		return nil, fmt.Errorf("checking idempotency: %w", err)
-	}
-	if alreadyProcessed {
-		logger := logging.FromContext(ctx)
-		logger.Info("detail add skipped: already processed", slog.String("idempotency_key", key))
-		return nil, ErrAlreadyProcessed
-	}
 
 	detail, err := domain.NewDetail(title, author, year, bookType, pages, publisher, language, isbn10, isbn13)
 	if err != nil {
 		return nil, fmt.Errorf("creating detail: %w", err)
 	}
 
-	if err := s.repo.Save(ctx, detail); err != nil {
-		return nil, fmt.Errorf("saving detail: %w", err)
+	alreadyProcessed, err := s.idempotency.CheckAndRecord(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("checking idempotency: %w", err)
 	}
 
+	if !alreadyProcessed {
+		if err := s.repo.Save(ctx, detail); err != nil {
+			return nil, fmt.Errorf("saving detail: %w", err)
+		}
+	} else {
+		logger := logging.FromContext(ctx)
+		logger.Info("detail save skipped: already processed", slog.String("idempotency_key", key))
+	}
+
+	evt := domain.BookAddedEvent{
+		ID:             detail.ID,
+		Title:          detail.Title,
+		Author:         detail.Author,
+		Year:           detail.Year,
+		Type:           detail.Type,
+		Pages:          detail.Pages,
+		Publisher:      detail.Publisher,
+		Language:       detail.Language,
+		ISBN10:         detail.ISBN10,
+		ISBN13:         detail.ISBN13,
+		IdempotencyKey: key,
+	}
+	if err := s.publisher.PublishBookAdded(ctx, evt); err != nil {
+		return nil, fmt.Errorf("publishing book-added event: %w", err)
+	}
+
+	if alreadyProcessed {
+		return nil, ErrAlreadyProcessed
+	}
 	return detail, nil
 }
 

--- a/services/details/internal/core/service/detail_service_idempotency_test.go
+++ b/services/details/internal/core/service/detail_service_idempotency_test.go
@@ -13,7 +13,7 @@ import (
 func TestAddDetail_Idempotent(t *testing.T) {
 	ctx := context.Background()
 	repo := memory.NewDetailRepository()
-	svc := service.NewDetailService(repo, idempotency.NewMemoryStore())
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), &fakePublisher{})
 
 	// Call twice with the same explicit key; expect ErrAlreadyProcessed on second.
 	_, err := svc.AddDetail(ctx,
@@ -35,7 +35,7 @@ func TestAddDetail_Idempotent(t *testing.T) {
 func TestAddDetail_NaturalKey(t *testing.T) {
 	ctx := context.Background()
 	repo := memory.NewDetailRepository()
-	svc := service.NewDetailService(repo, idempotency.NewMemoryStore())
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), &fakePublisher{})
 
 	_, err := svc.AddDetail(ctx,
 		"Book One", "Jane Doe", 2024, "paperback",

--- a/services/details/internal/core/service/detail_service_test.go
+++ b/services/details/internal/core/service/detail_service_test.go
@@ -3,16 +3,33 @@ package service_test
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/idempotency"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/adapter/outbound/memory"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/domain"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/details/internal/core/service"
 )
 
+type fakePublisher struct {
+	mu       sync.Mutex
+	calls    []domain.BookAddedEvent
+	forceErr error
+}
+
+func (f *fakePublisher) PublishBookAdded(_ context.Context, evt domain.BookAddedEvent) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, evt)
+	return f.forceErr
+}
+
 func TestAddDetail_Success(t *testing.T) {
 	repo := memory.NewDetailRepository()
-	svc := service.NewDetailService(repo, idempotency.NewMemoryStore())
+	pub := &fakePublisher{}
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), pub)
 
 	detail, err := svc.AddDetail(context.Background(),
 		"The Art of Go", "Jane Doe", 2024, "paperback",
@@ -21,18 +38,26 @@ func TestAddDetail_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 	if detail.ID == "" {
 		t.Error("expected non-empty ID")
 	}
 	if detail.Title != "The Art of Go" {
 		t.Errorf("Title = %q, want %q", detail.Title, "The Art of Go")
 	}
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if len(pub.calls) != 1 {
+		t.Fatalf("expected 1 publish call, got %d", len(pub.calls))
+	}
+	if pub.calls[0].Title != "The Art of Go" {
+		t.Errorf("event Title = %q, want %q", pub.calls[0].Title, "The Art of Go")
+	}
 }
 
 func TestAddDetail_ValidationError(t *testing.T) {
 	repo := memory.NewDetailRepository()
-	svc := service.NewDetailService(repo, idempotency.NewMemoryStore())
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), &fakePublisher{})
 
 	_, err := svc.AddDetail(context.Background(),
 		"", "Jane Doe", 2024, "paperback",
@@ -45,7 +70,7 @@ func TestAddDetail_ValidationError(t *testing.T) {
 
 func TestGetDetail_Found(t *testing.T) {
 	repo := memory.NewDetailRepository()
-	svc := service.NewDetailService(repo, idempotency.NewMemoryStore())
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), &fakePublisher{})
 
 	created, err := svc.AddDetail(context.Background(),
 		"The Art of Go", "Jane Doe", 2024, "paperback",
@@ -54,26 +79,68 @@ func TestGetDetail_Found(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating: %v", err)
 	}
-
 	found, err := svc.GetDetail(context.Background(), created.ID)
 	if err != nil {
 		t.Fatalf("unexpected error getting: %v", err)
 	}
-
 	if found.ID != created.ID {
 		t.Errorf("ID = %q, want %q", found.ID, created.ID)
-	}
-	if found.Title != "The Art of Go" {
-		t.Errorf("Title = %q, want %q", found.Title, "The Art of Go")
 	}
 }
 
 func TestGetDetail_NotFound(t *testing.T) {
 	repo := memory.NewDetailRepository()
-	svc := service.NewDetailService(repo, idempotency.NewMemoryStore())
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), &fakePublisher{})
 
 	_, err := svc.GetDetail(context.Background(), "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for nonexistent detail")
+	}
+}
+
+func TestAddDetail_PublishesOnIdempotencyDedup(t *testing.T) {
+	repo := memory.NewDetailRepository()
+	pub := &fakePublisher{}
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), pub)
+
+	args := []interface{}{
+		"The Art of Go", "Jane Doe", 2024, "paperback",
+		350, "Go Press", "English", "1234567890", "1234567890123", "fixed-key",
+	}
+
+	_, err := svc.AddDetail(context.Background(),
+		args[0].(string), args[1].(string), args[2].(int), args[3].(string),
+		args[4].(int), args[5].(string), args[6].(string), args[7].(string), args[8].(string), args[9].(string),
+	)
+	if err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+
+	// Second call with same idempotency key
+	_, err = svc.AddDetail(context.Background(),
+		args[0].(string), args[1].(string), args[2].(int), args[3].(string),
+		args[4].(int), args[5].(string), args[6].(string), args[7].(string), args[8].(string), args[9].(string),
+	)
+	if !errors.Is(err, service.ErrAlreadyProcessed) {
+		t.Fatalf("second call: expected ErrAlreadyProcessed, got %v", err)
+	}
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if len(pub.calls) != 2 {
+		t.Fatalf("expected 2 publish calls (one per attempt), got %d", len(pub.calls))
+	}
+}
+
+func TestAddDetail_PublishErrorPropagates(t *testing.T) {
+	repo := memory.NewDetailRepository()
+	pub := &fakePublisher{forceErr: errors.New("kafka down")}
+	svc := service.NewDetailService(repo, idempotency.NewMemoryStore(), pub)
+
+	_, err := svc.AddDetail(context.Background(),
+		"Test", "Author", 2024, "paperback", 10, "Pub", "en", "", "9780000000002", "",
+	)
+	if err == nil {
+		t.Fatal("expected publish error to propagate, got nil")
 	}
 }

--- a/services/ingestion/internal/adapter/outbound/kafka/producer.go
+++ b/services/ingestion/internal/adapter/outbound/kafka/producer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/ingestion/internal/core/domain"
 )
 
@@ -117,6 +118,8 @@ func (p *Producer) PublishBookAdded(ctx context.Context, book domain.Book) error
 			{Key: "content-type", Value: []byte("application/json")},
 		},
 	}
+
+	telemetry.InjectTraceContext(ctx, record)
 
 	results := p.client.ProduceSync(ctx, record)
 	if err := results.FirstErr(); err != nil {

--- a/services/ingestion/internal/adapter/outbound/kafka/producer.go
+++ b/services/ingestion/internal/adapter/outbound/kafka/producer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
@@ -119,10 +120,15 @@ func (p *Producer) PublishBookAdded(ctx context.Context, book domain.Book) error
 		},
 	}
 
+	ctx, span := telemetry.StartProducerSpan(ctx, p.topic, book.ISBN)
+	defer span.End()
+
 	telemetry.InjectTraceContext(ctx, record)
 
 	results := p.client.ProduceSync(ctx, record)
 	if err := results.FirstErr(); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("producing to Kafka: %w", err)
 	}
 

--- a/services/ingestion/internal/adapter/outbound/kafka/producer_test.go
+++ b/services/ingestion/internal/adapter/outbound/kafka/producer_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/ingestion/internal/adapter/outbound/kafka"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/ingestion/internal/core/domain"
@@ -185,3 +188,39 @@ func (e *errorClient) ProduceSync(_ context.Context, rs ...*kgo.Record) kgo.Prod
 }
 
 func (e *errorClient) Close() {}
+
+func TestPublishBookAdded_InjectsTraceparent(t *testing.T) {
+	t.Parallel()
+
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	ctx, span := otel.Tracer("test").Start(context.Background(), "parent")
+	defer span.End()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "raw_books_details")
+
+	book := domain.Book{
+		Title:       "T",
+		Authors:     []string{"A"},
+		ISBN:        "9780000000099",
+		PublishYear: 2024,
+	}
+	if err := p.PublishBookAdded(ctx, book); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	headers := map[string]string{}
+	for _, h := range fc.records[0].Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["traceparent"] == "" {
+		t.Fatal("expected traceparent header, got none")
+	}
+	want := span.SpanContext().TraceID().String()
+	if got := headers["traceparent"]; len(got) < 35 || got[3:35] != want {
+		t.Errorf("traceparent = %q, want embedded trace_id %q", got, want)
+	}
+}

--- a/services/ratings/cmd/main.go
+++ b/services/ratings/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/server"
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
 	handler "github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/adapter/inbound/http"
+	kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/adapter/outbound/kafka"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/adapter/outbound/memory"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/adapter/outbound/postgres"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/port"
@@ -107,7 +108,26 @@ func main() {
 		idemStore = idempotency.NewMemoryStore()
 	}
 
-	svc := service.NewRatingService(repo, idemStore)
+	var publisher port.EventPublisher
+	if cfg.KafkaBrokers != "" {
+		topic := cfg.KafkaTopic
+		if topic == "" {
+			topic = "bookinfo_ratings_events"
+		}
+		kProd, err := kafkaadapter.NewProducer(ctx, cfg.KafkaBrokers, topic)
+		if err != nil {
+			logger.Error("failed to create Kafka producer", "error", err)
+			os.Exit(1)
+		}
+		defer kProd.Close()
+		publisher = kProd
+		logger.Info("kafka publisher enabled", "topic", topic)
+	} else {
+		publisher = kafkaadapter.NewNoopPublisher()
+		logger.Info("kafka publisher disabled — using no-op")
+	}
+
+	svc := service.NewRatingService(repo, idemStore, publisher)
 	h := handler.NewHandler(svc)
 
 	registerRoutes := func(mux *http.ServeMux) {

--- a/services/ratings/internal/adapter/inbound/http/handler_test.go
+++ b/services/ratings/internal/adapter/inbound/http/handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/idempotency"
 	handler "github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/adapter/inbound/http"
+	kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/adapter/outbound/kafka"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/adapter/outbound/memory"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/service"
 )
@@ -17,7 +18,7 @@ import (
 func setupHandler(t *testing.T) *http.ServeMux {
 	t.Helper()
 	repo := memory.NewRatingRepository()
-	svc := service.NewRatingService(repo, idempotency.NewMemoryStore())
+	svc := service.NewRatingService(repo, idempotency.NewMemoryStore(), kafkaadapter.NewNoopPublisher())
 	mux := http.NewServeMux()
 	h := handler.NewHandler(svc)
 	h.RegisterRoutes(mux)

--- a/services/ratings/internal/adapter/outbound/kafka/noop.go
+++ b/services/ratings/internal/adapter/outbound/kafka/noop.go
@@ -1,0 +1,20 @@
+package kafka
+
+import (
+	"context"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/domain"
+)
+
+// NoopPublisher implements port.EventPublisher without side effects.
+type NoopPublisher struct{}
+
+// NewNoopPublisher returns a no-op publisher.
+func NewNoopPublisher() *NoopPublisher { return &NoopPublisher{} }
+
+// PublishRatingSubmitted logs at debug and returns nil.
+func (n *NoopPublisher) PublishRatingSubmitted(ctx context.Context, evt domain.RatingSubmittedEvent) error {
+	logging.FromContext(ctx).Debug("noop publisher: rating-submitted discarded", "idempotency_key", evt.IdempotencyKey)
+	return nil
+}

--- a/services/ratings/internal/adapter/outbound/kafka/producer.go
+++ b/services/ratings/internal/adapter/outbound/kafka/producer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
@@ -102,9 +103,15 @@ func (p *Producer) PublishRatingSubmitted(ctx context.Context, evt domain.Rating
 		},
 	}
 
+	ctx, span := telemetry.StartProducerSpan(ctx, p.topic, evt.IdempotencyKey)
+	defer span.End()
+
 	telemetry.InjectTraceContext(ctx, record)
+
 	results := p.client.ProduceSync(ctx, record)
 	if err := results.FirstErr(); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("producing to Kafka: %w", err)
 	}
 

--- a/services/ratings/internal/adapter/outbound/kafka/producer.go
+++ b/services/ratings/internal/adapter/outbound/kafka/producer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/domain"
 )
 
@@ -101,6 +102,7 @@ func (p *Producer) PublishRatingSubmitted(ctx context.Context, evt domain.Rating
 		},
 	}
 
+	telemetry.InjectTraceContext(ctx, record)
 	results := p.client.ProduceSync(ctx, record)
 	if err := results.FirstErr(); err != nil {
 		return fmt.Errorf("producing to Kafka: %w", err)

--- a/services/ratings/internal/adapter/outbound/kafka/producer.go
+++ b/services/ratings/internal/adapter/outbound/kafka/producer.go
@@ -1,0 +1,132 @@
+// Package kafka implements the EventPublisher port using a native Kafka producer.
+package kafka
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/domain"
+)
+
+const (
+	ceTypeRatingSubmitted = "com.bookinfo.ratings.rating-submitted"
+	ceSource              = "ratings"
+	ceVersion             = "1.0"
+
+	defaultPartitions        = 3
+	defaultReplicationFactor = 1
+)
+
+type submittedBody struct {
+	ID             string `json:"id,omitempty"`
+	ProductID      string `json:"product_id"`
+	Reviewer       string `json:"reviewer"`
+	Stars          int    `json:"stars"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+// Client abstracts the franz-go client for testing.
+type Client interface {
+	ProduceSync(ctx context.Context, rs ...*kgo.Record) kgo.ProduceResults
+	Close()
+}
+
+// Producer emits ratings domain events to Kafka.
+type Producer struct {
+	client Client
+	topic  string
+}
+
+// NewProducer creates a real producer connecting to the brokers. Creates topic if missing.
+func NewProducer(ctx context.Context, brokers, topic string) (*Producer, error) {
+	seeds := strings.Split(brokers, ",")
+	client, err := kgo.NewClient(kgo.SeedBrokers(seeds...), kgo.DefaultProduceTopic(topic))
+	if err != nil {
+		return nil, fmt.Errorf("creating Kafka client: %w", err)
+	}
+	if err := ensureTopic(ctx, client, topic); err != nil {
+		client.Close()
+		return nil, fmt.Errorf("ensuring topic %q: %w", topic, err)
+	}
+	return &Producer{client: client, topic: topic}, nil
+}
+
+// NewProducerWithClient creates a Producer with an injected client (for tests).
+func NewProducerWithClient(client Client, topic string) *Producer {
+	return &Producer{client: client, topic: topic}
+}
+
+// PublishRatingSubmitted sends a rating-submitted CloudEvent to Kafka.
+func (p *Producer) PublishRatingSubmitted(ctx context.Context, evt domain.RatingSubmittedEvent) error {
+	logger := logging.FromContext(ctx)
+
+	body := submittedBody{
+		ID:             evt.ID,
+		ProductID:      evt.ProductID,
+		Reviewer:       evt.Reviewer,
+		Stars:          evt.Stars,
+		IdempotencyKey: evt.IdempotencyKey,
+	}
+	value, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshaling rating-submitted event: %w", err)
+	}
+
+	recordKey := []byte(evt.ProductID)
+	if len(recordKey) == 0 {
+		recordKey = []byte(evt.IdempotencyKey)
+	}
+
+	now := time.Now().UTC()
+	record := &kgo.Record{
+		Topic: p.topic,
+		Key:   recordKey,
+		Value: value,
+		Headers: []kgo.RecordHeader{
+			{Key: "ce_specversion", Value: []byte(ceVersion)},
+			{Key: "ce_type", Value: []byte(ceTypeRatingSubmitted)},
+			{Key: "ce_source", Value: []byte(ceSource)},
+			{Key: "ce_id", Value: []byte(uuid.New().String())},
+			{Key: "ce_time", Value: []byte(now.Format(time.RFC3339))},
+			{Key: "ce_subject", Value: []byte(evt.IdempotencyKey)},
+			{Key: "content-type", Value: []byte("application/json")},
+		},
+	}
+
+	results := p.client.ProduceSync(ctx, record)
+	if err := results.FirstErr(); err != nil {
+		return fmt.Errorf("producing to Kafka: %w", err)
+	}
+
+	logger.Debug("published rating-submitted event", "topic", p.topic, "idempotency_key", evt.IdempotencyKey)
+	return nil
+}
+
+// Close flushes pending messages and closes the Kafka client.
+func (p *Producer) Close() { p.client.Close() }
+
+func ensureTopic(ctx context.Context, client *kgo.Client, topic string) error {
+	admin := kadm.NewClient(client)
+	resp, err := admin.CreateTopics(ctx, int32(defaultPartitions), int16(defaultReplicationFactor), nil, topic)
+	if err != nil {
+		return fmt.Errorf("creating topic: %w", err)
+	}
+	for _, t := range resp.Sorted() {
+		if t.Err != nil && t.ErrMessage != "" && !isTopicExistsError(t.ErrMessage) {
+			return fmt.Errorf("topic %q: %s", t.Topic, t.ErrMessage)
+		}
+	}
+	return nil
+}
+
+func isTopicExistsError(msg string) bool {
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "TOPIC_ALREADY_EXISTS")
+}

--- a/services/ratings/internal/adapter/outbound/kafka/producer_test.go
+++ b/services/ratings/internal/adapter/outbound/kafka/producer_test.go
@@ -1,0 +1,73 @@
+package kafka_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/adapter/outbound/kafka"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/domain"
+)
+
+type fakeClient struct {
+	mu      sync.Mutex
+	records []*kgo.Record
+}
+
+func (f *fakeClient) ProduceSync(_ context.Context, rs ...*kgo.Record) kgo.ProduceResults {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var results kgo.ProduceResults
+	for _, r := range rs {
+		f.records = append(f.records, r)
+		results = append(results, kgo.ProduceResult{Record: r})
+	}
+	return results
+}
+
+func (f *fakeClient) Close() {}
+
+func TestPublishRatingSubmitted(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_ratings_events")
+
+	evt := domain.RatingSubmittedEvent{
+		ID: "rat_1", ProductID: "prod-42", Reviewer: "alice", Stars: 5,
+		IdempotencyKey: "rat-idem-1",
+	}
+	if err := p.PublishRatingSubmitted(context.Background(), evt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if len(fc.records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(fc.records))
+	}
+	r := fc.records[0]
+
+	headers := map[string]string{}
+	for _, h := range r.Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["ce_type"] != "com.bookinfo.ratings.rating-submitted" {
+		t.Errorf("ce_type = %q", headers["ce_type"])
+	}
+	if headers["ce_source"] != "ratings" {
+		t.Errorf("ce_source = %q", headers["ce_source"])
+	}
+
+	var body map[string]interface{}
+	_ = json.Unmarshal(r.Value, &body)
+	if body["product_id"] != "prod-42" {
+		t.Errorf("product_id = %v", body["product_id"])
+	}
+	if body["stars"].(float64) != 5 {
+		t.Errorf("stars = %v", body["stars"])
+	}
+}

--- a/services/ratings/internal/adapter/outbound/kafka/producer_test.go
+++ b/services/ratings/internal/adapter/outbound/kafka/producer_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/adapter/outbound/kafka"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/domain"
@@ -69,5 +72,37 @@ func TestPublishRatingSubmitted(t *testing.T) {
 	}
 	if body["stars"].(float64) != 5 {
 		t.Errorf("stars = %v", body["stars"])
+	}
+}
+
+func TestPublishRatingSubmitted_InjectsTraceparent(t *testing.T) {
+	t.Parallel()
+
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	ctx, span := otel.Tracer("test").Start(context.Background(), "parent")
+	defer span.End()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_ratings_events")
+
+	if err := p.PublishRatingSubmitted(ctx, domain.RatingSubmittedEvent{
+		ID: "rt1", ProductID: "p", Reviewer: "u", Stars: 5, IdempotencyKey: "k1",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	headers := map[string]string{}
+	for _, h := range fc.records[0].Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["traceparent"] == "" {
+		t.Fatal("expected traceparent header, got none")
+	}
+	want := span.SpanContext().TraceID().String()
+	if got := headers["traceparent"]; len(got) < 35 || got[3:35] != want {
+		t.Errorf("traceparent = %q, want embedded trace_id %q", got, want)
 	}
 }

--- a/services/ratings/internal/core/domain/event.go
+++ b/services/ratings/internal/core/domain/event.go
@@ -1,0 +1,10 @@
+package domain
+
+// RatingSubmittedEvent is emitted after a successful SubmitRating.
+type RatingSubmittedEvent struct {
+	ID             string
+	ProductID      string
+	Reviewer       string
+	Stars          int
+	IdempotencyKey string
+}

--- a/services/ratings/internal/core/port/publisher.go
+++ b/services/ratings/internal/core/port/publisher.go
@@ -1,0 +1,12 @@
+package port
+
+import (
+	"context"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/domain"
+)
+
+// EventPublisher is the outbound port for emitting rating domain events.
+type EventPublisher interface {
+	PublishRatingSubmitted(ctx context.Context, evt domain.RatingSubmittedEvent) error
+}

--- a/services/ratings/internal/core/service/rating_service.go
+++ b/services/ratings/internal/core/service/rating_service.go
@@ -21,11 +21,12 @@ var ErrAlreadyProcessed = errors.New("request already processed")
 type RatingService struct {
 	repo        port.RatingRepository
 	idempotency idempotency.Store
+	publisher   port.EventPublisher
 }
 
-// NewRatingService creates a new RatingService with the given repository.
-func NewRatingService(repo port.RatingRepository, idem idempotency.Store) *RatingService {
-	return &RatingService{repo: repo, idempotency: idem}
+// NewRatingService creates a new RatingService with the given repository, idempotency store, and event publisher.
+func NewRatingService(repo port.RatingRepository, idem idempotency.Store, publisher port.EventPublisher) *RatingService {
+	return &RatingService{repo: repo, idempotency: idem, publisher: publisher}
 }
 
 // GetProductRatings returns all ratings aggregated for a product.
@@ -34,36 +35,45 @@ func (s *RatingService) GetProductRatings(ctx context.Context, productID string)
 	if err != nil {
 		return nil, fmt.Errorf("finding ratings for product %s: %w", productID, err)
 	}
-
-	return &domain.ProductRatings{
-		ProductID: productID,
-		Ratings:   ratings,
-	}, nil
+	return &domain.ProductRatings{ProductID: productID, Ratings: ratings}, nil
 }
 
-// SubmitRating creates and persists a new rating. Deduplicates on idempotencyKey
-// (falls back to a natural key derived from productID+reviewer+stars).
+// SubmitRating creates and persists a new rating, then publishes a RatingSubmittedEvent.
+// Always publishes (even on idempotency dedup) for retry safety.
 func (s *RatingService) SubmitRating(ctx context.Context, productID, reviewer string, stars int, idempotencyKey string) (*domain.Rating, error) {
 	key := idempotency.Resolve(idempotencyKey, productID, reviewer, strconv.Itoa(stars))
-
-	alreadyProcessed, err := s.idempotency.CheckAndRecord(ctx, key)
-	if err != nil {
-		return nil, fmt.Errorf("checking idempotency: %w", err)
-	}
-	if alreadyProcessed {
-		logger := logging.FromContext(ctx)
-		logger.Info("rating submit skipped: already processed", slog.String("idempotency_key", key))
-		return nil, ErrAlreadyProcessed
-	}
 
 	rating, err := domain.NewRating(productID, reviewer, stars)
 	if err != nil {
 		return nil, fmt.Errorf("creating rating: %w", err)
 	}
 
-	if err := s.repo.Save(ctx, rating); err != nil {
-		return nil, fmt.Errorf("saving rating: %w", err)
+	alreadyProcessed, err := s.idempotency.CheckAndRecord(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("checking idempotency: %w", err)
 	}
 
+	if !alreadyProcessed {
+		if err := s.repo.Save(ctx, rating); err != nil {
+			return nil, fmt.Errorf("saving rating: %w", err)
+		}
+	} else {
+		logging.FromContext(ctx).Info("rating submit skipped: already processed", slog.String("idempotency_key", key))
+	}
+
+	evt := domain.RatingSubmittedEvent{
+		ID:             rating.ID,
+		ProductID:      rating.ProductID,
+		Reviewer:       rating.Reviewer,
+		Stars:          rating.Stars,
+		IdempotencyKey: key,
+	}
+	if err := s.publisher.PublishRatingSubmitted(ctx, evt); err != nil {
+		return nil, fmt.Errorf("publishing rating-submitted event: %w", err)
+	}
+
+	if alreadyProcessed {
+		return nil, ErrAlreadyProcessed
+	}
 	return rating, nil
 }

--- a/services/ratings/internal/core/service/rating_service_idempotency_test.go
+++ b/services/ratings/internal/core/service/rating_service_idempotency_test.go
@@ -13,7 +13,7 @@ import (
 func TestSubmitRating_Idempotent(t *testing.T) {
 	ctx := context.Background()
 	repo := memory.NewRatingRepository()
-	svc := service.NewRatingService(repo, idempotency.NewMemoryStore())
+	svc := service.NewRatingService(repo, idempotency.NewMemoryStore(), &fakeRatingPublisher{})
 
 	// Call twice with the same explicit key; expect ErrAlreadyProcessed on second.
 	_, err := svc.SubmitRating(ctx, "product-1", "alice", 5, "key-1")
@@ -29,7 +29,7 @@ func TestSubmitRating_Idempotent(t *testing.T) {
 func TestSubmitRating_NaturalKey(t *testing.T) {
 	ctx := context.Background()
 	repo := memory.NewRatingRepository()
-	svc := service.NewRatingService(repo, idempotency.NewMemoryStore())
+	svc := service.NewRatingService(repo, idempotency.NewMemoryStore(), &fakeRatingPublisher{})
 
 	_, err := svc.SubmitRating(ctx, "p1", "bob", 4, "")
 	if err != nil {

--- a/services/ratings/internal/core/service/rating_service_test.go
+++ b/services/ratings/internal/core/service/rating_service_test.go
@@ -3,16 +3,30 @@ package service_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/idempotency"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/adapter/outbound/memory"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/domain"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/ratings/internal/core/service"
 )
 
+type fakeRatingPublisher struct {
+	mu    sync.Mutex
+	calls []domain.RatingSubmittedEvent
+}
+
+func (f *fakeRatingPublisher) PublishRatingSubmitted(_ context.Context, evt domain.RatingSubmittedEvent) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, evt)
+	return nil
+}
+
 func TestSubmitRating_Success(t *testing.T) {
 	repo := memory.NewRatingRepository()
-	svc := service.NewRatingService(repo, idempotency.NewMemoryStore())
+	svc := service.NewRatingService(repo, idempotency.NewMemoryStore(), &fakeRatingPublisher{})
 
 	rating, err := svc.SubmitRating(context.Background(), "product-1", "alice", 5, "")
 	if err != nil {
@@ -35,7 +49,7 @@ func TestSubmitRating_Success(t *testing.T) {
 
 func TestSubmitRating_ValidationError(t *testing.T) {
 	repo := memory.NewRatingRepository()
-	svc := service.NewRatingService(repo, idempotency.NewMemoryStore())
+	svc := service.NewRatingService(repo, idempotency.NewMemoryStore(), &fakeRatingPublisher{})
 
 	tests := []struct {
 		name      string
@@ -61,7 +75,7 @@ func TestSubmitRating_ValidationError(t *testing.T) {
 
 func TestGetProductRatings_Empty(t *testing.T) {
 	repo := memory.NewRatingRepository()
-	svc := service.NewRatingService(repo, idempotency.NewMemoryStore())
+	svc := service.NewRatingService(repo, idempotency.NewMemoryStore(), &fakeRatingPublisher{})
 
 	pr, err := svc.GetProductRatings(context.Background(), "nonexistent")
 	if err != nil {
@@ -81,7 +95,7 @@ func TestGetProductRatings_Empty(t *testing.T) {
 
 func TestGetProductRatings_WithRatings(t *testing.T) {
 	repo := memory.NewRatingRepository()
-	svc := service.NewRatingService(repo, idempotency.NewMemoryStore())
+	svc := service.NewRatingService(repo, idempotency.NewMemoryStore(), &fakeRatingPublisher{})
 
 	_, err := svc.SubmitRating(context.Background(), "product-1", "alice", 4, "")
 	if err != nil {

--- a/services/reviews/cmd/main.go
+++ b/services/reviews/cmd/main.go
@@ -111,8 +111,26 @@ func main() {
 
 	ratingsURL := envOrDefault("RATINGS_SERVICE_URL", "http://localhost:8080")
 	ratingsClient := ratingshttp.NewRatingsClient(ratingsURL)
-	// TODO(T16): replace NoopPublisher with the real franz-go Kafka producer.
-	publisher := reviewskafka.NewNoopPublisher()
+
+	var publisher port.EventPublisher
+	if cfg.KafkaBrokers != "" {
+		topic := cfg.KafkaTopic
+		if topic == "" {
+			topic = "bookinfo_reviews_events"
+		}
+		kProd, err := reviewskafka.NewProducer(ctx, cfg.KafkaBrokers, topic)
+		if err != nil {
+			logger.Error("failed to create Kafka producer", "error", err)
+			os.Exit(1)
+		}
+		defer kProd.Close()
+		publisher = kProd
+		logger.Info("kafka publisher enabled", "topic", topic)
+	} else {
+		publisher = reviewskafka.NewNoopPublisher()
+		logger.Info("kafka publisher disabled — using no-op")
+	}
+
 	svc := service.NewReviewService(repo, ratingsClient, idemStore, publisher)
 	h := handler.NewHandler(svc)
 

--- a/services/reviews/cmd/main.go
+++ b/services/reviews/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
 	handler "github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/inbound/http"
 	ratingshttp "github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/outbound/http"
+	reviewskafka "github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/outbound/kafka"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/outbound/memory"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/outbound/postgres"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/port"
@@ -110,7 +111,9 @@ func main() {
 
 	ratingsURL := envOrDefault("RATINGS_SERVICE_URL", "http://localhost:8080")
 	ratingsClient := ratingshttp.NewRatingsClient(ratingsURL)
-	svc := service.NewReviewService(repo, ratingsClient, idemStore)
+	// TODO(T16): replace NoopPublisher with the real franz-go Kafka producer.
+	publisher := reviewskafka.NewNoopPublisher()
+	svc := service.NewReviewService(repo, ratingsClient, idemStore, publisher)
 	h := handler.NewHandler(svc)
 
 	registerRoutes := func(mux *http.ServeMux) {

--- a/services/reviews/internal/adapter/inbound/http/handler.go
+++ b/services/reviews/internal/adapter/inbound/http/handler.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
-	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/port"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/service"
 )
@@ -129,20 +128,14 @@ func (h *Handler) deleteReview(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, ErrorResponse{Error: "review_id is required"})
 		return
 	}
-	reviewID := req.ReviewID
 
-	err := h.svc.DeleteReview(r.Context(), reviewID)
-	if err != nil {
-		if errors.Is(err, domain.ErrNotFound) {
-			writeJSON(w, http.StatusNotFound, ErrorResponse{Error: "review not found"})
-			return
-		}
-		logger.Error("failed to delete review", "error", err, "review_id", reviewID)
+	if err := h.svc.DeleteReview(r.Context(), req.ReviewID); err != nil {
+		logger.Error("failed to delete review", "error", err, "review_id", req.ReviewID)
 		writeJSON(w, http.StatusInternalServerError, ErrorResponse{Error: "internal error"})
 		return
 	}
 
-	logger.Info("review deleted", "review_id", reviewID)
+	logger.Info("review deleted", "review_id", req.ReviewID)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/services/reviews/internal/adapter/inbound/http/handler_test.go
+++ b/services/reviews/internal/adapter/inbound/http/handler_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/idempotency"
 	handler "github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/inbound/http"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/outbound/kafka"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/outbound/memory"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/service"
@@ -38,7 +39,7 @@ func setupHandler(t *testing.T) *http.ServeMux {
 			},
 		},
 	}
-	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore())
+	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore(), kafka.NewNoopPublisher())
 	mux := http.NewServeMux()
 	h := handler.NewHandler(svc)
 	h.RegisterRoutes(mux)
@@ -324,6 +325,8 @@ func TestDeleteReview_Success(t *testing.T) {
 	}
 }
 
+// TestDeleteReview_NotFound verifies that deleting a non-existent review is idempotent:
+// the endpoint returns 204 No Content rather than 404, enabling safe sensor retries.
 func TestDeleteReview_NotFound(t *testing.T) {
 	mux := setupHandler(t)
 
@@ -333,7 +336,7 @@ func TestDeleteReview_NotFound(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusNotFound {
-		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNoContent)
 	}
 }

--- a/services/reviews/internal/adapter/outbound/kafka/noop.go
+++ b/services/reviews/internal/adapter/outbound/kafka/noop.go
@@ -1,0 +1,26 @@
+package kafka
+
+import (
+	"context"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+)
+
+// NoopPublisher implements port.EventPublisher without side effects.
+type NoopPublisher struct{}
+
+// NewNoopPublisher returns a no-op publisher.
+func NewNoopPublisher() *NoopPublisher { return &NoopPublisher{} }
+
+// PublishReviewSubmitted logs at debug and returns nil.
+func (n *NoopPublisher) PublishReviewSubmitted(ctx context.Context, evt domain.ReviewSubmittedEvent) error {
+	logging.FromContext(ctx).Debug("noop publisher: review-submitted discarded", "idempotency_key", evt.IdempotencyKey)
+	return nil
+}
+
+// PublishReviewDeleted logs at debug and returns nil.
+func (n *NoopPublisher) PublishReviewDeleted(ctx context.Context, evt domain.ReviewDeletedEvent) error {
+	logging.FromContext(ctx).Debug("noop publisher: review-deleted discarded", "idempotency_key", evt.IdempotencyKey)
+	return nil
+}

--- a/services/reviews/internal/adapter/outbound/kafka/producer.go
+++ b/services/reviews/internal/adapter/outbound/kafka/producer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
@@ -123,9 +124,15 @@ func (p *Producer) produce(ctx context.Context, ceType, key, partitionHint strin
 		},
 	}
 
+	ctx, span := telemetry.StartProducerSpan(ctx, p.topic, key)
+	defer span.End()
+
 	telemetry.InjectTraceContext(ctx, record)
+
 	results := p.client.ProduceSync(ctx, record)
 	if err := results.FirstErr(); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("producing to Kafka: %w", err)
 	}
 

--- a/services/reviews/internal/adapter/outbound/kafka/producer.go
+++ b/services/reviews/internal/adapter/outbound/kafka/producer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/telemetry"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
 )
 
@@ -122,6 +123,7 @@ func (p *Producer) produce(ctx context.Context, ceType, key, partitionHint strin
 		},
 	}
 
+	telemetry.InjectTraceContext(ctx, record)
 	results := p.client.ProduceSync(ctx, record)
 	if err := results.FirstErr(); err != nil {
 		return fmt.Errorf("producing to Kafka: %w", err)

--- a/services/reviews/internal/adapter/outbound/kafka/producer.go
+++ b/services/reviews/internal/adapter/outbound/kafka/producer.go
@@ -1,0 +1,153 @@
+// Package kafka implements the EventPublisher port using a native Kafka producer.
+package kafka
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+)
+
+const (
+	ceTypeReviewSubmitted = "com.bookinfo.reviews.review-submitted"
+	ceTypeReviewDeleted   = "com.bookinfo.reviews.review-deleted"
+	ceSource              = "reviews"
+	ceVersion             = "1.0"
+
+	defaultPartitions        = 3
+	defaultReplicationFactor = 1
+)
+
+type submittedBody struct {
+	ID             string `json:"id,omitempty"`
+	ProductID      string `json:"product_id"`
+	Reviewer       string `json:"reviewer"`
+	Text           string `json:"text"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+type deletedBody struct {
+	ReviewID       string `json:"review_id"`
+	ProductID      string `json:"product_id,omitempty"`
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+// Client abstracts the franz-go client for testing.
+type Client interface {
+	ProduceSync(ctx context.Context, rs ...*kgo.Record) kgo.ProduceResults
+	Close()
+}
+
+// Producer emits reviews domain events to Kafka.
+type Producer struct {
+	client Client
+	topic  string
+}
+
+// NewProducer creates a real producer connecting to the brokers. Creates topic if missing.
+func NewProducer(ctx context.Context, brokers, topic string) (*Producer, error) {
+	seeds := strings.Split(brokers, ",")
+	client, err := kgo.NewClient(kgo.SeedBrokers(seeds...), kgo.DefaultProduceTopic(topic))
+	if err != nil {
+		return nil, fmt.Errorf("creating Kafka client: %w", err)
+	}
+	if err := ensureTopic(ctx, client, topic); err != nil {
+		client.Close()
+		return nil, fmt.Errorf("ensuring topic %q: %w", topic, err)
+	}
+	return &Producer{client: client, topic: topic}, nil
+}
+
+// NewProducerWithClient creates a Producer with an injected client (for tests).
+func NewProducerWithClient(client Client, topic string) *Producer {
+	return &Producer{client: client, topic: topic}
+}
+
+// PublishReviewSubmitted sends a review-submitted CloudEvent to Kafka.
+func (p *Producer) PublishReviewSubmitted(ctx context.Context, evt domain.ReviewSubmittedEvent) error {
+	body := submittedBody{
+		ID:             evt.ID,
+		ProductID:      evt.ProductID,
+		Reviewer:       evt.Reviewer,
+		Text:           evt.Text,
+		IdempotencyKey: evt.IdempotencyKey,
+	}
+	return p.produce(ctx, ceTypeReviewSubmitted, evt.IdempotencyKey, evt.ProductID, body)
+}
+
+// PublishReviewDeleted sends a review-deleted CloudEvent to Kafka.
+func (p *Producer) PublishReviewDeleted(ctx context.Context, evt domain.ReviewDeletedEvent) error {
+	body := deletedBody{
+		ReviewID:       evt.ReviewID,
+		ProductID:      evt.ProductID,
+		IdempotencyKey: evt.IdempotencyKey,
+	}
+	return p.produce(ctx, ceTypeReviewDeleted, evt.IdempotencyKey, evt.ProductID, body)
+}
+
+func (p *Producer) produce(ctx context.Context, ceType, key, partitionHint string, body any) error {
+	logger := logging.FromContext(ctx)
+
+	value, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshaling event: %w", err)
+	}
+
+	recordKey := []byte(partitionHint)
+	if len(recordKey) == 0 {
+		recordKey = []byte(key)
+	}
+
+	now := time.Now().UTC()
+	record := &kgo.Record{
+		Topic: p.topic,
+		Key:   recordKey,
+		Value: value,
+		Headers: []kgo.RecordHeader{
+			{Key: "ce_specversion", Value: []byte(ceVersion)},
+			{Key: "ce_type", Value: []byte(ceType)},
+			{Key: "ce_source", Value: []byte(ceSource)},
+			{Key: "ce_id", Value: []byte(uuid.New().String())},
+			{Key: "ce_time", Value: []byte(now.Format(time.RFC3339))},
+			{Key: "ce_subject", Value: []byte(key)},
+			{Key: "content-type", Value: []byte("application/json")},
+		},
+	}
+
+	results := p.client.ProduceSync(ctx, record)
+	if err := results.FirstErr(); err != nil {
+		return fmt.Errorf("producing to Kafka: %w", err)
+	}
+
+	logger.Debug("published reviews event", "topic", p.topic, "ce_type", ceType, "idempotency_key", key)
+	return nil
+}
+
+// Close flushes and closes the underlying client.
+func (p *Producer) Close() { p.client.Close() }
+
+func ensureTopic(ctx context.Context, client *kgo.Client, topic string) error {
+	admin := kadm.NewClient(client)
+	resp, err := admin.CreateTopics(ctx, int32(defaultPartitions), int16(defaultReplicationFactor), nil, topic)
+	if err != nil {
+		return fmt.Errorf("creating topic: %w", err)
+	}
+	for _, t := range resp.Sorted() {
+		if t.Err != nil && t.ErrMessage != "" && !isTopicExistsError(t.ErrMessage) {
+			return fmt.Errorf("topic %q: %s", t.Topic, t.ErrMessage)
+		}
+	}
+	return nil
+}
+
+func isTopicExistsError(msg string) bool {
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "TOPIC_ALREADY_EXISTS")
+}

--- a/services/reviews/internal/adapter/outbound/kafka/producer_test.go
+++ b/services/reviews/internal/adapter/outbound/kafka/producer_test.go
@@ -1,0 +1,101 @@
+package kafka_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/outbound/kafka"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+)
+
+type fakeClient struct {
+	mu      sync.Mutex
+	records []*kgo.Record
+}
+
+func (f *fakeClient) ProduceSync(_ context.Context, rs ...*kgo.Record) kgo.ProduceResults {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var results kgo.ProduceResults
+	for _, r := range rs {
+		f.records = append(f.records, r)
+		results = append(results, kgo.ProduceResult{Record: r})
+	}
+	return results
+}
+
+func (f *fakeClient) Close() {}
+
+func TestPublishReviewSubmitted(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_reviews_events")
+
+	evt := domain.ReviewSubmittedEvent{
+		ID: "rev_1", ProductID: "prod-42", Reviewer: "alice", Text: "Great",
+		IdempotencyKey: "rev-idem-1",
+	}
+	if err := p.PublishReviewSubmitted(context.Background(), evt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if len(fc.records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(fc.records))
+	}
+	r := fc.records[0]
+	headers := map[string]string{}
+	for _, h := range r.Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["ce_type"] != "com.bookinfo.reviews.review-submitted" {
+		t.Errorf("ce_type = %q", headers["ce_type"])
+	}
+	if headers["ce_source"] != "reviews" {
+		t.Errorf("ce_source = %q", headers["ce_source"])
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(r.Value, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["product_id"] != "prod-42" {
+		t.Errorf("body product_id = %v, want %q", body["product_id"], "prod-42")
+	}
+	if body["reviewer"] != "alice" {
+		t.Errorf("body reviewer = %v", body["reviewer"])
+	}
+}
+
+func TestPublishReviewDeleted(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_reviews_events")
+
+	evt := domain.ReviewDeletedEvent{ReviewID: "rev_99", ProductID: "prod-42", IdempotencyKey: "del-idem-1"}
+	if err := p.PublishReviewDeleted(context.Background(), evt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	r := fc.records[0]
+	headers := map[string]string{}
+	for _, h := range r.Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["ce_type"] != "com.bookinfo.reviews.review-deleted" {
+		t.Errorf("ce_type = %q", headers["ce_type"])
+	}
+	var body map[string]interface{}
+	_ = json.Unmarshal(r.Value, &body)
+	if body["review_id"] != "rev_99" {
+		t.Errorf("body review_id = %v", body["review_id"])
+	}
+}

--- a/services/reviews/internal/adapter/outbound/kafka/producer_test.go
+++ b/services/reviews/internal/adapter/outbound/kafka/producer_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	kafkaadapter "github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/outbound/kafka"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
@@ -97,5 +100,37 @@ func TestPublishReviewDeleted(t *testing.T) {
 	_ = json.Unmarshal(r.Value, &body)
 	if body["review_id"] != "rev_99" {
 		t.Errorf("body review_id = %v", body["review_id"])
+	}
+}
+
+func TestPublishReviewSubmitted_InjectsTraceparent(t *testing.T) {
+	t.Parallel()
+
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	ctx, span := otel.Tracer("test").Start(context.Background(), "parent")
+	defer span.End()
+
+	fc := &fakeClient{}
+	p := kafkaadapter.NewProducerWithClient(fc, "bookinfo_reviews_events")
+
+	if err := p.PublishReviewSubmitted(ctx, domain.ReviewSubmittedEvent{
+		ID: "r1", ProductID: "p", Reviewer: "u", Text: "ok", IdempotencyKey: "k1",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	headers := map[string]string{}
+	for _, h := range fc.records[0].Headers {
+		headers[h.Key] = string(h.Value)
+	}
+	if headers["traceparent"] == "" {
+		t.Fatal("expected traceparent header, got none")
+	}
+	want := span.SpanContext().TraceID().String()
+	if got := headers["traceparent"]; len(got) < 35 || got[3:35] != want {
+		t.Errorf("traceparent = %q, want embedded trace_id %q", got, want)
 	}
 }

--- a/services/reviews/internal/core/domain/event.go
+++ b/services/reviews/internal/core/domain/event.go
@@ -1,0 +1,17 @@
+package domain
+
+// ReviewSubmittedEvent is emitted after a successful SubmitReview.
+type ReviewSubmittedEvent struct {
+	ID             string
+	ProductID      string
+	Reviewer       string
+	Text           string
+	IdempotencyKey string
+}
+
+// ReviewDeletedEvent is emitted after a successful DeleteReview.
+type ReviewDeletedEvent struct {
+	ReviewID       string
+	ProductID      string
+	IdempotencyKey string
+}

--- a/services/reviews/internal/core/port/publisher.go
+++ b/services/reviews/internal/core/port/publisher.go
@@ -1,0 +1,13 @@
+package port
+
+import (
+	"context"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+)
+
+// EventPublisher is the outbound port for emitting review domain events.
+type EventPublisher interface {
+	PublishReviewSubmitted(ctx context.Context, evt domain.ReviewSubmittedEvent) error
+	PublishReviewDeleted(ctx context.Context, evt domain.ReviewDeletedEvent) error
+}

--- a/services/reviews/internal/core/service/helpers_test.go
+++ b/services/reviews/internal/core/service/helpers_test.go
@@ -1,0 +1,29 @@
+package service_test
+
+import (
+	"context"
+	"sync"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+)
+
+type fakeReviewPublisher struct {
+	mu        sync.Mutex
+	submitted []domain.ReviewSubmittedEvent
+	deleted   []domain.ReviewDeletedEvent
+	forceErr  error
+}
+
+func (f *fakeReviewPublisher) PublishReviewSubmitted(_ context.Context, evt domain.ReviewSubmittedEvent) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.submitted = append(f.submitted, evt)
+	return f.forceErr
+}
+
+func (f *fakeReviewPublisher) PublishReviewDeleted(_ context.Context, evt domain.ReviewDeletedEvent) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleted = append(f.deleted, evt)
+	return f.forceErr
+}

--- a/services/reviews/internal/core/service/review_service.go
+++ b/services/reviews/internal/core/service/review_service.go
@@ -21,14 +21,16 @@ type ReviewService struct {
 	repo          port.ReviewRepository
 	ratingsClient port.RatingsClient
 	idempotency   idempotency.Store
+	publisher     port.EventPublisher
 }
 
 // NewReviewService creates a new ReviewService.
-func NewReviewService(repo port.ReviewRepository, ratingsClient port.RatingsClient, idem idempotency.Store) *ReviewService {
+func NewReviewService(repo port.ReviewRepository, ratingsClient port.RatingsClient, idem idempotency.Store, publisher port.EventPublisher) *ReviewService {
 	return &ReviewService{
 		repo:          repo,
 		ratingsClient: ratingsClient,
 		idempotency:   idem,
+		publisher:     publisher,
 	}
 }
 
@@ -62,37 +64,60 @@ func (s *ReviewService) GetProductReviews(ctx context.Context, productID string,
 	return reviews, total, nil
 }
 
-// SubmitReview creates and persists a new review. Deduplicates on idempotencyKey
-// (falls back to a natural key derived from productID+reviewer+text).
+// SubmitReview creates and persists a new review, then publishes a ReviewSubmittedEvent.
+// Always publishes (even on idempotency dedup) for retry safety.
 func (s *ReviewService) SubmitReview(ctx context.Context, productID, reviewer, text, idempotencyKey string) (*domain.Review, error) {
 	key := idempotency.Resolve(idempotencyKey, productID, reviewer, text)
-
-	alreadyProcessed, err := s.idempotency.CheckAndRecord(ctx, key)
-	if err != nil {
-		return nil, fmt.Errorf("checking idempotency: %w", err)
-	}
-	if alreadyProcessed {
-		logger := logging.FromContext(ctx)
-		logger.Info("review submit skipped: already processed", slog.String("idempotency_key", key))
-		return nil, ErrAlreadyProcessed
-	}
 
 	review, err := domain.NewReview(productID, reviewer, text)
 	if err != nil {
 		return nil, fmt.Errorf("creating review: %w", err)
 	}
 
-	if err := s.repo.Save(ctx, review); err != nil {
-		return nil, fmt.Errorf("saving review: %w", err)
+	alreadyProcessed, err := s.idempotency.CheckAndRecord(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("checking idempotency: %w", err)
 	}
 
+	if !alreadyProcessed {
+		if err := s.repo.Save(ctx, review); err != nil {
+			return nil, fmt.Errorf("saving review: %w", err)
+		}
+	} else {
+		logging.FromContext(ctx).Info("review submit skipped: already processed", slog.String("idempotency_key", key))
+	}
+
+	evt := domain.ReviewSubmittedEvent{
+		ID:             review.ID,
+		ProductID:      review.ProductID,
+		Reviewer:       review.Reviewer,
+		Text:           review.Text,
+		IdempotencyKey: key,
+	}
+	if err := s.publisher.PublishReviewSubmitted(ctx, evt); err != nil {
+		return nil, fmt.Errorf("publishing review-submitted event: %w", err)
+	}
+
+	if alreadyProcessed {
+		return nil, ErrAlreadyProcessed
+	}
 	return review, nil
 }
 
-// DeleteReview removes a review by its ID.
+// DeleteReview removes a review by its ID and publishes a ReviewDeletedEvent.
+// Idempotent: if the review does not exist, returns nil and still publishes.
+// This is required for Option B retry semantics.
 func (s *ReviewService) DeleteReview(ctx context.Context, id string) error {
-	if err := s.repo.DeleteByID(ctx, id); err != nil {
+	if err := s.repo.DeleteByID(ctx, id); err != nil && !errors.Is(err, domain.ErrNotFound) {
 		return fmt.Errorf("deleting review %s: %w", id, err)
+	}
+
+	evt := domain.ReviewDeletedEvent{
+		ReviewID:       id,
+		IdempotencyKey: "review-deleted-" + id,
+	}
+	if err := s.publisher.PublishReviewDeleted(ctx, evt); err != nil {
+		return fmt.Errorf("publishing review-deleted event: %w", err)
 	}
 	return nil
 }

--- a/services/reviews/internal/core/service/review_service_idempotency_test.go
+++ b/services/reviews/internal/core/service/review_service_idempotency_test.go
@@ -13,7 +13,7 @@ import (
 func TestSubmitReview_Idempotent(t *testing.T) {
 	ctx := context.Background()
 	repo := memory.NewReviewRepository()
-	svc := service.NewReviewService(repo, nil, idempotency.NewMemoryStore())
+	svc := service.NewReviewService(repo, nil, idempotency.NewMemoryStore(), &fakeReviewPublisher{})
 
 	_, err := svc.SubmitReview(ctx, "p1", "alice", "great book", "key-1")
 	if err != nil {
@@ -29,7 +29,7 @@ func TestSubmitReview_Idempotent(t *testing.T) {
 func TestSubmitReview_NaturalKey(t *testing.T) {
 	ctx := context.Background()
 	repo := memory.NewReviewRepository()
-	svc := service.NewReviewService(repo, nil, idempotency.NewMemoryStore())
+	svc := service.NewReviewService(repo, nil, idempotency.NewMemoryStore(), &fakeReviewPublisher{})
 
 	_, err := svc.SubmitReview(ctx, "p1", "bob", "good", "")
 	if err != nil {

--- a/services/reviews/internal/core/service/review_service_test.go
+++ b/services/reviews/internal/core/service/review_service_test.go
@@ -227,4 +227,3 @@ func TestDeleteReview_PublishesEvent(t *testing.T) {
 		t.Errorf("ReviewID = %q", pub.deleted[0].ReviewID)
 	}
 }
-

--- a/services/reviews/internal/core/service/review_service_test.go
+++ b/services/reviews/internal/core/service/review_service_test.go
@@ -3,7 +3,6 @@ package service_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -25,7 +24,7 @@ func (s *stubRatingsClient) GetProductRatings(_ context.Context, _ string) (*dom
 func TestSubmitReview_Success(t *testing.T) {
 	repo := memory.NewReviewRepository()
 	client := &stubRatingsClient{}
-	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore())
+	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore(), &fakeReviewPublisher{})
 
 	review, err := svc.SubmitReview(context.Background(), "product-1", "alice", "Great book!", "")
 	if err != nil {
@@ -42,7 +41,7 @@ func TestSubmitReview_Success(t *testing.T) {
 func TestSubmitReview_ValidationError(t *testing.T) {
 	repo := memory.NewReviewRepository()
 	client := &stubRatingsClient{}
-	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore())
+	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore(), &fakeReviewPublisher{})
 
 	tests := []struct {
 		name      string
@@ -70,7 +69,7 @@ func TestGetProductReviews_Empty(t *testing.T) {
 	client := &stubRatingsClient{
 		data: &domain.RatingData{Average: 0, Count: 0, IndividualRatings: map[string]int{}},
 	}
-	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore())
+	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore(), &fakeReviewPublisher{})
 
 	reviews, total, err := svc.GetProductReviews(context.Background(), "nonexistent", 1, 10)
 	if err != nil {
@@ -92,7 +91,7 @@ func TestGetProductReviews_WithRatings(t *testing.T) {
 			IndividualRatings: map[string]int{"alice": 5, "bob": 2},
 		},
 	}
-	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore())
+	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore(), &fakeReviewPublisher{})
 
 	_, _ = svc.SubmitReview(context.Background(), "product-1", "alice", "Excellent!", "")
 	_, _ = svc.SubmitReview(context.Background(), "product-1", "bob", "Good read", "")
@@ -124,7 +123,7 @@ func TestGetProductReviews_Pagination(t *testing.T) {
 	client := &stubRatingsClient{
 		data: &domain.RatingData{Average: 4.0, Count: 15, IndividualRatings: map[string]int{}},
 	}
-	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore())
+	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore(), &fakeReviewPublisher{})
 
 	for i := 0; i < 15; i++ {
 		_, _ = svc.SubmitReview(context.Background(), "product-1", "reviewer", fmt.Sprintf("review text %d", i), "")
@@ -162,7 +161,8 @@ func TestGetProductReviews_Pagination(t *testing.T) {
 func TestDeleteReview_Success(t *testing.T) {
 	repo := memory.NewReviewRepository()
 	client := &stubRatingsClient{}
-	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore())
+	pub := &fakeReviewPublisher{}
+	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore(), pub)
 
 	review, _ := svc.SubmitReview(context.Background(), "product-1", "alice", "Great book!", "")
 	err := svc.DeleteReview(context.Background(), review.ID)
@@ -177,15 +177,54 @@ func TestDeleteReview_Success(t *testing.T) {
 	if len(reviews) != 0 {
 		t.Errorf("expected empty reviews after delete, got %d", len(reviews))
 	}
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if len(pub.deleted) != 1 {
+		t.Fatalf("expected 1 deleted publish, got %d", len(pub.deleted))
+	}
+	if pub.deleted[0].ReviewID != review.ID {
+		t.Errorf("ReviewID = %q, want %q", pub.deleted[0].ReviewID, review.ID)
+	}
 }
 
+// TestDeleteReview_NotFound verifies that deleting a non-existent review is a no-op (idempotent)
+// and still publishes the event — required for Option B sensor retry semantics.
 func TestDeleteReview_NotFound(t *testing.T) {
 	repo := memory.NewReviewRepository()
 	client := &stubRatingsClient{}
-	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore())
+	pub := &fakeReviewPublisher{}
+	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore(), pub)
 
 	err := svc.DeleteReview(context.Background(), "nonexistent-id")
-	if !errors.Is(err, domain.ErrNotFound) {
-		t.Errorf("expected ErrNotFound, got %v", err)
+	if err != nil {
+		t.Fatalf("expected nil (idempotent delete), got: %v", err)
+	}
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if len(pub.deleted) != 1 {
+		t.Fatalf("expected 1 deleted publish even for missing review, got %d", len(pub.deleted))
 	}
 }
+
+func TestDeleteReview_PublishesEvent(t *testing.T) {
+	repo := memory.NewReviewRepository()
+	pub := &fakeReviewPublisher{}
+	svc := service.NewReviewService(repo, nil, idempotency.NewMemoryStore(), pub)
+
+	// Deleting a non-existent review succeeds and still publishes.
+	if err := svc.DeleteReview(context.Background(), "rev_missing"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if len(pub.deleted) != 1 {
+		t.Fatalf("expected 1 deleted publish, got %d", len(pub.deleted))
+	}
+	if pub.deleted[0].ReviewID != "rev_missing" {
+		t.Errorf("ReviewID = %q", pub.deleted[0].ReviewID)
+	}
+}
+


### PR DESCRIPTION
## Summary

Replace parallel \`notify-*\` sensor triggers (which fired notifications regardless of write outcome) with Kafka events emitted by write services after successful persistence. Notification consumes events via Argo Events with \`ce_type\` filtering, ensuring notifications only fire for actually persisted writes.

**Bug fixed:** Today, CQRS sensors for details/reviews/ratings fan out \`create-*\` and \`notify-*\` triggers in parallel. Argo Events runs sensor triggers concurrently, so notifications shipped even when writes failed.

**New flow:** write services publish a CloudEvents-formatted event to Kafka after \`Save\` returns. Notification subscribes via Argo Events Consumer Sensor with \`ce_type\` filtering. \`notify-*\` triggers removed from CQRS sensors.

Spec: \`docs/superpowers/specs/2026-04-24-event-driven-notifications-design.md\`
Plan: \`docs/superpowers/plans/2026-04-24-event-driven-notifications.md\`

## What changed

**Chart (\`charts/bookinfo-service\`):**
- New optional \`events.exposed.<key>.eventTypes\` list — rendered as \`bookinfo.io/emitted-ce-types\` annotation on EventSource
- New optional \`events.consumed.<key>.filter.ceType\` — rendered as Argo Events sensor data filter on \`headers.ce_type\` path
- Fix: EventSource pod now runs as the service's ServiceAccount (was \`default\`, breaking leader election)

**Producer services (details, reviews, ratings):**
- New \`port.EventPublisher\` outbound port + \`franz-go\` Kafka adapter (mirrors ingestion pattern)
- New \`NoopPublisher\` for docker-compose / unit tests
- Service layer always-publishes after the idempotency branch (Option B retry semantics)
- \`DeleteReview\` now idempotent (returns success on \`ErrNotFound\`) and always publishes — required for sensor retry safety after a Kafka blip

**Helm values:**
- \`details/reviews/ratings/values-local.yaml\`: add \`events.exposed.events\`, drop \`notify-*\` triggers
- \`notification/values-local.yaml\`: 4 new \`events.consumed\` entries with \`ce_type\` filters

**Topics & event types:**

| Producer | Topic | \`ce_type\` |
|---|---|---|
| details-write | \`bookinfo_details_events\` | \`com.bookinfo.details.book-added\` |
| reviews-write | \`bookinfo_reviews_events\` | \`com.bookinfo.reviews.review-submitted\`, \`.review-deleted\` |
| ratings-write | \`bookinfo_ratings_events\` | \`com.bookinfo.ratings.rating-submitted\` |

## End-to-end validation (local k8s)

POSTed each event type, confirmed full chain:

\`\`\`
gateway → CQRS sensor → write service → Kafka topic → Argo Events EventSource
       → notification consumer sensor (ce_type filter) → notification-write → Postgres
\`\`\`

Verified all four notification types persisted with correct subject mapping:
- \`book-added\`: subject = book title
- \`review-submitted\`: subject = product_id
- \`review-deleted\`: subject = review_id
- \`rating-submitted\`: subject = product_id

## Test plan

- [x] Unit tests for producer adapters (each service's \`producer_test.go\` mirrors ingestion's pattern)
- [x] Service-layer tests with fake publisher assert publish on dedup retry
- [x] \`make test\` — all packages pass
- [x] \`make lint\` — clean
- [x] \`make helm-lint\` — clean across all 7 services
- [x] \`make run-k8s\` — full deploy
- [x] Smoke tests for all 4 event types end-to-end (notifications persisted)
- [ ] Kafka outage retry test (deferred — Option B retry semantics covered by sensor \`retryStrategy\` + always-publish service code)
- [ ] Tempo trace inspection (deferred — manual verification in Grafana)

🤖 Generated with [Claude Code](https://claude.com/claude-code)