### PR TITLE
fix(reviews): order product reviews newest-first via created_at

### DIFF
--- a/docs/superpowers/plans/2026-04-26-reviews-chronological-ordering.md
+++ b/docs/superpowers/plans/2026-04-26-reviews-chronological-ordering.md
@@ -1,0 +1,854 @@
+# Reviews Chronological Ordering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reviews returned by `GET /v1/reviews/{productID}` are ordered newest-first across both postgres and memory adapters.
+
+**Architecture:** Add a `created_at TIMESTAMPTZ` column to the `reviews` table (with a composite index `(product_id, created_at DESC, id)` to support the new ORDER BY), thread a `CreatedAt time.Time` field through `domain.Review`, set it in `ReviewService.SubmitReview`, and update both adapters to honor the order. Surface the field in `ReviewResponse` for clients.
+
+**Tech Stack:** Go 1.25, `github.com/jackc/pgx/v5`, `github.com/golang-migrate/migrate/v4`, in-memory `sort.SliceStable`.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-reviews-chronological-ordering-design.md`
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `services/reviews/migrations/003_add_created_at.up.sql` | NEW | Add `created_at` column + composite index |
+| `services/reviews/migrations/003_add_created_at.down.sql` | NEW | Reverse migration |
+| `services/reviews/internal/core/domain/review.go` | MODIFY | Add `CreatedAt time.Time` to `Review` |
+| `services/reviews/internal/core/service/review_service.go` | MODIFY | Set `review.CreatedAt` in `SubmitReview` |
+| `services/reviews/internal/core/service/review_service_test.go` | MODIFY | Add ordering test against memory adapter |
+| `services/reviews/internal/adapter/outbound/memory/review_repository.go` | MODIFY | Propagate `CreatedAt`, sort newest-first |
+| `services/reviews/internal/adapter/outbound/memory/review_repository_test.go` | MODIFY | Add `TestFindByProductID_OrdersNewestFirst` |
+| `services/reviews/internal/adapter/outbound/postgres/review_repository.go` | MODIFY | INSERT/SELECT/Scan changes |
+| `services/reviews/internal/adapter/inbound/http/dto.go` | MODIFY | Add `CreatedAt` to `ReviewResponse` |
+| `services/reviews/internal/adapter/inbound/http/handler.go` | MODIFY | Set `CreatedAt` in two inline `ReviewResponse` constructions |
+
+---
+
+## Task 1: Add migration files
+
+**Files:**
+- Create: `services/reviews/migrations/003_add_created_at.up.sql`
+- Create: `services/reviews/migrations/003_add_created_at.down.sql`
+
+The migrations are auto-applied at service startup via `database.RunMigrations`, which already discovers files via the `embed.FS` in `services/reviews/migrations/embed.go` (matches `*.sql`). No code changes needed there.
+
+- [ ] **Step 1: Create the up migration**
+
+Write `services/reviews/migrations/003_add_created_at.up.sql`:
+
+```sql
+ALTER TABLE reviews ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+DROP INDEX IF EXISTS idx_reviews_product_id;
+CREATE INDEX idx_reviews_product_id_created_at ON reviews (product_id, created_at DESC, id);
+```
+
+- [ ] **Step 2: Create the down migration**
+
+Write `services/reviews/migrations/003_add_created_at.down.sql`:
+
+```sql
+DROP INDEX IF EXISTS idx_reviews_product_id_created_at;
+CREATE INDEX idx_reviews_product_id ON reviews (product_id);
+ALTER TABLE reviews DROP COLUMN IF EXISTS created_at;
+```
+
+- [ ] **Step 3: Verify the embed picks them up**
+
+Run: `cd services/reviews && go build ./migrations/...`
+Expected: build succeeds, no errors. (The `//go:embed *.sql` directive auto-includes the new files.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/reviews/migrations/003_add_created_at.up.sql services/reviews/migrations/003_add_created_at.down.sql
+git commit -s -m "feat(reviews): add created_at column and composite index migration
+
+Adds migration 003: created_at TIMESTAMPTZ NOT NULL DEFAULT now() plus
+composite index (product_id, created_at DESC, id) to support
+chronological ordering of reviews per product. Drops the old single-
+column idx_reviews_product_id.
+"
+```
+
+---
+
+## Task 2: Add `CreatedAt` to `domain.Review`
+
+**Files:**
+- Modify: `services/reviews/internal/core/domain/review.go`
+
+The struct currently has `ID, ProductID, Reviewer, Text, Rating`. Adding `CreatedAt time.Time` is purely additive — `NewReview` does NOT take the timestamp (the service sets it; first-write wins on idempotent replay). No tests exist for this struct directly; the value is exercised by service and adapter tests in later tasks.
+
+- [ ] **Step 1: Add `time` import and `CreatedAt` field**
+
+Edit `services/reviews/internal/core/domain/review.go`:
+
+Replace the `import` block:
+```go
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+```
+
+with:
+```go
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+```
+
+Replace the `Review` struct:
+```go
+// Review represents a user review for a product.
+type Review struct {
+	ID        string
+	ProductID string
+	Reviewer  string
+	Text      string
+	Rating    *ReviewRating
+}
+```
+
+with:
+```go
+// Review represents a user review for a product.
+type Review struct {
+	ID        string
+	ProductID string
+	Reviewer  string
+	Text      string
+	CreatedAt time.Time
+	Rating    *ReviewRating
+}
+```
+
+`NewReview` is left unchanged; the service is responsible for setting `CreatedAt` after construction (Task 3).
+
+- [ ] **Step 2: Verify the package builds**
+
+Run: `cd services/reviews && go build ./internal/core/domain/...`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/reviews/internal/core/domain/review.go
+git commit -s -m "feat(reviews): add CreatedAt to Review domain struct
+
+Adds CreatedAt time.Time so the service can stamp creation time on
+new reviews. NewReview does not take it as an argument — the service
+sets it after construction so the constructor signature stays stable
+for existing callers and idempotent replay paths.
+"
+```
+
+---
+
+## Task 3: Set `CreatedAt` in `SubmitReview` + service-layer ordering test
+
+**Files:**
+- Modify: `services/reviews/internal/core/service/review_service.go`
+- Modify: `services/reviews/internal/core/service/review_service_test.go`
+
+`SubmitReview` calls `domain.NewReview(...)` at line 72, then runs the idempotency check, then `s.repo.Save(ctx, review)` at line 83. The timestamp goes between `NewReview` and the idempotency check — set it before either branch so it's populated whether or not we end up saving (it's harmless to set on the dedup branch since we don't pass `review` anywhere observable).
+
+- [ ] **Step 1: Read `services/reviews/internal/core/service/review_service.go`**
+
+Confirm the structure around `SubmitReview`. The relevant snippet (lines 69-105):
+
+```go
+func (s *ReviewService) SubmitReview(ctx context.Context, productID, reviewer, text, idempotencyKey string) (*domain.Review, error) {
+	key := idempotency.Resolve(idempotencyKey, productID, reviewer, text)
+
+	review, err := domain.NewReview(productID, reviewer, text)
+	if err != nil {
+		return nil, fmt.Errorf("creating review: %w", err)
+	}
+
+	alreadyProcessed, err := s.idempotency.CheckAndRecord(ctx, key)
+	...
+```
+
+- [ ] **Step 2: Write the failing service-layer test**
+
+Append to `services/reviews/internal/core/service/review_service_test.go`:
+
+```go
+func TestGetProductReviews_OrderedNewestFirst(t *testing.T) {
+	repo := memory.NewReviewRepository()
+	client := &stubRatingsClient{}
+	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore(), &fakeReviewPublisher{})
+
+	ctx := context.Background()
+	for _, reviewer := range []string{"first", "second", "third"} {
+		if _, err := svc.SubmitReview(ctx, "product-1", reviewer, "text", ""); err != nil {
+			t.Fatalf("submitting %q: %v", reviewer, err)
+		}
+		// Ensure distinct CreatedAt values across submissions.
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	reviews, total, err := svc.GetProductReviews(ctx, "product-1", 1, 10)
+	if err != nil {
+		t.Fatalf("getting reviews: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("total = %d, want 3", total)
+	}
+	want := []string{"third", "second", "first"}
+	for i, w := range want {
+		if reviews[i].Reviewer != w {
+			t.Errorf("reviews[%d].Reviewer = %q, want %q", i, reviews[i].Reviewer, w)
+		}
+	}
+}
+```
+
+Add `"time"` to the import block of that test file (the rest of the imports — `context`, `fmt`, `testing`, etc. — already exist).
+
+- [ ] **Step 3: Run the test — expect failure**
+
+Run: `go test ./services/reviews/internal/core/service/... -run TestGetProductReviews_OrderedNewestFirst -count=1 -v`
+Expected: FAIL — without the service setting `CreatedAt`, both the adapter sort (Task 4) and the service ordering are missing. The test will fail because `reviews[0].Reviewer` will be "first" (insertion order) not "third".
+
+(If Task 4 has not yet been done, the failure mode is "memory adapter returns insertion order" — same outcome: `reviews[0].Reviewer == "first"`. Test still fails until both Task 3 and Task 4 land.)
+
+- [ ] **Step 4: Set `CreatedAt` in `SubmitReview`**
+
+Edit `services/reviews/internal/core/service/review_service.go`:
+
+Add `"time"` to the existing import block (it currently has `context`, `errors`, `fmt`, `log/slog`, plus repo packages). Insert `"time"` in the standard-library group:
+
+```go
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/idempotency"
+	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/port"
+)
+```
+
+Replace:
+
+```go
+	review, err := domain.NewReview(productID, reviewer, text)
+	if err != nil {
+		return nil, fmt.Errorf("creating review: %w", err)
+	}
+
+	alreadyProcessed, err := s.idempotency.CheckAndRecord(ctx, key)
+```
+
+with:
+
+```go
+	review, err := domain.NewReview(productID, reviewer, text)
+	if err != nil {
+		return nil, fmt.Errorf("creating review: %w", err)
+	}
+	review.CreatedAt = time.Now().UTC()
+
+	alreadyProcessed, err := s.idempotency.CheckAndRecord(ctx, key)
+```
+
+- [ ] **Step 5: Run the test — still expects to fail until Task 4 sorts**
+
+Run: `go test ./services/reviews/internal/core/service/... -run TestGetProductReviews_OrderedNewestFirst -count=1 -v`
+Expected: still FAIL — the memory adapter does not yet sort. Reviews come back in insertion order ("first" then "second" then "third"). Service is now stamping `CreatedAt`, but the order is enforced by the adapter (Task 4).
+
+If you want this task to be self-contained green, defer the commit until Task 4. Otherwise commit now and let Task 4 close the loop. Plan recommends: defer the commit to bundle Task 3 + Task 4 once the test passes.
+
+- [ ] **Step 6: Hold the diff (no commit yet)**
+
+Do not commit yet. Move to Task 4. Both will be committed together once the test passes.
+
+---
+
+## Task 4: Memory adapter — propagate `CreatedAt` and sort newest-first
+
+**Files:**
+- Modify: `services/reviews/internal/adapter/outbound/memory/review_repository.go`
+- Modify: `services/reviews/internal/adapter/outbound/memory/review_repository_test.go`
+
+The current adapter has two issues to fix in this task:
+
+1. `FindByProductID` builds a per-product `filtered` slice by copying field-by-field — `ID, ProductID, Reviewer, Text` — which silently drops `CreatedAt`. Need to add `CreatedAt`.
+2. The slice has no sort — insertion order leaks out. Need a `sort.SliceStable` on `CreatedAt` descending with `id` as tiebreaker.
+
+`Save` already does `r.reviews = append(r.reviews, *review)` which copies the full struct, so once the service stamps `CreatedAt` (Task 3) it's stored. Only the per-call copy in `FindByProductID` needs adjustment.
+
+- [ ] **Step 1: Write the failing memory-adapter test**
+
+Append to `services/reviews/internal/adapter/outbound/memory/review_repository_test.go`:
+
+```go
+func TestFindByProductID_OrdersNewestFirst(t *testing.T) {
+	repo := memory.NewReviewRepository()
+	now := time.Now().UTC()
+
+	// Save in arbitrary order; the adapter must return newest first.
+	saves := []struct {
+		id        string
+		reviewer  string
+		createdAt time.Time
+	}{
+		{id: "id-oldest", reviewer: "oldest", createdAt: now},
+		{id: "id-newest", reviewer: "newest", createdAt: now.Add(2 * time.Minute)},
+		{id: "id-middle", reviewer: "middle", createdAt: now.Add(1 * time.Minute)},
+	}
+	for _, s := range saves {
+		rev := domain.Review{
+			ID:        s.id,
+			ProductID: "product-1",
+			Reviewer:  s.reviewer,
+			Text:      "text",
+			CreatedAt: s.createdAt,
+		}
+		if err := repo.Save(context.Background(), &rev); err != nil {
+			t.Fatalf("saving %q: %v", s.id, err)
+		}
+	}
+
+	out, total, err := repo.FindByProductID(context.Background(), "product-1", 0, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("total = %d, want 3", total)
+	}
+	want := []string{"newest", "middle", "oldest"}
+	for i, w := range want {
+		if out[i].Reviewer != w {
+			t.Errorf("out[%d].Reviewer = %q, want %q", i, out[i].Reviewer, w)
+		}
+	}
+}
+```
+
+Add `"time"` to that file's import block (currently `context`, `errors`, `testing` plus the local packages).
+
+- [ ] **Step 2: Run the test — expect failure**
+
+Run: `go test ./services/reviews/internal/adapter/outbound/memory/... -run TestFindByProductID_OrdersNewestFirst -count=1 -v`
+Expected: FAIL. Without the sort, `out[0].Reviewer == "oldest"` (insertion order) — wanted "newest".
+
+Also, even after sort is added, `out[i].Reviewer` would round-trip but `out[i].CreatedAt` would be zero-value if the field-copy isn't fixed. The reviewer-string assertions don't catch that, but the next step does both fixes together.
+
+- [ ] **Step 3: Update the adapter — copy `CreatedAt` and sort**
+
+Edit `services/reviews/internal/adapter/outbound/memory/review_repository.go`:
+
+Add `"sort"` to the import block:
+
+```go
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
+)
+```
+
+Replace the body of `FindByProductID`:
+
+```go
+func (r *ReviewRepository) FindByProductID(_ context.Context, productID string, offset, limit int) ([]domain.Review, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var filtered []domain.Review
+	for _, review := range r.reviews {
+		if review.ProductID == productID {
+			filtered = append(filtered, domain.Review{
+				ID:        review.ID,
+				ProductID: review.ProductID,
+				Reviewer:  review.Reviewer,
+				Text:      review.Text,
+			})
+		}
+	}
+
+	total := len(filtered)
+
+	if offset >= total {
+		return []domain.Review{}, total, nil
+	}
+
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+
+	return filtered[offset:end], total, nil
+}
+```
+
+with:
+
+```go
+func (r *ReviewRepository) FindByProductID(_ context.Context, productID string, offset, limit int) ([]domain.Review, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var filtered []domain.Review
+	for _, review := range r.reviews {
+		if review.ProductID == productID {
+			filtered = append(filtered, domain.Review{
+				ID:        review.ID,
+				ProductID: review.ProductID,
+				Reviewer:  review.Reviewer,
+				Text:      review.Text,
+				CreatedAt: review.CreatedAt,
+			})
+		}
+	}
+
+	sort.SliceStable(filtered, func(i, j int) bool {
+		if !filtered[i].CreatedAt.Equal(filtered[j].CreatedAt) {
+			return filtered[i].CreatedAt.After(filtered[j].CreatedAt)
+		}
+		return filtered[i].ID < filtered[j].ID
+	})
+
+	total := len(filtered)
+
+	if offset >= total {
+		return []domain.Review{}, total, nil
+	}
+
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+
+	return filtered[offset:end], total, nil
+}
+```
+
+- [ ] **Step 4: Run the new memory-adapter test — expect pass**
+
+Run: `go test ./services/reviews/internal/adapter/outbound/memory/... -run TestFindByProductID_OrdersNewestFirst -count=1 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the service-layer test from Task 3 — expect pass**
+
+Run: `go test ./services/reviews/internal/core/service/... -run TestGetProductReviews_OrderedNewestFirst -count=1 -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full reviews suite — make sure nothing regressed**
+
+Run: `go test ./services/reviews/... -race -count=1`
+Expected: all tests pass, including the existing `TestFindByProductID_Pagination` which doesn't depend on order.
+
+- [ ] **Step 7: Commit Tasks 3 + 4 together**
+
+```bash
+git add services/reviews/internal/core/domain/review.go \
+        services/reviews/internal/core/service/review_service.go \
+        services/reviews/internal/core/service/review_service_test.go \
+        services/reviews/internal/adapter/outbound/memory/review_repository.go \
+        services/reviews/internal/adapter/outbound/memory/review_repository_test.go
+git commit -s -m "fix(reviews): order product reviews newest-first
+
+Adds CreatedAt to domain.Review and stamps it in ReviewService.
+SubmitReview as time.Now().UTC() right after domain.NewReview returns.
+
+Memory adapter now propagates CreatedAt across the per-product copy
+loop and sorts the filtered slice newest-first via sort.SliceStable
+with the review id as the deterministic tiebreaker.
+
+New tests:
+- TestGetProductReviews_OrderedNewestFirst (service layer, memory)
+- TestFindByProductID_OrdersNewestFirst (memory adapter unit)
+
+Bug surface: GET /v1/reviews/{id} previously returned reviews in
+insertion order (memory) or UUID-lexical order (postgres ORDER BY id),
+which looks random in the productpage UI.
+"
+```
+
+(Domain change from Task 2 was already committed; this commit reuses the existing domain field. Re-add domain/review.go only if you skipped Task 2's commit.)
+
+---
+
+## Task 5: Postgres adapter — `created_at` in INSERT, SELECT order, Scan
+
+**Files:**
+- Modify: `services/reviews/internal/adapter/outbound/postgres/review_repository.go`
+
+The postgres adapter has three statements to update:
+
+- INSERT (line 62): add `created_at` column + parameter — explicit timestamp wins over the column default for deterministic timestamps.
+- SELECT (line 35): add `created_at` to the projection AND change `ORDER BY id` to `ORDER BY created_at DESC, id`.
+- Scan (line 46): add `&review.CreatedAt` to the field list.
+
+There is no `FindByID` in this adapter (the file has `FindByProductID`, `Save`, `DeleteByID` only — no individual GET path). Skip the spec's `FindByID` note.
+
+No unit tests are added in this task (postgres tests would need real DB infra). The change is verified by the service-layer test (already passing against the memory adapter, which mirrors the contract) and the k3d smoke test (Task 7).
+
+- [ ] **Step 1: Update SELECT — projection and ORDER BY**
+
+Edit `services/reviews/internal/adapter/outbound/postgres/review_repository.go`:
+
+Replace the SELECT in `FindByProductID`:
+
+```go
+	rows, err := r.pool.Query(ctx,
+		"SELECT id, product_id, reviewer, text FROM reviews WHERE product_id = $1 ORDER BY id LIMIT $2 OFFSET $3",
+		productID, limit, offset,
+	)
+```
+
+with:
+
+```go
+	rows, err := r.pool.Query(ctx,
+		"SELECT id, product_id, reviewer, text, created_at "+
+			"FROM reviews WHERE product_id = $1 "+
+			"ORDER BY created_at DESC, id LIMIT $2 OFFSET $3",
+		productID, limit, offset,
+	)
+```
+
+- [ ] **Step 2: Update Scan to include `CreatedAt`**
+
+Replace:
+
+```go
+		if err := rows.Scan(&review.ID, &review.ProductID, &review.Reviewer, &review.Text); err != nil {
+			return nil, 0, fmt.Errorf("scanning review row: %w", err)
+		}
+```
+
+with:
+
+```go
+		if err := rows.Scan(&review.ID, &review.ProductID, &review.Reviewer, &review.Text, &review.CreatedAt); err != nil {
+			return nil, 0, fmt.Errorf("scanning review row: %w", err)
+		}
+```
+
+`pgx/v5` natively scans `TIMESTAMPTZ` into `time.Time`.
+
+- [ ] **Step 3: Update INSERT to include `created_at`**
+
+Replace:
+
+```go
+	_, err := r.pool.Exec(ctx,
+		"INSERT INTO reviews (id, product_id, reviewer, text) VALUES ($1, $2, $3, $4)",
+		review.ID, review.ProductID, review.Reviewer, review.Text,
+	)
+```
+
+with:
+
+```go
+	_, err := r.pool.Exec(ctx,
+		"INSERT INTO reviews (id, product_id, reviewer, text, created_at) VALUES ($1, $2, $3, $4, $5)",
+		review.ID, review.ProductID, review.Reviewer, review.Text, review.CreatedAt,
+	)
+```
+
+- [ ] **Step 4: Build and lint**
+
+Run: `cd services/reviews && go build ./... && golangci-lint run ./internal/adapter/outbound/postgres/...`
+Expected: success, 0 lint issues.
+
+- [ ] **Step 5: Run the full reviews suite again to make sure builds still test-clean**
+
+Run: `go test ./services/reviews/... -race -count=1`
+Expected: all tests pass (postgres adapter has no unit tests but must compile cleanly).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/reviews/internal/adapter/outbound/postgres/review_repository.go
+git commit -s -m "fix(reviews): postgres adapter orders reviews by created_at desc
+
+Updates ReviewRepository.FindByProductID's projection to select
+created_at and changes ORDER BY id to ORDER BY created_at DESC, id —
+the trailing id is a tiebreaker for rows submitted in the same
+microsecond, which keeps offset pagination stable.
+
+INSERT statement now binds review.CreatedAt explicitly so the timestamp
+the service stamped in SubmitReview survives round-tripping through
+the database (the column default of now() is the floor; explicit value
+wins for deterministic ordering across replicas).
+"
+```
+
+---
+
+## Task 6: DTO + handler — surface `CreatedAt` in `ReviewResponse`
+
+**Files:**
+- Modify: `services/reviews/internal/adapter/inbound/http/dto.go`
+- Modify: `services/reviews/internal/adapter/inbound/http/handler.go`
+
+`ReviewResponse` is constructed inline in two places in `handler.go`:
+
+1. Line 60-65 — inside the `getProductReviews` loop.
+2. Line 116-121 — inside `submitReview` for the 201 response.
+
+Both need `CreatedAt` added.
+
+- [ ] **Step 1: Add `time` import + `CreatedAt` field to DTO**
+
+Edit `services/reviews/internal/adapter/inbound/http/dto.go`:
+
+Replace the file's start (it currently has no imports — package directive only) and the `ReviewResponse` struct:
+
+```go
+// Package http provides HTTP handlers and DTOs for the reviews service.
+package http //nolint:revive // package name matches directory convention
+
+// SubmitReviewRequest is the JSON body for POST /v1/reviews.
+type SubmitReviewRequest struct {
+	ProductID      string `json:"product_id"`
+	Reviewer       string `json:"reviewer"`
+	Text           string `json:"text"`
+	IdempotencyKey string `json:"idempotency_key,omitempty"` // optional; falls back to natural key
+}
+
+// ReviewRatingResponse represents rating data embedded in a review response.
+type ReviewRatingResponse struct {
+	Stars   int     `json:"stars"`
+	Average float64 `json:"average"`
+	Count   int     `json:"count"`
+}
+
+// ReviewResponse represents a single review in API responses.
+type ReviewResponse struct {
+	ID        string                `json:"id"`
+	ProductID string                `json:"product_id"`
+	Reviewer  string                `json:"reviewer"`
+	Text      string                `json:"text"`
+	Rating    *ReviewRatingResponse `json:"rating,omitempty"`
+}
+```
+
+with:
+
+```go
+// Package http provides HTTP handlers and DTOs for the reviews service.
+package http //nolint:revive // package name matches directory convention
+
+import "time"
+
+// SubmitReviewRequest is the JSON body for POST /v1/reviews.
+type SubmitReviewRequest struct {
+	ProductID      string `json:"product_id"`
+	Reviewer       string `json:"reviewer"`
+	Text           string `json:"text"`
+	IdempotencyKey string `json:"idempotency_key,omitempty"` // optional; falls back to natural key
+}
+
+// ReviewRatingResponse represents rating data embedded in a review response.
+type ReviewRatingResponse struct {
+	Stars   int     `json:"stars"`
+	Average float64 `json:"average"`
+	Count   int     `json:"count"`
+}
+
+// ReviewResponse represents a single review in API responses.
+type ReviewResponse struct {
+	ID        string                `json:"id"`
+	ProductID string                `json:"product_id"`
+	Reviewer  string                `json:"reviewer"`
+	Text      string                `json:"text"`
+	CreatedAt time.Time             `json:"created_at"`
+	Rating    *ReviewRatingResponse `json:"rating,omitempty"`
+}
+```
+
+- [ ] **Step 2: Update both inline `ReviewResponse` constructions in handler.go**
+
+Edit `services/reviews/internal/adapter/inbound/http/handler.go`:
+
+Replace (in `getProductReviews`):
+
+```go
+		resp := ReviewResponse{
+			ID:        review.ID,
+			ProductID: review.ProductID,
+			Reviewer:  review.Reviewer,
+			Text:      review.Text,
+		}
+```
+
+with:
+
+```go
+		resp := ReviewResponse{
+			ID:        review.ID,
+			ProductID: review.ProductID,
+			Reviewer:  review.Reviewer,
+			Text:      review.Text,
+			CreatedAt: review.CreatedAt,
+		}
+```
+
+Replace (in `submitReview`):
+
+```go
+	writeJSON(w, http.StatusCreated, ReviewResponse{
+		ID:        review.ID,
+		ProductID: review.ProductID,
+		Reviewer:  review.Reviewer,
+		Text:      review.Text,
+	})
+```
+
+with:
+
+```go
+	writeJSON(w, http.StatusCreated, ReviewResponse{
+		ID:        review.ID,
+		ProductID: review.ProductID,
+		Reviewer:  review.Reviewer,
+		Text:      review.Text,
+		CreatedAt: review.CreatedAt,
+	})
+```
+
+- [ ] **Step 3: Run the full reviews suite**
+
+Run: `go test ./services/reviews/... -race -count=1`
+Expected: all tests pass.
+
+- [ ] **Step 4: Lint the package**
+
+Run: `golangci-lint run ./services/reviews/...`
+Expected: 0 issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/reviews/internal/adapter/inbound/http/dto.go \
+        services/reviews/internal/adapter/inbound/http/handler.go
+git commit -s -m "feat(reviews): expose CreatedAt on ReviewResponse
+
+Adds CreatedAt time.Time to the ReviewResponse DTO and threads
+review.CreatedAt through both inline constructions in
+getProductReviews and submitReview.
+
+JSON marshal of time.Time produces RFC3339 (e.g.
+2026-04-26T19:30:00Z); existing clients that ignore unknown fields
+are unaffected. Spec generator (PR #59) maps time.Time to
+{type: string, format: date-time} automatically when
+services/reviews/api/openapi.yaml regenerates.
+"
+```
+
+---
+
+## Task 7: End-to-end k3d verification
+
+**Files:**
+- No code changes. Verification only.
+
+This is the standing rule from PR #63's brainstorm: the user expects k3d clean-cycle verification on every PR with a runtime impact. Migrations + ordering changes count.
+
+- [ ] **Step 1: Run `make lint` and `make test` from repo root**
+
+Run: `make lint && make test`
+Expected: 0 lint issues, all tests pass with `-race`.
+
+- [ ] **Step 2: Clean k3d cycle**
+
+Run: `make stop-k8s && make run-k8s`
+Expected: cluster comes up; all 11 deployments report `Available`. Reviews-write applies migration 003 at startup. Watch with `kubectl --context=k3d-bookinfo-local -n bookinfo logs deploy/reviews-write | grep migration` — expect a line confirming `003_add_created_at` applied.
+
+- [ ] **Step 3: Verify schema in postgres**
+
+Run:
+```bash
+kubectl --context=k3d-bookinfo-local -n bookinfo exec -it reviews-postgresql-0 -- \
+  psql -U reviews -d reviews -c '\d+ reviews'
+```
+Expected: column `created_at | timestamp with time zone | not null | now()` and index `idx_reviews_product_id_created_at btree (product_id, created_at DESC, id)`.
+
+- [ ] **Step 4: Submit three reviews to a fresh product**
+
+```bash
+PID="ord-test-$(date +%s)"
+for r in alice bob carol; do
+  curl -fsS -X POST http://localhost:8080/v1/reviews \
+    -H 'Content-Type: application/json' \
+    -d "{\"product_id\":\"$PID\",\"reviewer\":\"$r\",\"text\":\"review by $r\"}"
+  sleep 1
+done
+```
+
+Expected: three 200-or-201 responses with `created_at` populated in the body.
+
+- [ ] **Step 5: Verify newest-first via the gateway**
+
+```bash
+curl -s "http://localhost:8080/v1/reviews/$PID" | jq '.reviews[].reviewer'
+```
+Expected output:
+```
+"carol"
+"bob"
+"alice"
+```
+
+- [ ] **Step 6: Verify in the productpage UI**
+
+Open `http://localhost:8080/products/$PID` in a browser. The reviews list should show carol on top, bob in the middle, alice at the bottom — newest first.
+
+- [ ] **Step 7: Confirm Tempo trace integrity**
+
+Open Grafana at `http://localhost:3000`, navigate to Tempo, search for traces tagged `service.name=reviews-write` in the last 5 minutes. Pick one — confirm the chain: `gateway → reviews-events EventSource → notification-consumer-sensor → notification-write` is intact (no new spans broken by the migration).
+
+- [ ] **Step 8: Done — no commit**
+
+This task is verification-only. Move on to the finishing-a-development-branch flow.
+
+---
+
+## Self-review
+
+After writing this plan, verify:
+
+1. **Spec coverage**: Each spec section maps to a task —
+   - Schema change → Task 1
+   - Domain change → Task 2
+   - Service change → Task 3
+   - Postgres adapter → Task 5
+   - Memory adapter → Task 4
+   - DTO change → Task 6
+   - Tests → integrated into Tasks 3 + 4
+   - Verification → Task 7
+
+2. **Spec gaps**: The spec mentions `FindByID` for postgres — that method does not exist in the current adapter. Plan correctly skips it (called out in Task 5).
+
+3. **Spec gap on `services/reviews/api/openapi.yaml` regeneration**: Listed in spec file summary as a generated artifact. Skipped in this plan because the project's spec generator is invoked as a separate step (the `make` target / CI pipeline regenerates it on commit). If regeneration is wanted in this PR, run `cd tools/specgen && go run . generate ../../services/reviews` after Task 6 and add the regenerated file to the Task 6 commit.
+
+4. **Productpage client struct**: `services/productpage/internal/client/reviews.go::ReviewResponse` currently mirrors the reviews DTO without `CreatedAt`. JSON decode will tolerate the unknown field. Plan does not add `CreatedAt` to the client struct — out of scope per spec ("transparent to producers"); UI does not currently render the timestamp. If a follow-up wants timestamp display in the UI, it adds the field to the client struct and the template.
+
+5. **Type consistency**: `time.Time` used consistently across domain, service, adapters, DTO. `CreatedAt` capitalization is consistent.
+
+6. **No placeholders**: Every task has runnable commands and full code blocks. No "implement appropriately" or "add error handling" stubs.

--- a/docs/superpowers/specs/2026-04-26-reviews-chronological-ordering-design.md
+++ b/docs/superpowers/specs/2026-04-26-reviews-chronological-ordering-design.md
@@ -1,0 +1,264 @@
+# Reviews Chronological Ordering — Design
+
+**Status:** Design approved · Implementation pending
+**Date:** 2026-04-26
+**Scope:** `reviews` service only (one repo + one migration + handful of adjacent edits)
+
+## Problem
+
+Reviews displayed on the productpage frontend (`http://localhost:8080/products/<id>`) appear in random-looking order. Investigation:
+
+- `services/reviews/migrations/001_create_reviews.up.sql` — table has only `id, product_id, reviewer, text` (no creation timestamp)
+- `services/reviews/internal/adapter/outbound/postgres/review_repository.go:35` — `... ORDER BY id LIMIT $2 OFFSET $3`. UUIDs sort lexicographically, so the result *looks* random
+- `services/reviews/internal/adapter/outbound/memory/review_repository.go::FindByProductID` — returns insertion order, no sort, no timestamp tracked
+- `services/reviews/internal/core/domain/review.go::Review` — struct has no `CreatedAt` field
+
+The bug pre-dates the API spec generation work (PRs #55, #58, #59, #63, #64). Other services have similar patterns (`details.ORDER BY title`, `ratings` no sort) but only `reviews` is user-visibly broken because it's the only listing the productpage UI surfaces with implied chronology.
+
+## Goals
+
+- Reviews returned by `GET /v1/reviews/{productID}` are ordered **newest first** (DESC on creation time).
+- Both `postgres` and `memory` adapters honor the order so dev (compose) and prod (k3d) match.
+- The change is transparent to producers: `POST /v1/reviews` payload doesn't change. The client doesn't need to send `created_at`.
+- Clients that want the timestamp see it in `ReviewResponse` for free.
+
+## Non-goals
+
+- Fixing the same pattern in `details` (uses `ORDER BY title` — semantically reasonable; no user complaint) or `ratings` (no ORDER BY but no user-visible chronology either). Each can get its own ticket if needed.
+- Backfilling historical creation times for existing rows. Migration default `now()` is honest about the limitation: rows present at migration time get a current-ish timestamp; subsequent rows are correct.
+- Soft-delete column. Reviews are hard-deleted via the existing `DeleteByID` flow.
+- Cursor-based pagination. The current offset-pagination keeps working with the new ORDER BY.
+
+## Schema change
+
+New migration pair:
+
+**`services/reviews/migrations/003_add_created_at.up.sql`:**
+
+```sql
+ALTER TABLE reviews ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+-- Drop the existing single-column index in favor of a composite that
+-- supports both per-product filtering AND chronological ordering.
+DROP INDEX IF EXISTS idx_reviews_product_id;
+CREATE INDEX idx_reviews_product_id_created_at ON reviews (product_id, created_at DESC, id);
+```
+
+**`services/reviews/migrations/003_add_created_at.down.sql`:**
+
+```sql
+DROP INDEX IF EXISTS idx_reviews_product_id_created_at;
+CREATE INDEX idx_reviews_product_id ON reviews (product_id);
+ALTER TABLE reviews DROP COLUMN IF EXISTS created_at;
+```
+
+Migration is automatically applied by `database.RunMigrations` at service startup (existing pattern from `services/reviews/cmd/main.go`).
+
+The composite index `(product_id, created_at DESC, id)` supports the new `WHERE product_id = $1 ORDER BY created_at DESC, id` query path. The trailing `id` is a tiebreaker for rows submitted in the same millisecond — important for pagination stability.
+
+## Domain change
+
+`services/reviews/internal/core/domain/review.go`:
+
+```go
+import "time"
+
+type Review struct {
+    ID        string
+    ProductID string
+    Reviewer  string
+    Text      string
+    CreatedAt time.Time      // NEW
+    Rating    *ReviewRating
+}
+```
+
+`NewReview(productID, reviewer, text)` does NOT take `createdAt` as an argument — the service sets it. Keeps the constructor signature stable for existing callers.
+
+## Service change
+
+`services/reviews/internal/core/service/review_service.go::SubmitReview` (or wherever `repo.Save` is called for new reviews) sets:
+
+```go
+review.CreatedAt = time.Now().UTC()
+```
+
+right after `domain.NewReview(...)` returns and before `repo.Save(...)`. Use UTC so postgres `TIMESTAMPTZ` storage is unambiguous.
+
+The idempotent-replay path (when `idempotencyKey` matches an existing record) does NOT update `CreatedAt` — first-write wins. This is consistent with the existing dedup logic in the service layer.
+
+## Postgres adapter
+
+`services/reviews/internal/adapter/outbound/postgres/review_repository.go`:
+
+### INSERT
+
+Existing INSERT statement (find via grep `INSERT INTO reviews`) gains the `created_at` column. Pass `review.CreatedAt` from the caller. The DB also has `DEFAULT now()` so omitting the column would also work — but explicit is better for tests that need deterministic timestamps.
+
+### SELECT (the broken query)
+
+```go
+rows, err := r.pool.Query(ctx,
+    "SELECT id, product_id, reviewer, text, created_at "+
+        "FROM reviews WHERE product_id = $1 "+
+        "ORDER BY created_at DESC, id LIMIT $2 OFFSET $3",
+    productID, limit, offset,
+)
+```
+
+The `id` tiebreaker makes pagination stable when multiple reviews share a microsecond.
+
+### Scan
+
+```go
+if err := rows.Scan(&review.ID, &review.ProductID, &review.Reviewer, &review.Text, &review.CreatedAt); err != nil {
+    return nil, 0, fmt.Errorf("scanning review row: %w", err)
+}
+```
+
+`pgx.v5` natively scans `TIMESTAMPTZ` into `time.Time`.
+
+### `FindByID` (for delete/individual gets)
+
+Find existing `SELECT id, product_id, reviewer, text FROM reviews WHERE id = $1` and add `created_at` to it too. Otherwise `FindByID` would return `Review{CreatedAt: zero}` which is harmless but inconsistent.
+
+## Memory adapter
+
+`services/reviews/internal/adapter/outbound/memory/review_repository.go::FindByProductID`:
+
+After the existing per-product filter loop, sort the filtered slice before pagination:
+
+```go
+sort.SliceStable(filtered, func(i, j int) bool {
+    if !filtered[i].CreatedAt.Equal(filtered[j].CreatedAt) {
+        return filtered[i].CreatedAt.After(filtered[j].CreatedAt)
+    }
+    return filtered[i].ID < filtered[j].ID
+})
+```
+
+`Save` already copies the whole struct (no field renames), so `CreatedAt` flows through automatically once the service sets it.
+
+## DTO change
+
+`services/reviews/internal/adapter/inbound/http/dto.go`:
+
+```go
+type ReviewResponse struct {
+    ID         string                  `json:"id"`
+    ProductID  string                  `json:"product_id"`
+    Reviewer   string                  `json:"reviewer"`
+    Text       string                  `json:"text"`
+    CreatedAt  time.Time               `json:"created_at"`         // NEW
+    Rating     *ReviewRatingResponse   `json:"rating,omitempty"`
+}
+```
+
+The `time.Time` JSON marshals as RFC3339 (e.g. `2026-04-26T19:30:00Z`). Productpage's existing template uses this for display if needed; clients can omit. Spec generator (PR #59) maps `time.Time` → `{type: string, format: date-time}` automatically — the `services/reviews/api/openapi.yaml` regenerates with that schema.
+
+The `toReviewResponse(domain)` helper gains a single line: `CreatedAt: r.CreatedAt`.
+
+## Tests
+
+### Service layer test (memory adapter)
+
+In `services/reviews/internal/core/service/review_service_test.go` (or a new file if none exists):
+
+```go
+func TestGetProductReviews_OrderedNewestFirst(t *testing.T) {
+    repo := memory.NewReviewRepository()
+    svc := service.NewReviewService(repo, /* ... other deps ... */)
+
+    // Submit three reviews with monotonic timestamps via service (which sets CreatedAt).
+    // Use t.Setenv or a fake clock if the service uses one; otherwise just submit
+    // sequentially and rely on time.Now() ordering.
+    for _, reviewer := range []string{"first", "second", "third"} {
+        _, err := svc.SubmitReview(ctx, productID, reviewer, "text", uuid.NewString())
+        if err != nil { t.Fatal(err) }
+        time.Sleep(2 * time.Millisecond) // ensure distinct timestamps
+    }
+
+    reviews, total, err := svc.GetProductReviews(ctx, productID, 1, 10)
+    if err != nil { t.Fatal(err) }
+    if total != 3 { t.Errorf("total = %d, want 3", total) }
+
+    // Newest first.
+    if reviews[0].Reviewer != "third" {
+        t.Errorf("reviews[0].Reviewer = %q, want third", reviews[0].Reviewer)
+    }
+    if reviews[2].Reviewer != "first" {
+        t.Errorf("reviews[2].Reviewer = %q, want first", reviews[2].Reviewer)
+    }
+}
+```
+
+### Memory adapter unit test
+
+In `services/reviews/internal/adapter/outbound/memory/review_repository_test.go`:
+
+```go
+func TestFindByProductID_OrdersNewestFirst(t *testing.T) {
+    repo := memory.NewReviewRepository()
+    now := time.Now().UTC()
+
+    for i, reviewer := range []string{"oldest", "middle", "newest"} {
+        rev := domain.Review{
+            ID: fmt.Sprintf("id-%d", i),
+            ProductID: "product-1",
+            Reviewer: reviewer,
+            Text: "text",
+            CreatedAt: now.Add(time.Duration(i) * time.Minute),
+        }
+        if err := repo.Save(ctx, &rev); err != nil { t.Fatal(err) }
+    }
+
+    out, _, err := repo.FindByProductID(ctx, "product-1", 0, 10)
+    if err != nil { t.Fatal(err) }
+    want := []string{"newest", "middle", "oldest"}
+    for i, w := range want {
+        if out[i].Reviewer != w {
+            t.Errorf("out[%d].Reviewer = %q, want %q", i, out[i].Reviewer, w)
+        }
+    }
+}
+```
+
+### Postgres adapter test
+
+The existing postgres tests (typically gated by a build tag `integration` and require a real Postgres) gain a parallel ordering test. If no postgres tests run by default, adding one is optional — the SQL is simple enough to verify by k3d smoke. Acceptable to skip in this PR if it requires new test infrastructure.
+
+## Verification
+
+1. `go test ./services/reviews/... -race -count=1` — all reviews tests pass, including the two new ordering tests
+2. `golangci-lint run ./...` — 0 issues
+3. `make e2e` — compose-mode regression check; existing reviews tests still pass
+4. **Local k3d clean cycle** (`make stop-k8s && make run-k8s`):
+   - Reviews-write rolls out with the new migration applied (database has `created_at` column + new index)
+   - Submit 3 reviews to a fresh product via the gateway
+   - `curl http://localhost:8080/v1/reviews/<id>` returns reviews newest-first
+   - Open productpage in browser at `http://localhost:8080/products/<id>` and verify the reviews list ordering matches submission order (newest at top)
+5. **Tempo trace** (per the standing rule from PR #63's brainstorm): one review-submitted chain spans through the gateway → reviews-events EventSource → notification-consumer-sensor; confirms no runtime-path regression
+
+## Risks & open questions
+
+- **Migration on a populated dev cluster**: existing reviews get `now()` as `created_at` at migration time. Their ordering relative to each other becomes "all clustered at migration time" which is honest and acceptable. Subsequent reviews ordered correctly.
+- **Schema change is technically breaking** for any external consumer that reads the table directly (we have none — the repo is internal to the reviews service). For the REST contract, the additional `created_at` field on `ReviewResponse` is an additive change — existing clients ignore unknown fields.
+- **Time skew across replicas**: postgres `now()` is server-side, so replicas write consistent timestamps. The service-layer `time.Now().UTC()` is set on the application node before INSERT — if there's clock skew between app replicas, ordering could appear slightly out-of-order across submissions from different replicas. In practice the local k3d cluster has a single replica per service; production multi-replica concerns are out of scope.
+- **Productpage's HTMX poll for pending reviews** — the productpage caches "submitted" reviews in Redis until they're visible from the reviews service. The pending cache is best-effort and doesn't depend on chronology; no change there.
+
+## File summary
+
+```
+services/reviews/migrations/003_add_created_at.up.sql      # NEW (~5 lines)
+services/reviews/migrations/003_add_created_at.down.sql    # NEW (~3 lines)
+services/reviews/internal/core/domain/review.go            # +1 field on Review struct
+services/reviews/internal/core/service/review_service.go   # +1 line in SubmitReview
+services/reviews/internal/adapter/outbound/postgres/review_repository.go   # SELECT/INSERT/Scan changes
+services/reviews/internal/adapter/outbound/memory/review_repository.go     # +sort.SliceStable in FindByProductID
+services/reviews/internal/adapter/inbound/http/dto.go      # +CreatedAt on ReviewResponse + toReviewResponse
+services/reviews/internal/adapter/outbound/memory/review_repository_test.go  # +TestFindByProductID_OrdersNewestFirst
+services/reviews/internal/core/service/review_service_test.go                # +TestGetProductReviews_OrderedNewestFirst (or appropriate test file)
+services/reviews/api/openapi.yaml                          # regenerated (CreatedAt field appears as date-time)
+```
+
+Net: 2 new files, ~7 modified, 1 generated artifact regenerated. ~80–120 lines of net diff.

--- a/services/reviews/api/openapi.yaml
+++ b/services/reviews/api/openapi.yaml
@@ -152,6 +152,9 @@ components:
           items:
             type: object
             properties:
+              created_at:
+                type: string
+                format: date-time
               id:
                 type: string
               product_id:
@@ -181,6 +184,7 @@ components:
               - product_id
               - reviewer
               - text
+              - created_at
       required:
         - product_id
         - reviews
@@ -188,6 +192,9 @@ components:
     ReviewResponse:
       type: object
       properties:
+        created_at:
+          type: string
+          format: date-time
         id:
           type: string
         product_id:
@@ -217,6 +224,7 @@ components:
         - product_id
         - reviewer
         - text
+        - created_at
     SubmitReviewRequest:
       type: object
       properties:

--- a/services/reviews/internal/adapter/inbound/http/dto.go
+++ b/services/reviews/internal/adapter/inbound/http/dto.go
@@ -1,6 +1,8 @@
 // Package http provides HTTP handlers and DTOs for the reviews service.
 package http //nolint:revive // package name matches directory convention
 
+import "time"
+
 // SubmitReviewRequest is the JSON body for POST /v1/reviews.
 type SubmitReviewRequest struct {
 	ProductID      string `json:"product_id"`
@@ -22,6 +24,7 @@ type ReviewResponse struct {
 	ProductID string                `json:"product_id"`
 	Reviewer  string                `json:"reviewer"`
 	Text      string                `json:"text"`
+	CreatedAt time.Time             `json:"created_at"`
 	Rating    *ReviewRatingResponse `json:"rating,omitempty"`
 }
 

--- a/services/reviews/internal/adapter/inbound/http/handler.go
+++ b/services/reviews/internal/adapter/inbound/http/handler.go
@@ -62,6 +62,7 @@ func (h *Handler) getProductReviews(w http.ResponseWriter, r *http.Request) {
 			ProductID: review.ProductID,
 			Reviewer:  review.Reviewer,
 			Text:      review.Text,
+			CreatedAt: review.CreatedAt,
 		}
 		if review.Rating != nil {
 			resp.Rating = &ReviewRatingResponse{
@@ -118,6 +119,7 @@ func (h *Handler) submitReview(w http.ResponseWriter, r *http.Request) {
 		ProductID: review.ProductID,
 		Reviewer:  review.Reviewer,
 		Text:      review.Text,
+		CreatedAt: review.CreatedAt,
 	})
 }
 

--- a/services/reviews/internal/adapter/outbound/memory/review_repository.go
+++ b/services/reviews/internal/adapter/outbound/memory/review_repository.go
@@ -3,6 +3,7 @@ package memory
 
 import (
 	"context"
+	"sort"
 	"sync"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
@@ -34,9 +35,17 @@ func (r *ReviewRepository) FindByProductID(_ context.Context, productID string, 
 				ProductID: review.ProductID,
 				Reviewer:  review.Reviewer,
 				Text:      review.Text,
+				CreatedAt: review.CreatedAt,
 			})
 		}
 	}
+
+	sort.SliceStable(filtered, func(i, j int) bool {
+		if !filtered[i].CreatedAt.Equal(filtered[j].CreatedAt) {
+			return filtered[i].CreatedAt.After(filtered[j].CreatedAt)
+		}
+		return filtered[i].ID < filtered[j].ID
+	})
 
 	total := len(filtered)
 

--- a/services/reviews/internal/adapter/outbound/memory/review_repository_test.go
+++ b/services/reviews/internal/adapter/outbound/memory/review_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/outbound/memory"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/core/domain"
@@ -91,5 +92,46 @@ func TestDeleteByID_NotFound(t *testing.T) {
 	err := repo.DeleteByID(context.Background(), "nonexistent-id")
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestFindByProductID_OrdersNewestFirst(t *testing.T) {
+	repo := memory.NewReviewRepository()
+	now := time.Now().UTC()
+
+	saves := []struct {
+		id        string
+		reviewer  string
+		createdAt time.Time
+	}{
+		{id: "id-oldest", reviewer: "oldest", createdAt: now},
+		{id: "id-newest", reviewer: "newest", createdAt: now.Add(2 * time.Minute)},
+		{id: "id-middle", reviewer: "middle", createdAt: now.Add(1 * time.Minute)},
+	}
+	for _, s := range saves {
+		rev := domain.Review{
+			ID:        s.id,
+			ProductID: "product-1",
+			Reviewer:  s.reviewer,
+			Text:      "text",
+			CreatedAt: s.createdAt,
+		}
+		if err := repo.Save(context.Background(), &rev); err != nil {
+			t.Fatalf("saving %q: %v", s.id, err)
+		}
+	}
+
+	out, total, err := repo.FindByProductID(context.Background(), "product-1", 0, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("total = %d, want 3", total)
+	}
+	want := []string{"newest", "middle", "oldest"}
+	for i, w := range want {
+		if out[i].Reviewer != w {
+			t.Errorf("out[%d].Reviewer = %q, want %q", i, out[i].Reviewer, w)
+		}
 	}
 }

--- a/services/reviews/internal/adapter/outbound/postgres/review_repository.go
+++ b/services/reviews/internal/adapter/outbound/postgres/review_repository.go
@@ -32,7 +32,9 @@ func (r *ReviewRepository) FindByProductID(ctx context.Context, productID string
 	}
 
 	rows, err := r.pool.Query(ctx,
-		"SELECT id, product_id, reviewer, text FROM reviews WHERE product_id = $1 ORDER BY id LIMIT $2 OFFSET $3",
+		"SELECT id, product_id, reviewer, text, created_at "+
+			"FROM reviews WHERE product_id = $1 "+
+			"ORDER BY created_at DESC, id LIMIT $2 OFFSET $3",
 		productID, limit, offset,
 	)
 	if err != nil {
@@ -43,7 +45,7 @@ func (r *ReviewRepository) FindByProductID(ctx context.Context, productID string
 	var reviews []domain.Review
 	for rows.Next() {
 		var review domain.Review
-		if err := rows.Scan(&review.ID, &review.ProductID, &review.Reviewer, &review.Text); err != nil {
+		if err := rows.Scan(&review.ID, &review.ProductID, &review.Reviewer, &review.Text, &review.CreatedAt); err != nil {
 			return nil, 0, fmt.Errorf("scanning review row: %w", err)
 		}
 		reviews = append(reviews, review)
@@ -59,8 +61,8 @@ func (r *ReviewRepository) FindByProductID(ctx context.Context, productID string
 // Save persists a review in PostgreSQL.
 func (r *ReviewRepository) Save(ctx context.Context, review *domain.Review) error {
 	_, err := r.pool.Exec(ctx,
-		"INSERT INTO reviews (id, product_id, reviewer, text) VALUES ($1, $2, $3, $4)",
-		review.ID, review.ProductID, review.Reviewer, review.Text,
+		"INSERT INTO reviews (id, product_id, reviewer, text, created_at) VALUES ($1, $2, $3, $4, $5)",
+		review.ID, review.ProductID, review.Reviewer, review.Text, review.CreatedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("inserting review %s: %w", review.ID, err)

--- a/services/reviews/internal/core/domain/review.go
+++ b/services/reviews/internal/core/domain/review.go
@@ -4,6 +4,7 @@ package domain
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -31,6 +32,7 @@ type Review struct {
 	ProductID string
 	Reviewer  string
 	Text      string
+	CreatedAt time.Time
 	Rating    *ReviewRating
 }
 

--- a/services/reviews/internal/core/service/review_service.go
+++ b/services/reviews/internal/core/service/review_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/idempotency"
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/logging"
@@ -73,6 +74,7 @@ func (s *ReviewService) SubmitReview(ctx context.Context, productID, reviewer, t
 	if err != nil {
 		return nil, fmt.Errorf("creating review: %w", err)
 	}
+	review.CreatedAt = time.Now().UTC()
 
 	alreadyProcessed, err := s.idempotency.CheckAndRecord(ctx, key)
 	if err != nil {

--- a/services/reviews/internal/core/service/review_service_test.go
+++ b/services/reviews/internal/core/service/review_service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/kaio6fellipe/event-driven-bookinfo/pkg/idempotency"
 	"github.com/kaio6fellipe/event-driven-bookinfo/services/reviews/internal/adapter/outbound/memory"
@@ -225,5 +226,35 @@ func TestDeleteReview_PublishesEvent(t *testing.T) {
 	}
 	if pub.deleted[0].ReviewID != "rev_missing" {
 		t.Errorf("ReviewID = %q", pub.deleted[0].ReviewID)
+	}
+}
+
+func TestGetProductReviews_OrderedNewestFirst(t *testing.T) {
+	repo := memory.NewReviewRepository()
+	client := &stubRatingsClient{
+		data: &domain.RatingData{Average: 0, Count: 0, IndividualRatings: map[string]int{}},
+	}
+	svc := service.NewReviewService(repo, client, idempotency.NewMemoryStore(), &fakeReviewPublisher{})
+
+	ctx := context.Background()
+	for _, reviewer := range []string{"first", "second", "third"} {
+		if _, err := svc.SubmitReview(ctx, "product-1", reviewer, "text", ""); err != nil {
+			t.Fatalf("submitting %q: %v", reviewer, err)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	reviews, total, err := svc.GetProductReviews(ctx, "product-1", 1, 10)
+	if err != nil {
+		t.Fatalf("getting reviews: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("total = %d, want 3", total)
+	}
+	want := []string{"third", "second", "first"}
+	for i, w := range want {
+		if reviews[i].Reviewer != w {
+			t.Errorf("reviews[%d].Reviewer = %q, want %q", i, reviews[i].Reviewer, w)
+		}
 	}
 }

--- a/services/reviews/migrations/003_add_created_at.down.sql
+++ b/services/reviews/migrations/003_add_created_at.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_reviews_product_id_created_at;
+CREATE INDEX idx_reviews_product_id ON reviews (product_id);
+ALTER TABLE reviews DROP COLUMN IF EXISTS created_at;

--- a/services/reviews/migrations/003_add_created_at.up.sql
+++ b/services/reviews/migrations/003_add_created_at.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE reviews ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+DROP INDEX IF EXISTS idx_reviews_product_id;
+CREATE INDEX idx_reviews_product_id_created_at ON reviews (product_id, created_at DESC, id);


### PR DESCRIPTION
## Summary
- Adds migration 003 introducing `created_at TIMESTAMPTZ NOT NULL DEFAULT now()` on the `reviews` table plus a composite index `(product_id, created_at DESC, id)` to back the new query path.
- Threads `CreatedAt` through `domain.Review`, `ReviewService.SubmitReview` (stamped as `time.Now().UTC()` after `domain.NewReview`), both adapters (postgres `ORDER BY created_at DESC, id`; memory `sort.SliceStable` newest-first with `id` tiebreaker), and surfaces `created_at` on `ReviewResponse` JSON.

## Why
`GET /v1/reviews/{productID}` returned reviews in random-looking order:
- Postgres adapter sorted by `id` (UUIDs sort lexicographically — looks random).
- Memory adapter returned insertion order with no sort.
- Domain had no creation timestamp at all.

Visible on the productpage UI at `/products/{id}` where reviewers appeared shuffled.

## Test Plan
- [x] `make lint` (0 issues) and `make test` (-race -count=1, all `ok`)
- [x] New unit tests:
  - `TestFindByProductID_OrdersNewestFirst` (memory adapter)
  - `TestGetProductReviews_OrderedNewestFirst` (service layer with memory backing)
- [x] k3d clean redeploy (`make k8s-rebuild`); `reviews-write` log emitted `database migrations applied`.
- [x] Postgres schema verified: `created_at timestamp with time zone NOT NULL DEFAULT now()` + index `idx_reviews_product_id_created_at btree (product_id, created_at DESC, id)`. Old `idx_reviews_product_id` dropped.
- [x] Submitted alice → bob → carol; `GET /v1/reviews/<pid>` returned carol → bob → alice with strictly decreasing `created_at` timestamps.
- [x] `/partials/reviews/<pid>` HTMX partial renders avatars `c, b, a` (newest first).
- [x] Tempo trace `9447fe9557431baa2c4ead68171bd60` traverses the full chain: `gateway → reviews-events-eventsource → reviews-sensor → reviews (write) → review-submitted-eventsource → notification-consumer-sensor → notification`.

## Notes
- Migration is additive with `DEFAULT now()` — existing rows get a current-ish `created_at` at apply time (acceptable; documented in the design).
- DTO change is additive: `ReviewResponse.created_at` is RFC3339; existing clients ignore unknown fields. Spec generator (PR #59) will pick up the field automatically when openapi.yaml regenerates.
- Productpage's mirror client struct (`services/productpage/internal/client/reviews.go::ReviewResponse`) is unchanged — JSON decode tolerates the new field; UI does not currently render the timestamp. Follow-up if surface needed.

Spec: `docs/superpowers/specs/2026-04-26-reviews-chronological-ordering-design.md`
Plan: `docs/superpowers/plans/2026-04-26-reviews-chronological-ordering.md`