### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ coverage.out
 
 # Git worktrees
 .worktrees/
+
+docs/answer*.md


### PR DESCRIPTION
## Summary

- Adds `docs/answer*.md` to `.gitignore` so local analysis scratch files in `docs/answer*.md` (e.g. multi-question deep-dives) don't leak into commits.

## Test plan

- [x] `git status` clean after creating files matching `docs/answer*.md`
- [x] Pattern is scoped to `docs/` to avoid masking unrelated `answer*.md` elsewhere